### PR TITLE
Add missing eslint support for js files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     ]
   },
   "scripts": {
-    "eslint": "eslint . --fix --ignore-path .gitignore --ext .ts,.tsx",
-    "eslint:check": "eslint . --ignore-path .gitignore --ext .ts,.tsx",
+    "eslint": "eslint . --fix --ignore-path .gitignore --ext .ts,.tsx,.js",
+    "eslint:check": "eslint . --ignore-path .gitignore --ext .ts,.tsx,.js",
     "prettier": "prettier --ignore-path .gitignore --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json}\"",
     "prettier:check": "prettier --ignore-path .gitignore --check \"**/*{.ts,.tsx,.js,.jsx,.css,.json}\""
   },

--- a/packages/pipeline-editor/webpack.config.js
+++ b/packages/pipeline-editor/webpack.config.js
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018-2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* global module, path, __dirname */
 module.exports = {
   entry: './src/index.tsx',
   output: {


### PR DESCRIPTION
eslint was specifically running on ts and tsx files and thus not on js files
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

