### PR TITLE
Pin to typescript-eslint 2.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     }
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.14.0",
-    "@typescript-eslint/parser": "^2.14.0",
+    "@typescript-eslint/eslint-plugin": "~2.23.0",
+    "@typescript-eslint/parser": "~2.23.0",
     "eslint": "^6.5.0",
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-header": "^3.0.0",


### PR DESCRIPTION
Today's release of typescript-eslint 2.24.0
is breaking the lint phase of the build with
"Parsing error: Cannot read property 'name' of
undefined"

Fixes #367
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

