### PR TITLE
Don't create namespace directory on GET requests

### DIFF
--- a/elyra/metadata/handlers.py
+++ b/elyra/metadata/handlers.py
@@ -30,6 +30,8 @@ class MetadataHandler(APIHandler):
         metadata_manager = MetadataManager(namespace=namespace)
         try:
             metadata = yield maybe_future(metadata_manager.get_all())
+        except (ValidationError, KeyError) as err:
+            raise web.HTTPError(404, str(err))
         except Exception as ex:
             raise web.HTTPError(500, repr(ex))
 

--- a/elyra/metadata/tests/test_handlers.py
+++ b/elyra/metadata/tests/test_handlers.py
@@ -78,7 +78,7 @@ class MetadataHandlerTest(NotebookTestBase):
 
     def test_bogus_namespace(self):
         # Validate missing is not found
-        with assert_http_error(404, "Metadata 'missing' in namespace 'bogus' was not found!"):
+        with assert_http_error(404, "Namespace 'bogus' was not found!"):
             self.bogus_namespace_api.get('missing')
 
         self.assertFalse(os.path.exists(self.bogus_dir))
@@ -113,10 +113,14 @@ class MetadataHandlerTest(NotebookTestBase):
         self.assertIn('another', runtimes.keys())
         self.assertIn('valid', runtimes.keys())
 
-    def test_get_runtimes_none(self):
-        # Delete the metadata dir and attempt listing metadata
+    def test_get_runtimes_empty(self):
+        # Delete the metadata dir contents and attempt listing metadata
         shutil.rmtree(self.runtime_dir)
+        with assert_http_error(404, "Namespace 'runtimes' was not found!"):
+            r = self.runtime_api.get_all()
 
+        # Now create empty namespace
+        os.makedirs(self.runtime_dir)
         r = self.runtime_api.get_all()
         self.assertEqual(r.status_code, 200)
         metadata = r.json()

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -75,14 +75,22 @@ class MetadataManagerTestCase(MetadataTestBase):
                 self.assertTrue(metadata.name == "valid")
 
     def test_list_metadata_summary_none(self):
-        # Delete the metadata dir and attempt listing metadata
+        # Delete the metadata dir contents and attempt listing metadata
         shutil.rmtree(self.metadata_dir)
+        assert self.metadata_manager.namespace_exists() == False
+        os.makedirs(self.metadata_dir)
+        assert self.metadata_manager.namespace_exists()
+
         metadata_summary_list = self.metadata_manager.get_all_metadata_summary()
         self.assertEqual(len(metadata_summary_list), 0)
 
     def test_list_all_metadata_none(self):
-        # Delete the metadata dir and attempt listing metadata
+        # Delete the metadata dir contents and attempt listing metadata
         shutil.rmtree(self.metadata_dir)
+        assert self.metadata_manager.namespace_exists() == False
+        os.makedirs(self.metadata_dir)
+        assert self.metadata_manager.namespace_exists()
+
         metadata_list = self.metadata_manager.get_all()
         self.assertEqual(len(metadata_list), 0)
 
@@ -193,14 +201,22 @@ class MetadataFileStoreTestCase(MetadataTestBase):
         self.assertEqual(len(metadata_list), 2)
 
     def test_list_metadata_summary_none(self):
-        # Delete the metadata dir and attempt listing metadata
+        # Delete the metadata dir contents and attempt listing metadata
         shutil.rmtree(self.metadata_dir)
+        assert self.metadata_file_store.namespace_exists() == False
+        os.makedirs(self.metadata_dir)
+        assert self.metadata_file_store.namespace_exists()
+
         metadata_summary_list = self.metadata_file_store.get_all_metadata_summary(include_invalid=True)
         self.assertEqual(len(metadata_summary_list), 0)
 
     def test_list_all_metadata_none(self):
-        # Delete the metadata dir and attempt listing metadata
+        # Delete the metadata dir contents and attempt listing metadata
         shutil.rmtree(self.metadata_dir)
+        assert self.metadata_file_store.namespace_exists() == False
+        os.makedirs(self.metadata_dir)
+        assert self.metadata_file_store.namespace_exists()
+
         metadata_list = self.metadata_file_store.get_all()
         self.assertEqual(len(metadata_list), 0)
 


### PR DESCRIPTION
If a namespace was provided that doesn't already exist, the server
was creating an empty directory when initializing the metadata
instance.  Now, the containing directory is created on demand but
only when saving metadata for a given namespace.

Fixes #246



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

