### PR TITLE
Restrict carbon verson to compatable release

### DIFF
--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -48,7 +48,7 @@
         "@elyra-ai/canvas": "^6.1.23",
         "@elyra/application": "^0.4.0",
         "autoprefixer": "^9.6.0",
-        "carbon-components": "^10.3.2",
+        "carbon-components": "~10.8.1",
         "json-loader": "^0.5.7",
         "react": "^16.8.6",
         "react-dom": "^16.8.6",


### PR DESCRIPTION
Carbon 10.9.0 introduced css changes that break how the common properties
module is displayed. This forces the editor to use an earlier compatable
version.

Note: This fix may need to eventually be replaced if we update to a later version of canvas (the internal release is farther ahead). The latest canvas release relies on the newer carbon version and will most likely break this fix. But based on some initial testing we will need to rework our case-specific css for common properties anyway to make that update.

This fixes #270 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

