### PR TITLE
Include invalid runtime metadata when listing runtimes

### DIFF
--- a/ai_workspace/metadata/tests/test_metadata.py
+++ b/ai_workspace/metadata/tests/test_metadata.py
@@ -58,8 +58,10 @@ class MetadataManagerTestCase(MetadataTestBase):
         self.metadata_manager = MetadataManager(namespace="runtime")
 
     def test_list_metadata_summary(self):
-        metadata_summary_list = self.metadata_manager.get_all_metadata_summary()
+        metadata_summary_list = self.metadata_manager.get_all_metadata_summary(include_invalid=False)
         self.assertEqual(len(metadata_summary_list), 2)
+        metadata_summary_list = self.metadata_manager.get_all_metadata_summary(include_invalid=True)
+        self.assertEqual(len(metadata_summary_list), 3)
 
     def test_list_all_metadata(self):
         metadata_list = self.metadata_manager.get_all()
@@ -172,8 +174,10 @@ class MetadataFileStoreTestCase(MetadataTestBase):
         self.metadata_file_store = FileMetadataStore(namespace='runtime', metadata_dir=self.metadata_dir)
 
     def test_list_metadata_summary(self):
-        metadata_summary_list = self.metadata_file_store.get_all_metadata_summary()
+        metadata_summary_list = self.metadata_file_store.get_all_metadata_summary(include_invalid=False)
         self.assertEqual(len(metadata_summary_list), 2)
+        metadata_summary_list = self.metadata_file_store.get_all_metadata_summary(include_invalid=True)
+        self.assertEqual(len(metadata_summary_list), 3)
 
     def test_list_all_metadata(self):
         metadata_list = self.metadata_file_store.get_all()
@@ -182,7 +186,7 @@ class MetadataFileStoreTestCase(MetadataTestBase):
     def test_list_metadata_summary_none(self):
         # Delete the metadata dir and attempt listing metadata
         shutil.rmtree(self.metadata_dir)
-        metadata_summary_list = self.metadata_file_store.get_all_metadata_summary()
+        metadata_summary_list = self.metadata_file_store.get_all_metadata_summary(include_invalid=True)
         self.assertEqual(len(metadata_summary_list), 0)
 
     def test_list_all_metadata_none(self):


### PR DESCRIPTION
`jupyter runtime list` will now include invalid runtime metadata in
its output.  The invalid metadata will be marked with an entry of
`**INVALID** (<reason>)` where `<reason>` will likely be the exception
class name.

Users wishing to not include invalid metadata can use the new option
`--valid-only`, in which case the invalid metadata will not be included.
However, because logging goes to stderr, users will typically see the
log message that includes the details of the invalid metadata.

Also fixed a bug in `jupyter runtime list --json` which was not handling
the JSON correctly.

Here is output from various command forms:

  <details><summary>jupyter runtime list</summary><p>

```
[ListRuntimes] ERROR | Schema validation failed for metadata 'foo' in namespace 'runtime' with error: 'Foo Bar ++' does not match '^[a-zA-Z][a-zA-Z0-9-_. (){}]*[a-zA-Z0-9)}]$'

Failed validating 'pattern' in schema['properties']['display_name']:
    {'description': 'The display name of the metadata',
     'pattern': '^[a-zA-Z][a-zA-Z0-9-_. (){}]*[a-zA-Z0-9)}]$',
     'type': 'string'}

On instance['display_name']:
    'Foo Bar ++'
Available metadata for external runtimes:
  bar               /Users/kbates/Library/Jupyter/metadata/runtime/bar.json               
  foo               /Users/kbates/Library/Jupyter/metadata/runtime/foo.json               **INVALID** (ValidationError)
  really_long_name  /Users/kbates/Library/Jupyter/metadata/runtime/really_long_name.json  
```
  </p></details>
  <details><summary>jupyter runtime list --json</summary><p>

```
[ListRuntimes] ERROR | Schema validation failed for metadata 'foo' in namespace 'runtime' with error: 'Foo Bar ++' does not match '^[a-zA-Z][a-zA-Z0-9-_. (){}]*[a-zA-Z0-9)}]$'

Failed validating 'pattern' in schema['properties']['display_name']:
    {'description': 'The display name of the metadata',
     'pattern': '^[a-zA-Z][a-zA-Z0-9-_. (){}]*[a-zA-Z0-9)}]$',
     'type': 'string'}

On instance['display_name']:
    'Foo Bar ++'
Runtime: foo **INVALID**
{
  "display_name": "Foo Bar ++",
  "metadata": {
    "api_endpoint": "http://wackwach",
    "cos_endpoint": "http://zackzach",
    "cos_bucket": "cos_chuckit"
  },
  "schema_name": "kfp",
  "name": "foo",
  "resource": "/Users/kbates/Library/Jupyter/metadata/runtime/foo.json",
  "reason": "ValidationError"
}
Runtime: bar 
{
  "display_name": "Bar Baz",
  "metadata": {
    "api_endpoint": "http://wackwach",
    "cos_endpoint": "http://zackzach",
    "cos_bucket": "cos_chuckit"
  },
  "schema_name": "kfp",
  "name": "bar",
  "resource": "/Users/kbates/Library/Jupyter/metadata/runtime/bar.json"
}
Runtime: really_long_name 
{
  "display_name": "Really Long Name",
  "metadata": {
    "api_endpoint": "http://wackwack",
    "cos_endpoint": "http://zachzach",
    "cos_bucket": "cos_chuckit"
  },
  "schema_name": "kfp",
  "name": "really_long_name",
  "resource": "/Users/kbates/Library/Jupyter/metadata/runtime/really_long_name.json"
}
```
  </p></details>
  <details><summary>jupyter runtime list --valid-only</summary><p>

```
[ListRuntimes] ERROR | Schema validation failed for metadata 'foo' in namespace 'runtime' with error: 'Foo Bar ++' does not match '^[a-zA-Z][a-zA-Z0-9-_. (){}]*[a-zA-Z0-9)}]$'

Failed validating 'pattern' in schema['properties']['display_name']:
    {'description': 'The display name of the metadata',
     'pattern': '^[a-zA-Z][a-zA-Z0-9-_. (){}]*[a-zA-Z0-9)}]$',
     'type': 'string'}

On instance['display_name']:
    'Foo Bar ++'
Available metadata for external runtimes:
  bar               /Users/kbates/Library/Jupyter/metadata/runtime/bar.json               
  really_long_name  /Users/kbates/Library/Jupyter/metadata/runtime/really_long_name.json  
```
  </p></details>
  <details><summary>jupyter runtime list - when all are valid</summary><p>

```
Available metadata for external runtimes:
  bar               /Users/kbates/Library/Jupyter/metadata/runtime/bar.json               
  foo               /Users/kbates/Library/Jupyter/metadata/runtime/foo.json               
  really_long_name  /Users/kbates/Library/Jupyter/metadata/runtime/really_long_name.json  
```
  </p></details>
Fixes: #213
