### PR TITLE
Make python-runner toc dependancy optional

### DIFF
--- a/packages/python-runner/src/index.ts
+++ b/packages/python-runner/src/index.ts
@@ -62,20 +62,19 @@ const extension: JupyterFrontEndPlugin<void> = {
     IEditorServices,
     ICommandPalette,
     ISettingRegistry,
-    IFileBrowserFactory,
-    ITableOfContentsRegistry
+    IFileBrowserFactory
   ],
-  optional: [ILayoutRestorer, IMainMenu, ILauncher],
+  optional: [ILayoutRestorer, IMainMenu, ILauncher, ITableOfContentsRegistry],
   activate: (
     app: JupyterFrontEnd,
     editorServices: IEditorServices,
     palette: ICommandPalette,
     settingRegistry: ISettingRegistry,
     browserFactory: IFileBrowserFactory,
-    tocRegistry: ITableOfContentsRegistry,
     restorer: ILayoutRestorer | null,
     menu: IMainMenu | null,
-    launcher: ILauncher | null
+    launcher: ILauncher | null,
+    tocRegistry: ITableOfContentsRegistry | null
   ) => {
     console.log('Elyra - python-runner extension is activated!');
 
@@ -97,10 +96,12 @@ const extension: JupyterFrontEndPlugin<void> = {
       namespace: PYTHON_EDITOR_NAMESPACE
     });
 
-    const pythonGenerator = createPythonGenerator(tracker);
-    tocRegistry.add(
-      (pythonGenerator as unknown) as TableOfContentsRegistry.IGenerator
-    );
+    if (tocRegistry) {
+      const pythonGenerator = createPythonGenerator(tracker);
+      tocRegistry.add(
+        (pythonGenerator as unknown) as TableOfContentsRegistry.IGenerator
+      );
+    }
 
     let config: CodeEditor.IConfig = { ...CodeEditor.defaultConfig };
 


### PR DESCRIPTION
Currently python-runner doesn't work without toc installed

Fixes #352 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

