### PR TITLE
Add lint support

### DIFF
--- a/elyra/metadata/handlers.py
+++ b/elyra/metadata/handlers.py
@@ -34,7 +34,7 @@ class MetadataHandler(APIHandler):
             raise web.HTTPError(500, repr(ex))
 
         metadata_model = {}
-        metadata_model[namespace] = {r.name : r.to_dict() for r in metadata}
+        metadata_model[namespace] = {r.name: r.to_dict() for r in metadata}
         self.set_header("Content-Type", 'application/json')
         self.finish(metadata_model)
 

--- a/elyra/metadata/metadata.py
+++ b/elyra/metadata/metadata.py
@@ -21,7 +21,7 @@ import re
 from abc import ABC, abstractmethod
 from jsonschema import validate, ValidationError
 from jupyter_core.paths import jupyter_data_dir
-from traitlets import HasTraits, List, Unicode, Dict, Type, log
+from traitlets import HasTraits, Unicode, Dict, Type, log
 from traitlets.config import SingletonConfigurable, LoggingConfigurable
 
 DEFAULT_SCHEMA_NAME = 'kfp'
@@ -68,10 +68,8 @@ class Metadata(HasTraits):
 
 class MetadataManager(LoggingConfigurable):
     metadata_class = Type(Metadata, config=True,
-        help="""The metadata class.  This is configurable to allow
-        subclassing of the MetadataManager for customized behavior.
-        """
-    )
+                          help="""The metadata class.  This is configurable to allow subclassing of
+                          the MetadataManager for customized behavior.""")
 
     def __init__(self, namespace, store=None, **kwargs):
         """
@@ -210,7 +208,8 @@ class FileMetadataStore(MetadataStore):
             if replace:
                 os.remove(resource)
             else:
-                self.log.error("Metadata resource '{}' already exists. Use the replace flag to overwrite.".format(resource))
+                self.log.error("Metadata resource '{}' already exists. Use the replace flag to overwrite.".
+                               format(resource))
                 return None
 
         with io.open(resource, 'w', encoding='utf-8') as f:

--- a/elyra/metadata/runtime.py
+++ b/elyra/metadata/runtime.py
@@ -13,17 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import io
-import json
-import os
 
 from .metadata import Metadata, MetadataManager
 
 from traitlets.config.application import Application
-from jupyter_core.application import (
-    JupyterApp, base_flags, base_aliases
-)
-from traitlets import Instance, Dict, Unicode, Bool, List
+from jupyter_core.application import base_flags
+from traitlets import Instance, Dict, Unicode, Bool
 from elyra._version import __version__
 
 
@@ -77,9 +72,8 @@ class ListRuntimes(Application, AppUtilMixin):
             return
 
         if self.json_output:
-            [print('Runtime: {} {}\n{}'.format(rt.name,
-                                            "**INVALID**" if rt.reason and len(rt.reason) > 0 else "",
-                                            rt.to_json()))
+            [print('Runtime: {} {}\n{}'.
+                   format(rt.name, "**INVALID**" if rt.reason and len(rt.reason) > 0 else "", rt.to_json()))
              for rt in runtimes]
         else:
             sorted_runtimes = sorted(runtimes, key=lambda runtime: runtime.name)
@@ -95,7 +89,9 @@ class ListRuntimes(Application, AppUtilMixin):
                 invalid = ""
                 if runtime.reason and len(runtime.reason) > 0:
                     invalid = "**INVALID** ({})".format(runtime.reason)
-                print("  %s  %s  %s" % (runtime.name.ljust(max_name_len), runtime.resource.ljust(max_resource_len), invalid))
+                print("  %s  %s  %s" % (runtime.name.ljust(max_name_len),
+                                        runtime.resource.ljust(max_resource_len),
+                                        invalid))
 
 
 class RemoveRuntime(Application, AppUtilMixin):
@@ -108,20 +104,18 @@ class RemoveRuntime(Application, AppUtilMixin):
     name = Unicode(None, config=True, allow_none=True,
                    help="The name of the runtime metadata to remove.")
 
-
     aliases = {
         'name': 'RemoveRuntime.name',
     }
 
-    flags = {'debug': base_flags['debug'],}
+    flags = {'debug': base_flags['debug']}
 
     def _metadata_manager_default(self):
         return MetadataManager(namespace=self.metadata_namespace)
 
     def start(self):
         self._validate_parameters()
-
-        resource = self.metadata_manager.remove(self.name)
+        self.metadata_manager.remove(self.name)
 
     def _validate_parameters(self):
         self._confirm_required("name", self.name)
@@ -255,7 +249,7 @@ class InstallRuntime(Application):
 
     def start(self):
         if self.subapp is None:
-            print("No subcommand specified. Must specify one of: %s"% list(self.subcommands))
+            print("No subcommand specified. Must specify one of: %s" % list(self.subcommands))
             print()
             self.print_description()
             self.print_subcommands()
@@ -280,7 +274,7 @@ class RuntimeMetadataApp(Application):
 
     def start(self):
         if self.subapp is None:
-            print("No subcommand specified. Must specify one of: %s"% list(self.subcommands))
+            print("No subcommand specified. Must specify one of: %s" % list(self.subcommands))
             print()
             self.print_description()
             self.print_subcommands()
@@ -291,5 +285,3 @@ class RuntimeMetadataApp(Application):
 
 if __name__ == '__main__':
     RuntimeMetadataApp.launch_instance()
-
-

--- a/elyra/metadata/tests/test_handlers.py
+++ b/elyra/metadata/tests/test_handlers.py
@@ -32,13 +32,12 @@ class MetadataRestAPI(object):
         self.headers = headers
 
     def _req(self, verb, path, body=None):
-        response = self.request(verb,
-                url_path_join('api', 'metadata', self.namespace, path), data=body)
+        response = self.request(verb, url_path_join('api', 'metadata', self.namespace, path), data=body)
 
         if 400 <= response.status_code < 600:
             try:
                 response.reason = response.json()['message']
-            except:
+            except Exception:
                 pass
         response.raise_for_status()
 
@@ -121,4 +120,3 @@ class MetadataHandlerTest(NotebookTestBase):
         self.assertEqual(len(metadata), 1)
         runtimes = metadata['runtimes']
         self.assertEqual(len(runtimes), 0)
-

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -18,7 +18,6 @@ import io
 import json
 import os
 import shutil
-import time
 import tempfile
 import unittest
 

--- a/elyra/pipeline/itests/itest_pipeline_runtime.py
+++ b/elyra/pipeline/itests/itest_pipeline_runtime.py
@@ -20,8 +20,7 @@ import unittest
 import unittest.mock as mock
 
 from elyra.metadata import Metadata
-from elyra.pipeline import PipelineParser, PipelineProcessorManager, Pipeline, Operation
-from elyra.pipeline import KfpPipelineProcessor
+from elyra.pipeline import PipelineParser, PipelineProcessorManager
 
 
 def mock_get_metadata(arg, **kwargs):
@@ -48,7 +47,7 @@ class PipelineRuntimeTestCase(unittest.TestCase):
         pipeline_definition = self.read_pipeline_resource('pipeline.json')
 
         pipeline = PipelineParser.parse(pipeline_definition)
-        response = PipelineProcessorManager.process(pipeline)
+        PipelineProcessorManager.process(pipeline)
 
     @staticmethod
     def read_pipeline_resource(pipeline_filename):

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -18,7 +18,8 @@ import os
 
 class Operation:
 
-    def __init__(self, id, type, title, artifact, image, vars=None, file_dependencies=None, recursive_dependencies=False, outputs=None, inputs=None, dependencies=None ):
+    def __init__(self, id, type, title, artifact, image, vars=None, file_dependencies=None,
+                 recursive_dependencies=False, outputs=None, inputs=None, dependencies=None):
         self._id = id
         self._type = type
         self._title = title
@@ -90,16 +91,16 @@ class Operation:
     def __eq__(self, other: object) -> bool:
         if isinstance(self, other.__class__):
             return self.id == other.id and \
-                   self.type == other.type  and \
-                   self.title == other.title  and \
-                   self.artifact == other.artifact  and \
-                   self.image == other.image and \
-                   self.vars == other.vars and \
-                   self.file_dependencies == other.file_dependencies and \
-                   self.recursive_dependencies == other.recursive_dependencies and \
-                   self.outputs == other.outputs and \
-                   self.inputs == other.inputs and \
-                   self.dependencies == other.dependencies
+                self.type == other.type and \
+                self.title == other.title and \
+                self.artifact == other.artifact and \
+                self.image == other.image and \
+                self.vars == other.vars and \
+                self.file_dependencies == other.file_dependencies and \
+                self.recursive_dependencies == other.recursive_dependencies and \
+                self.outputs == other.outputs and \
+                self.inputs == other.inputs and \
+                self.dependencies == other.dependencies
 
     @staticmethod
     def __initialize_empty_array_if_none(value):
@@ -147,6 +148,6 @@ class Pipeline:
     def __eq__(self, other: object) -> bool:
         if isinstance(self, other.__class__):
             return self.title == other.title and \
-                   self.runtime_type == other.runtime_type and \
-                   self.runtime_config == other.runtime_config and \
-                   self.operations == other.operations
+                self.runtime_type == other.runtime_type and \
+                self.runtime_config == other.runtime_config and \
+                self.operations == other.operations

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import entrypoints
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from traitlets.config import SingletonConfigurable, LoggingConfigurable
 
 
@@ -26,11 +26,11 @@ class PipelineProcessorRegistry(SingletonConfigurable):
         for processor in entrypoints.get_group_all('elyra.pipeline.processors'):
             try:
                 # instantiate an actual instance of the processor
-                processor_instance = processor.load()() #Load an instance
+                processor_instance = processor.load()()  # Load an instance
                 processor_type = processor_instance.type
                 self.log.info('Registering processor "{}" with type -> {}'.format(processor, processor_type))
                 self.__processors[processor_type] = processor_instance
-            except:
+            except Exception:
                 # log and ignore initialization errors
                 self.log.error('Error registering processor "{}"'.format(processor))
 
@@ -39,7 +39,7 @@ class PipelineProcessorRegistry(SingletonConfigurable):
         self.__processors[processor.type] = processor
 
     def get_processor(self, processor_type):
-        if  processor_type in self.__processors.keys():
+        if processor_type in self.__processors.keys():
             return self.__processors[processor_type]
         else:
             return None
@@ -59,7 +59,7 @@ class PipelineProcessorManager(SingletonConfigurable):
         return processor.process(pipeline)
 
 
-class PipelineProcessor(LoggingConfigurable): # ABC
+class PipelineProcessor(LoggingConfigurable):  # ABC
 
     @property
     @abstractmethod
@@ -69,5 +69,3 @@ class PipelineProcessor(LoggingConfigurable): # ABC
     @abstractmethod
     def process(self, pipeline):
         raise NotImplementedError()
-
-

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -14,17 +14,15 @@
 # limitations under the License.
 #
 
-import json
 import kfp
 import os
-import tarfile
 import tempfile
 
 from datetime import datetime
 
 from elyra.metadata import MetadataManager
 from elyra.metadata.runtime import Runtime
-from elyra.pipeline import PipelineProcessor, PipelineProcessorRegistry
+from elyra.pipeline import PipelineProcessor
 from elyra.util.archive import create_temp_archive
 from elyra.util.cos import CosClient
 from kubernetes.client.models import V1EnvVar
@@ -61,7 +59,8 @@ class KfpPipelineProcessor(PipelineProcessor):
                 for dependency in pipeline_child_operation.dependencies:
                     pipeline_parent_operation = pipeline.operations[dependency]
                     if pipeline_parent_operation.outputs:
-                        pipeline_child_operation.inputs = pipeline_child_operation.inputs + pipeline_parent_operation.outputs
+                        pipeline_child_operation.inputs = \
+                            pipeline_child_operation.inputs + pipeline_parent_operation.outputs
 
             for operation in pipeline.operations.values():
                 operation_artifact_archive = self._get_dependency_archive_name(operation)
@@ -109,7 +108,7 @@ class KfpPipelineProcessor(PipelineProcessor):
                         # Splits on the first occurrence of '='
                         result = [x.strip(' \'\"') for x in env_var.split('=', 1)]
                         # Should be non empty key with a value
-                        if len(result) is 2 and result[0] is not '':
+                        if len(result) == 2 and result[0] != '':
                             notebook_op.container.add_env_variable(V1EnvVar(name=result[0], value=result[1]))
 
                 notebook_ops[operation.id] = notebook_op
@@ -120,7 +119,9 @@ class KfpPipelineProcessor(PipelineProcessor):
                 try:
                     dependency_archive_path = self._generate_dependency_archive(operation)
                     cos_client = CosClient(config=runtime_configuration)
-                    cos_client.upload_file_to_dir(dir=cos_directory, file_name=operation_artifact_archive, file_path=dependency_archive_path)
+                    cos_client.upload_file_to_dir(dir=cos_directory,
+                                                  file_name=operation_artifact_archive,
+                                                  file_path=dependency_archive_path)
                 except BaseException:
                     self.log.error("Error uploading artifacts to object storage.", exc_info=True)
                     raise
@@ -203,4 +204,4 @@ class KfpPipelineProcessor(PipelineProcessor):
         except BaseException as err:
             self.log.error('Error retrieving runtime configuration for {}'.format(name),
                            exc_info=True)
-            raise RuntimeError('Error retrieving runtime configuration for {}', err )
+            raise RuntimeError('Error retrieving runtime configuration for {}', err)

--- a/elyra/pipeline/tests/test_pipeline_parser.py
+++ b/elyra/pipeline/tests/test_pipeline_parser.py
@@ -17,7 +17,7 @@ import os
 import unittest
 import json
 
-from elyra.pipeline import PipelineParser, Pipeline, Operation
+from elyra.pipeline import PipelineParser, Operation
 
 
 class PipelineParserTestCase(unittest.TestCase):
@@ -41,7 +41,7 @@ class PipelineParserTestCase(unittest.TestCase):
     def test_parse_invalid_pipeline(self):
         pipeline_definition = self.read_pipeline_resource('pipeline_invalid.json')
 
-        pipeline = PipelineParser.parse(pipeline_definition)
+        PipelineParser.parse(pipeline_definition)
 
     def test_parse_multinode_pipeline(self):
         pipeline_definition = self.read_pipeline_resource('pipeline_3_node_sample.json')
@@ -86,5 +86,3 @@ class PipelineParserTestCase(unittest.TestCase):
             pipeline_json = json.load(f)
 
         return pipeline_json
-
-

--- a/elyra/util/cos.py
+++ b/elyra/util/cos.py
@@ -46,9 +46,9 @@ class CosClient(LoggingConfigurable):
 
         # Initialize minioClient with an endpoint and access/secret keys.
         self.client = Minio(endpoint=self.endpoint.netloc,
-                                  access_key=self.access_key,
-                                  secret_key=self.secret_key,
-                                  secure=False)
+                            access_key=self.access_key,
+                            secret_key=self.secret_key,
+                            secure=False)
 
         # Make a bucket with the make_bucket API call.
         try:
@@ -93,7 +93,7 @@ class CosClient(LoggingConfigurable):
         """
         self.upload_file(os.path.join(dir, file_name), file_path)
 
-    def download_file(self, file_name, file_path ):
+    def download_file(self, file_name, file_path):
         """
         Downloads and saves the object as a file in the local filesystem.
         :param file_name: Name of the file object in object storage
@@ -103,12 +103,12 @@ class CosClient(LoggingConfigurable):
         try:
             self.client.fget_object(bucket_name=self.bucket,
                                     object_name=file_name,
-                                    file_path= file_path)
+                                    file_path=file_path)
         except BaseException:
             self.log.error('Error reading file {} from bucket {}'.format(file_name, self.bucket), exc_info=True)
             raise
 
-    def download_file_from_dir(self, dir, file_name, file_path ):
+    def download_file_from_dir(self, dir, file_name, file_path):
         """
         Downloads and saves the object as a file in the local filesystem.
         :param dir: the directory where the file is located
@@ -118,4 +118,3 @@ class CosClient(LoggingConfigurable):
         """
 
         self.download_file(os.path.join(dir, file_name), file_path)
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,3 +19,22 @@ universal=0
 
 [metadata]
 description-file=README.md
+
+[flake8]
+# References:
+# https://flake8.readthedocs.io/en/latest/user/configuration.html
+# https://flake8.readthedocs.io/en/latest/user/error-codes.html
+exclude = __init__.py
+ignore =
+    # Import formatting
+    E4,
+    # Comparing types instead of isinstance
+    E721,
+    # Assigning lambda expression
+    E731,
+    # Ambiguous variable names
+    E741,
+    # Allow breaks after binary operators
+    W504
+max-line-length = 120
+

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,10 @@ setup_args = dict(
         'requests>=2.9.1,<3.0',
         'entrypoints>=0.3',
     ],
-    tests_require = [
-        'pytest', 'pytest-console-scripts',
-    ],
+    extra_require={
+        'test': ['pytest', 'pytest-console-scripts'],
+        'dev': ['flake8'],
+    },
     include_package_data=True,
     description="Elyra",
     long_description=long_desc,


### PR DESCRIPTION
Adds the ability to lint the elyra python files.  Added a new 'lint'
target to the Makefile and updated targets 'test' and 'install' to
depend on 'lint' as well.

Updated all linted files to conform to the configured lint rules.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

