### PR TITLE
Add debug logging to metadata service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,9 @@ test-dependencies:
 	@pip install -q -r test_requirements.txt
 
 lint: test-dependencies ## Run linters
-	flake8 elyra
 	yarn run prettier
 	yarn run eslint
+	flake8 elyra
 
 lerna-build: yarn-install
 	export PATH=$$(pwd)/node_modules/.bin:$$PATH && lerna run build

--- a/elyra/__init__.py
+++ b/elyra/__init__.py
@@ -21,7 +21,7 @@ from .metadata.handlers import MetadataHandler, MetadataNamespaceHandler
 from .metadata import MetadataManager
 
 namespace_regex = r"(?P<namespace>[\w\.\-]+)"
-resource_regex = r"(?P<target>[\w\.\-]+)"
+resource_regex = r"(?P<resource>[\w\.\-]+)"
 
 def _jupyter_server_extension_paths():
     return [{

--- a/elyra/metadata/handlers.py
+++ b/elyra/metadata/handlers.py
@@ -29,13 +29,14 @@ class MetadataHandler(APIHandler):
         namespace = url_unescape(namespace)
         metadata_manager = MetadataManager(namespace=namespace)
         try:
+            self.log.debug("MetadataHandler: Fetching all metadata resources from namespace '{}'...".format(namespace))
             metadata = yield maybe_future(metadata_manager.get_all())
         except (ValidationError, KeyError) as err:
             raise web.HTTPError(404, str(err))
         except Exception as ex:
             raise web.HTTPError(500, repr(ex))
 
-        metadata_model = {}
+        metadata_model = dict()
         metadata_model[namespace] = {r.name: r.to_dict() for r in metadata}
         self.set_header("Content-Type", 'application/json')
         self.finish(metadata_model)
@@ -46,13 +47,14 @@ class MetadataNamespaceHandler(APIHandler):
 
     @web.authenticated
     @gen.coroutine
-    def get(self, namespace, target):
+    def get(self, namespace, resource):
         namespace = url_unescape(namespace)
-        target = url_unescape(target)
+        resource = url_unescape(resource)
         metadata_manager = MetadataManager(namespace=namespace)
         try:
-
-            metadata = yield maybe_future(metadata_manager.get(target))
+            self.log.debug("MetadataNamespaceHandler: Fetching metadata resource '{}' from namespace '{}'...".
+                           format(resource, namespace))
+            metadata = yield maybe_future(metadata_manager.get(resource))
         except (ValidationError, KeyError) as err:
             raise web.HTTPError(404, str(err))
         except Exception as ex:

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -127,6 +127,14 @@ def test_manager_add_remove_valid(runtimes_manager, metadata_runtimes_dir):
         assert "schema_name" in valid_add
         assert valid_add['schema_name'] == "test"
 
+    # Attempt to create again w/o replace, then replace it.
+    resource = runtimes_manager.add(metadata_name, metadata, replace=False)
+    assert resource is None
+
+    resource = runtimes_manager.add(metadata_name, metadata)
+    assert resource is not None
+
+    # And finally, remove it.
     resource = runtimes_manager.remove(metadata_name)
 
     assert not os.path.exists(metadata_file)
@@ -141,6 +149,13 @@ def test_manager_remove_invalid(runtimes_manager, metadata_runtimes_dir):
     metadata_file = os.path.join(metadata_runtimes_dir, 'remove_invalid.json')
     assert not os.path.exists(metadata_file)
     assert resource == metadata_file
+
+
+def test_manager_remove_missing(runtimes_manager, metadata_runtimes_dir):
+    # Ensure removal of missing metadata file is handled.
+    metadata_name = 'missing'
+    resource = runtimes_manager.remove(metadata_name)
+    assert resource is None
 
 
 def test_manager_read_valid_by_name(runtimes_manager, metadata_runtimes_dir):

--- a/elyra/metadata/tests/test_runtime_app.py
+++ b/elyra/metadata/tests/test_runtime_app.py
@@ -273,7 +273,8 @@ def test_remove_help_all(script_runner):
 def test_remove_missing(script_runner):
     ret = script_runner.run('jupyter-runtimes', 'remove', '--name=missing')
     assert ret.success
-    assert ret.stderr == "[RemoveRuntime] WARNING | Metadata 'missing' in namespace 'runtimes' was not found!\n"
+    assert ret.stderr == "[RemoveRuntime] WARNING | Metadata resource 'missing' in namespace " \
+                         "'runtimes' was not found!\n"
 
 
 def test_remove_runtime(script_runner, mock_runtime_dir):


### PR DESCRIPTION
Added logging in various places throughout the metadata and handlers.

Made some minor improvements for maintainability along the way.
Switched order of linters so that `flake8` follows the others.  Since the others auto-correct, I felt it important to have the `flake8` issues presented last.

Fixes #335
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

