### PR TITLE
Generalize metadata handlers across namespaces

### DIFF
--- a/ai_workspace/__init__.py
+++ b/ai_workspace/__init__.py
@@ -16,10 +16,11 @@
 from notebook.utils import url_path_join
 
 from .scheduler.handler import SchedulerHandler
-from .metadata.handlers import MainRuntimeHandler, RuntimeHandler
+from .metadata.handlers import MetadataHandler, MetadataNamespaceHandler
 from .metadata import MetadataManager
 
-runtime_name_regex = r"(?P<runtime_name>[\w\.\-%]+)"
+namespace_regex = r"(?P<namespace>[\w\.\-]+)"
+target_regex = r"(?P<target>[\w\.\-]+)"
 
 def _jupyter_server_extension_paths():
     return [{
@@ -32,9 +33,7 @@ def load_jupyter_server_extension(nb_server_app):
     host_pattern = '.*$'
     web_app.add_handlers(host_pattern, [
         (url_path_join(web_app.settings['base_url'], r'/scheduler'), SchedulerHandler),
-        (url_path_join(web_app.settings['base_url'], r'/metadata/runtime'), MainRuntimeHandler),
-        (url_path_join(web_app.settings['base_url'], r'/metadata/runtime/%s' % runtime_name_regex), RuntimeHandler),
+        (url_path_join(web_app.settings['base_url'], r'/metadata/%s' % (namespace_regex)), MetadataHandler),
+        (url_path_join(web_app.settings['base_url'], r'/metadata/%s/%s' % (namespace_regex,target_regex)), MetadataNamespaceHandler),
     ])
-    # Instantiate metadata namespace singletons
-    MetadataManager.instance(namespace="runtime")
 

--- a/ai_workspace/metadata/metadata.py
+++ b/ai_workspace/metadata/metadata.py
@@ -21,7 +21,7 @@ from abc import ABC, abstractmethod
 from jsonschema import validate, ValidationError
 from jupyter_core.paths import jupyter_data_dir
 from traitlets import HasTraits, List, Unicode, Dict, Type, log
-from traitlets.config import SingletonConfigurable
+from traitlets.config import SingletonConfigurable, LoggingConfigurable
 
 
 class Metadata(HasTraits):
@@ -67,7 +67,7 @@ class Metadata(HasTraits):
         return j
 
 
-class MetadataManager(SingletonConfigurable):
+class MetadataManager(LoggingConfigurable):
     metadata_class = Type(Metadata, config=True,
         help="""The metadata class.  This is configurable to allow
         subclassing of the MetadataManager for customized behavior.

--- a/ai_workspace/metadata/tests/test_metadata.py
+++ b/ai_workspace/metadata/tests/test_metadata.py
@@ -50,12 +50,6 @@ class MetadataTestBase(NotebookTestBase):
         create_json_file(self.metadata_dir, 'another.json', another_metadata_json)
         create_json_file(self.metadata_dir, 'invalid.json', invalid_metadata_json)
 
-    def tearDown(self):
-        super(MetadataTestBase, self).tearDown()
-        # Clear singletons, otherwise they'll reference a metadata dir that
-        # doesn't exist - breaking the "next" test.
-        MetadataManager.clear_instance()
-
 
 class MetadataManagerTestCase(MetadataTestBase):
     """Test Metadata REST API"""
@@ -63,7 +57,7 @@ class MetadataManagerTestCase(MetadataTestBase):
 
     def setUp(self):
         super(MetadataManagerTestCase, self).setUp()
-        self.metadata_manager = MetadataManager.instance(namespace="runtime")
+        self.metadata_manager = MetadataManager(namespace="runtime")
 
     def test_list_metadata_summary(self):
         metadata_summary_list = self.metadata_manager.get_all_metadata_summary()


### PR DESCRIPTION
Metadata handlers will be invoked for any general string that follows a `/metadata/` endpoint.  We may want to validate the 'namespace' portion of the endpoint at some point, but right now any value (alphanumeric, _, -, and .) is allowed.

Attempts to access invalid/bogus namespaces will result in the return of an empty list (e.g., `/metadata/bogus_namespace`) and a `404` HTTPError for the direct get (e.g., `/metadata/bogus_namespace/my_metadata_instance`).

Fixes: #130