### PR TITLE
Refactor targets around lint usability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ yarn-install:
 	yarn cache clean
 	yarn
 
-test-dependencies: yarn-install
+test-dependencies:
 	@pip install -q -r test_requirements.txt
 
 lint: test-dependencies ## Run linters
@@ -53,7 +53,7 @@ lint: test-dependencies ## Run linters
 	yarn run prettier
 	yarn run eslint
 
-lerna-build: lint
+lerna-build: yarn-install
 	export PATH=$$(pwd)/node_modules/.bin:$$PATH && lerna run build
 
 npm-packages: lerna-build
@@ -68,7 +68,7 @@ npm-packages: lerna-build
 bdist: npm-packages
 	python setup.py bdist_wheel
 
-install: bdist ## Build distribution and install
+install: bdist lint ## Build distribution and install
 	pip install --upgrade dist/elyra-*-py3-none-any.whl
 	$(call UNLINK_LAB_EXTENSION,application)
 	$(call UNINSTALL_LAB_EXTENSION,notebook-scheduler-extension)


### PR DESCRIPTION
This also shaves 1m 20s from the test step due to the elimination of a redundant yarn-install build.

It does assume that `make install` _has been_ run before `make lint`, but I think that constraint is worth the time savings.

Resolves #312



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

