### PR TITLE
Handle missing directory when listing runtimes

### DIFF
--- a/elyra/metadata/runtime.py
+++ b/elyra/metadata/runtime.py
@@ -64,10 +64,13 @@ class ListRuntimes(Application, AppUtilMixin):
 
     def start(self):
         include_invalid = not self.valid_only
-        runtimes = self.metadata_manager.get_all_metadata_summary(include_invalid=include_invalid)
+        try:
+            runtimes = self.metadata_manager.get_all_metadata_summary(include_invalid=include_invalid)
+        except KeyError:
+            runtimes = None
 
         if not runtimes:
-            print("No metadata available for external runtimes at : '{}'"
+            print("No metadata available for external runtimes at: '{}'"
                   .format(self.metadata_manager.get_metadata_location))
             return
 

--- a/elyra/metadata/tests/test_runtime_app.py
+++ b/elyra/metadata/tests/test_runtime_app.py
@@ -191,6 +191,12 @@ def test_list_help_all(script_runner):
 def test_list_runtimes(script_runner, mock_runtime_dir):
     metadata_manager = MetadataManager(namespace=Runtime.namespace)
 
+    ret = script_runner.run('jupyter-runtimes', 'list')
+    assert ret.success
+    lines = ret.stdout.split('\n')
+    assert len(lines) == 2  # always 2 more than the actual runtime count
+    assert lines[0].startswith("No metadata available for external runtimes")
+
     valid = Runtime(**valid_metadata_json)
     resource = metadata_manager.add('valid', valid)
     assert resource is not None


### PR DESCRIPTION
If no runtimes directory exists, the tool now produces the following:

```
$ jupyter runtimes list
No metadata available for external runtimes at : '/Users/kbates/Library/Jupyter/metadata/runtimes'
```
Resolves #317



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

