### PR TITLE
Improve robustness of pipeline parser

### DIFF
--- a/elyra/pipeline/tests/test_pipeline_parser.py
+++ b/elyra/pipeline/tests/test_pipeline_parser.py
@@ -14,75 +14,117 @@
 # limitations under the License.
 #
 import os
-import unittest
 import json
+import pytest
+
 
 from elyra.pipeline import PipelineParser, Operation
 
 
-class PipelineParserTestCase(unittest.TestCase):
-    valid_operation = Operation(id='{{uuid}}',
-                                type='{{type}}',
-                                title='{{title}}',
-                                artifact='{{artifact}}',
-                                image='{{image}}')
+@pytest.fixture
+def valid_operation():
+    return Operation(id='{{uuid}}',
+                     type='{{type}}',
+                     title='{{title}}',
+                     artifact='{{artifact}}',
+                     image='{{image}}')
 
-    def test_parse_valid_pipeline(self):
-        pipeline_definition = self.read_pipeline_resource('pipeline_valid.json')
 
-        pipeline = PipelineParser.parse(pipeline_definition)
+def read_pipeline_resource(pipeline_filename):
+    root = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+    pipeline_path = os.path.join(root, pipeline_filename)
 
-        self.assertEqual(pipeline.title, '{{title}}')
-        self.assertEqual(len(pipeline.operations), 1)
+    with open(pipeline_path, 'r') as f:
+        pipeline_json = json.load(f)
 
-        self.assertTrue(pipeline.operations['{{uuid}}'] == PipelineParserTestCase.valid_operation)
+    return pipeline_json
 
-    @unittest.expectedFailure
-    def test_parse_invalid_pipeline(self):
-        pipeline_definition = self.read_pipeline_resource('pipeline_invalid.json')
 
+def test_valid_pipeline(valid_operation):
+    pipeline_definition = read_pipeline_resource('pipeline_valid.json')
+
+    pipeline = PipelineParser.parse(pipeline_definition)
+
+    assert pipeline.title == '{{title}}'
+    assert len(pipeline.operations) == 1
+    assert pipeline.operations['{{uuid}}'] == valid_operation
+
+
+def test_missing_artifact():
+    pipeline_definition = read_pipeline_resource('pipeline_invalid.json')
+
+    with pytest.raises(SyntaxError) as e:
         PipelineParser.parse(pipeline_definition)
 
-    def test_parse_multinode_pipeline(self):
-        pipeline_definition = self.read_pipeline_resource('pipeline_3_node_sample.json')
+    assert "Missing field 'artifact'" in str(e.value)
 
-        pipeline = PipelineParser.parse(pipeline_definition)
 
-        self.assertEqual(len(pipeline.operations), 3)
+def test_missing_primary():
+    pipeline_definition = read_pipeline_resource('pipeline_invalid.json')
+    pipeline_definition.pop('primary_pipeline')
 
-    def test_parse_pipeline_operations_and_handle_artifact_file_details(self):
-        pipeline_definition = self.read_pipeline_resource('pipeline_3_node_sample.json')
+    with pytest.raises(SyntaxError):
+        PipelineParser.parse(pipeline_definition)
 
-        pipeline = PipelineParser.parse(pipeline_definition)
 
-        self.assertEqual(len(pipeline.operations), 3)
+def test_missing_pipelines():
+    pipeline_definition = read_pipeline_resource('pipeline_invalid.json')
+    pipeline_definition.pop('pipelines')
 
-        for op in pipeline.operations.values():
-            self.assertTrue('/' not in op.artifact_filename)
-            self.assertTrue('.' not in op.artifact_name)
+    with pytest.raises(SyntaxError):
+        PipelineParser.parse(pipeline_definition)
 
-    def test_parse_pipeline_with_dependencies(self):
-        pipeline_definition = self.read_pipeline_resource('pipeline_3_node_sample_with_dependencies.json')
 
-        pipeline = PipelineParser.parse(pipeline_definition)
+def test_missing_primary_id():
+    pipeline_definition = read_pipeline_resource('pipeline_invalid.json')
+    # Replace pipeline id with non-matching guid so primary is not found
+    pipeline_definition['pipelines'][0]['id'] = "deadbeef-dead-beef-dead-beefdeadbeef"
 
-        self.assertEqual(len(pipeline.operations['acc4527d-7cc8-4c16-b520-5aa0f50a2e34'].dependencies), 2)
+    with pytest.raises(SyntaxError):
+        PipelineParser.parse(pipeline_definition)
 
-    def test_parse_pipeline_global_attributes(self):
-        pipeline_definition = self.read_pipeline_resource('pipeline_valid.json')
 
-        pipeline = PipelineParser.parse(pipeline_definition)
+def test_zero_nodes():
+    pipeline_definition = read_pipeline_resource('pipeline_invalid.json')
+    pipeline_definition['pipelines'][0]['nodes'] = []
 
-        self.assertEqual(pipeline.title, '{{title}}')
-        self.assertEqual(pipeline.runtime, '{{runtime}}')
-        self.assertEqual(pipeline.runtime_config, '{{runtime-config}}')
+    with pytest.raises(SyntaxError):
+        PipelineParser.parse(pipeline_definition)
 
-    @staticmethod
-    def read_pipeline_resource(pipeline_filename):
-        root = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
-        pipeline_path = os.path.join(root, pipeline_filename)
 
-        with open(pipeline_path, 'r') as f:
-            pipeline_json = json.load(f)
+def test_multinode_pipeline():
+    pipeline_definition = read_pipeline_resource('pipeline_3_node_sample.json')
 
-        return pipeline_json
+    pipeline = PipelineParser.parse(pipeline_definition)
+
+    assert len(pipeline.operations) == 3
+
+
+def test_pipeline_operations_and_handle_artifact_file_details():
+    pipeline_definition = read_pipeline_resource('pipeline_3_node_sample.json')
+
+    pipeline = PipelineParser.parse(pipeline_definition)
+
+    assert len(pipeline.operations) == 3
+
+    for op in pipeline.operations.values():
+        assert '/' not in op.artifact_filename
+        assert '.' not in op.artifact_name
+
+
+def test_pipeline_with_dependencies():
+    pipeline_definition = read_pipeline_resource('pipeline_3_node_sample_with_dependencies.json')
+
+    pipeline = PipelineParser.parse(pipeline_definition)
+
+    assert len(pipeline.operations['acc4527d-7cc8-4c16-b520-5aa0f50a2e34'].dependencies) == 2
+
+
+def test_pipeline_global_attributes():
+    pipeline_definition = read_pipeline_resource('pipeline_valid.json')
+
+    pipeline = PipelineParser.parse(pipeline_definition)
+
+    assert pipeline.title == '{{title}}'
+    assert pipeline.runtime == '{{runtime}}'
+    assert pipeline.runtime_config == '{{runtime-config}}'

--- a/elyra/scheduler/handler.py
+++ b/elyra/scheduler/handler.py
@@ -34,11 +34,13 @@ class SchedulerHandler(APIHandler):
 
         self.log.debug("JSON payload: %s", pipeline_definition)
 
-        pipeline = PipelineParser.parse(pipeline_definition)
-
-        run_url = PipelineProcessorManager.process(pipeline)
-
-        self.send_success_message("pipeline successfully submitted", run_url)
+        try:
+            pipeline = PipelineParser.parse(pipeline_definition)
+            run_url = PipelineProcessorManager.process(pipeline)
+        except Exception as e:
+            self.send_error_message(500, "Pipeline submission failed with the following error: {}".format(str(e)))
+        else:
+            self.send_success_message("Pipeline successfully submitted", run_url)
 
     def send_message(self, message):
         self.write(message)


### PR DESCRIPTION
- The parse() method now only throws `SyntaxError` with context-sensitive
messages. This allows callers to simplify their error handling.
- The handler was updated to detect issues and send back error messages.
- Parser tests have been converted to `pytest`.

Fixes #267



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

