### PR TITLE
Install test dependencies prior to testing

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -42,7 +42,7 @@ jobs:
         mkdir -p ~/.npm-global
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip wheel flake8 notebook jupyterlab
+        python -m pip install --upgrade pip wheel notebook jupyterlab
     - name: Install NPM dependencies
       run: |
         sudo apt install yarn
@@ -54,9 +54,8 @@ jobs:
       run: |
         export PATH=~/.npm-global/bin:$PATH
         make install
-    - name: Test with pytest
+    - name: Test
       run: |
-        pip install pytest pytest-console-scripts
         make test
     - name: Collect logs
       if: failure()

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-.PHONY: help clean prepare install clean-docker docker-image
+.PHONY: help clean prepare install clean-docker docker-image test_dependencies
 
 SHELL:=/bin/bash
 
@@ -41,7 +41,10 @@ clean: ## Make a clean source tree
 test: lint ## Run unit tests
 	pytest -v elyra
 
-lint: ## Lint python files
+test_dependencies:
+	@pip install -q -r test_requirements.txt
+
+lint: test_dependencies ## Lint python files
 	flake8 elyra
 
 # Prepares Elyra for build/packaging/installation

--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,6 @@ setup_args = dict(
         'requests>=2.9.1,<3.0',
         'entrypoints>=0.3',
     ],
-    extra_require={
-        'test': ['pytest', 'pytest-tornasync', 'pytest-console-scripts'],
-        'dev': ['flake8'],
-    },
     include_package_data=True,
     description="Elyra",
     long_description=long_desc,

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-tornasync
+pytest-console-scripts
+flake8


### PR DESCRIPTION
This change removes the test dependencies from extras_require,
since that doesn't really work as the command also installs
elyra. Instead, the test dependencies (and flake8) have been
moved to test_requirements.txt.  The Makefile 'lint' target
now depends on a 'test_dependencies' target which installs
the modules in test_requirements.txt.  Since both 'install'
and 'test' targets depend on 'lint', all test dependencies
are in place as part of running either 'make install' or
'make test'.

Resolves #263



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

