### PR TITLE
Fix metadata manager instance creation in scheduler

### DIFF
--- a/ai_workspace/scheduler/handler.py
+++ b/ai_workspace/scheduler/handler.py
@@ -56,7 +56,7 @@ class SchedulerHandler(APIHandler):
         # retrieve associated runtime metadata
         runtime_type = pipeline.platform
         try:
-            runtime_configuration = MetadataManager.instance(namespace="runtime").get(runtime_type)
+            runtime_configuration = MetadataManager(namespace="runtime").get(runtime_type)
         except (ValidationError, KeyError) as err:
             raise web.HTTPError(404, str(err))
         except Exception as ex:


### PR DESCRIPTION
A previous PR failed to convert all occurrences of MetadataManager creation when it changed from a singleton to a regular object.  This updates that missed occurrence.