### PR TITLE
Update kfp dependency and pin kfp-server-api

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup_args = dict(
         "kfp==0.2.2",
         "urllib3==1.24",
         "kfp-notebook>=0.6.1",
-        "kfp-server-api==0.1.18.3",
+        "kfp-server-api==0.1.37",
         "minio>=5.0.7",
         'jupyterlab>=1.0.0,<2.0.0',
         'jupyterlab-git',


### PR DESCRIPTION
kfp-server-api is normally resolved by the kfp package however
v0.1.40 is currently broken when trying to use with kubeflow v1.0
deployment.

prelim testing so far is good with both kubeflow v0.7 and v1.0

Also pinned urllib3 to 1.24 to suppress warning messages during build.

Fixes #308 


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

