### PR TITLE
Freeze Jupyterlab extension versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ npm-packages: lerna-build
 	$(call PACKAGE_LAB_EXTENSION,notebook-scheduler)
 	$(call PACKAGE_LAB_EXTENSION,pipeline-editor)
 	$(call PACKAGE_LAB_EXTENSION,python-runner)
-	cd dist && curl -O $$(npm view @jupyterlab/git dist.tarball --userconfig=./npm_config) && cd -
-	cd dist && curl -O $$(npm view @jupyterlab/toc dist.tarball --userconfig=./npm_config) && cd -
+	cd dist && curl -O $$(npm view @jupyterlab/git@0.9.0 dist.tarball --userconfig=./npm_config) && cd -
+	cd dist && curl -O $$(npm view @jupyterlab/toc@2.0.0 dist.tarball --userconfig=./npm_config) && cd -
 
 bdist: npm-packages
 	python setup.py bdist_wheel


### PR DESCRIPTION
As the JupyterLab extensions are all preparing to
release the support for Lab 2.0.0, we need to make
sure we freeze these to the versions that are still
supporting Lab 1.x

Fixes #315 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

