### PR TITLE
Fix bug when closing the output in python editor

### DIFF
--- a/packages/python-runner/src/widget.tsx
+++ b/packages/python-runner/src/widget.tsx
@@ -175,7 +175,7 @@ export class PythonFileEditor extends DocumentWidget<FileEditor, DocumentRegistr
     // TODO: Set layout height to be flexible
     BoxLayout.setStretch(this.dockPanel, 1);
 
-    if ( !this.hasOutputTab() ){
+    if ( this.dockPanel.isEmpty ){
       // Add a tab to dockPanel
       this.dockPanel.addWidget(this.outputAreaWidget, { mode: 'split-bottom' });
 
@@ -183,7 +183,7 @@ export class PythonFileEditor extends DocumentWidget<FileEditor, DocumentRegistr
       outputTab.id = 'tab-python-editor-output';
       outputTab.currentTitle.label = 'Python Console Output';
       outputTab.currentTitle.closable = true;
-      this.addCollapseButton();
+      outputTab.disposed.connect((sender, args) => { this.resetOutputArea(); }, this);
     }
   };
 
@@ -239,23 +239,6 @@ export class PythonFileEditor extends DocumentWidget<FileEditor, DocumentRegistr
    */
   private updatePromptText = (kernelStatusFlag: string) => {
     this.getOutputAreaPromptWidget().node.innerText = '[' + kernelStatusFlag + ']:';
-  };
-
-  /**
-   * Function: Returns a boolean representing if the DockPanel instance has a TabBar.
-   */
-  private hasOutputTab = () => {
-    return Object.entries(this.dockPanel.tabBars()).length !== 0;
-  }
-
-  //  TODO: Add collapse button to tab
-  private addCollapseButton = () => {
-    // Commented code below swaps close icon to collapse icon. We want both.
-    // const tabBar = this.dockPanel.tabBars().next();
-    // let closeIconElem = tabBar.contentNode.getElementsByClassName('p-TabBar-tabCloseIcon')[0];
-    // if (closeIconElem){
-    //   closeIconElem.classList.add(COLLAPSE_ICON_CLASS);
-    // }
   };
 
   /**


### PR DESCRIPTION
Previously when closing the output that for a python editor the
space set aside for the tab stayed even after the tab was gone.

Now on tab close the editopr returns to the state it was in before
the output tab was opened.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

