### PR TITLE
Add message when waiting for python kernel to start

### DIFF
--- a/packages/python-runner/src/widget.tsx
+++ b/packages/python-runner/src/widget.tsx
@@ -225,9 +225,7 @@ export class PythonFileEditor extends DocumentWidget<
       };
       this.outputAreaWidget.model.add(options);
       this.updatePromptText(' ');
-      this.getOutputAreaChildWidget().addClass(OUTPUT_AREA_CHILD_CLASS);
-      this.getOutputAreaOutputWidget().addClass(OUTPUT_AREA_OUTPUT_CLASS);
-      this.getOutputAreaPromptWidget().addClass(OUTPUT_AREA_PROMPT_CLASS);
+      this.setOutputAreaClasses();
       outputTab.disposed.connect((sender, args) => {
         this.resetOutputArea();
       }, this);
@@ -270,10 +268,14 @@ export class PythonFileEditor extends DocumentWidget<
         this.outputAreaWidget.model.add(options);
       }
       this.updatePromptText('*');
-      this.getOutputAreaChildWidget().addClass(OUTPUT_AREA_CHILD_CLASS);
-      this.getOutputAreaOutputWidget().addClass(OUTPUT_AREA_OUTPUT_CLASS);
-      this.getOutputAreaPromptWidget().addClass(OUTPUT_AREA_PROMPT_CLASS);
+      this.setOutputAreaClasses();
     }
+  };
+
+  private setOutputAreaClasses = (): void => {
+    this.getOutputAreaChildWidget().addClass(OUTPUT_AREA_CHILD_CLASS);
+    this.getOutputAreaOutputWidget().addClass(OUTPUT_AREA_OUTPUT_CLASS);
+    this.getOutputAreaPromptWidget().addClass(OUTPUT_AREA_PROMPT_CLASS);
   };
 
   /**


### PR DESCRIPTION
Adds a message before kernel starts on python runner extension
to replace the blank screen. Message says "Waiting for
kernel to start..."
<img width="1268" alt="kernel start" src="https://user-images.githubusercontent.com/6673460/76129950-8eafa980-5fce-11ea-9d99-cbb6844264a1.png">

Fixes #336


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

