### PR TITLE
Change unsupported files messaging to reference selection

### DIFF
--- a/packages/pipeline-editor/src/index.tsx
+++ b/packages/pipeline-editor/src/index.tsx
@@ -386,7 +386,7 @@ class Pipeline extends React.Component<Pipeline.Props, Pipeline.State> {
     if (failedAdd) {
       return showDialog({
         title: 'Unsupported File(s)',
-        body: 'Only selected notebook files can be added to a pipeline',
+        body: 'Currently, only selected notebook files can be added to a pipeline',
         buttons: [Dialog.okButton()]
       });
     }


### PR DESCRIPTION
This is a temporary change to the longer-term issue #265.  It changes the current message to include a clause about "selected notebooks" so that users then get an implicit link between the + button and the selected files on the left-hand pane.
 
![Screen Shot 2020-02-17 at 3 39 11 PM](https://user-images.githubusercontent.com/22599560/74692522-5f123c00-519c-11ea-8b58-c8fb5e56a0ba.png)

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
