### PR TITLE
Make sure nbdime is version compatable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup_args = dict(
         "kfp-server-api==0.1.18.3",
         "minio>=5.0.7",
         'jupyterlab>=1.0.0,<2.0.0',
+        'nbdime>=1.0.0,<2.0.0',
         'jupyterlab-git',
         'nbconvert>=5.6.1',
         'notebook>=6.0.3',


### PR DESCRIPTION
Currently nbdime defaults to 2.0.0 which is not compatible with lab 1.X

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

