### PR TITLE
Revert package name change for canvas dependency

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -33,8 +33,9 @@ jobs:
         pip --version
     - name: Create npm configuration for authentication
       run: |
-        echo "@elyra-ai:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-        echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_PERSONAL_TOKEN }}" >> ~/.npmrc
+        echo "@elyra:registry=https://na.artifactory.swg-devops.com/artifactory/api/npm/dbg-aiw-npm-virtual/" >> ~/.npmrc
+        echo "email=${{ secrets.ARTIFACTORY_PERSONAL_USER }}" >> ~/.npmrc
+        echo "_auth=${{ secrets.ARTIFACTORY_PERSONAL_TOKEN }}" >> ~/.npmrc
         echo "always-auth=true" >> ~/.npmrc
         echo "scripts-prepend-node-path=true" >> ~/.npmrc
         echo "prefix=~/.npm-global" >> ~/.npmrc

--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -45,7 +45,7 @@
         "@phosphor/widgets": "^1.8.1",
         "@types/jest": "24.0.15",
         "@types/node": "^12.0.10",
-        "@elyra-ai/canvas": "^6.1.23",
+        "@elyra/canvas": "^6.1.23",
         "@elyra/application": "^0.4.0",
         "autoprefixer": "^9.6.0",
         "carbon-components": "~10.8.1",

--- a/packages/pipeline-editor/src/common-canvas.d.ts
+++ b/packages/pipeline-editor/src/common-canvas.d.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-declare module '@elyra-ai/canvas';
+declare module '@elyra/canvas';

--- a/packages/pipeline-editor/src/index.tsx
+++ b/packages/pipeline-editor/src/index.tsx
@@ -27,8 +27,8 @@ import {toArray} from '@phosphor/algorithm';
 import {IDragEvent} from '@phosphor/dragdrop';
 import {Widget, PanelLayout} from '@phosphor/widgets';
 
-import {CommonCanvas, CanvasController, CommonProperties} from '@elyra-ai/canvas';
-import '@elyra-ai/canvas/dist/common-canvas.min.css';
+import {CommonCanvas, CanvasController, CommonProperties} from '@elyra/canvas';
+import '@elyra/canvas/dist/common-canvas.min.css';
 import {NotebookParser, SubmissionHandler} from "@elyra/application";
 import 'carbon-components/css/carbon-components.min.css';
 import '../style/index.css';


### PR DESCRIPTION
With these changes, we can retrieve the canvas from the internal artifactory repository, avoiding the rename to `@elyra-ai/canvas`
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

