### PR TITLE
Add auto-scrolling to follow output in python runner

### DIFF
--- a/packages/python-runner/package.json
+++ b/packages/python-runner/package.json
@@ -37,6 +37,7 @@
     "@jupyterlab/docregistry": "^1.0.0",
     "@jupyterlab/fileeditor": "^1.0.0",
     "@jupyterlab/launcher": "^1.0.0",
+    "@jupyterlab/logconsole": "^1.0.0",
     "@jupyterlab/mainmenu": "^1.0.0",
     "@jupyterlab/outputarea": "^1.0.0",
     "@jupyterlab/toc": "^2.0.0",

--- a/packages/python-runner/src/widget.tsx
+++ b/packages/python-runner/src/widget.tsx
@@ -203,6 +203,25 @@ export class PythonFileEditor extends DocumentWidget<
     this.displayOutput(output);
   };
 
+  private createScrollButtons = (
+    scrollingWidget: ScrollingWidget<OutputArea>
+  ): void => {
+    const scrollUpButton = document.createElement('button');
+    const scrollDownButton = document.createElement('button');
+    scrollUpButton.className = 'elyra-PythonEditor-scrollTop';
+    scrollUpButton.innerHTML = '&uarr;';
+    scrollDownButton.className = 'elyra-PythonEditor-scrollBottom';
+    scrollDownButton.innerHTML = '&darr;';
+    scrollUpButton.onclick = function(): void {
+      scrollingWidget.node.scrollTop = 0;
+    };
+    scrollDownButton.onclick = function(): void {
+      scrollingWidget.node.scrollTop = scrollingWidget.node.scrollHeight;
+    };
+    this.dockPanel.node.appendChild(scrollUpButton);
+    this.dockPanel.node.appendChild(scrollDownButton);
+  };
+
   /**
    * Function: Displays output area widget.
    */
@@ -214,24 +233,10 @@ export class PythonFileEditor extends DocumentWidget<
 
     if (this.dockPanel.isEmpty) {
       // Add a tab to dockPanel
-      const scrollingWidget = new ScrollingWidget({
+      this.scrollingWidget = new ScrollingWidget({
         content: this.outputAreaWidget
       });
-      this.scrollingWidget = scrollingWidget;
-      const scrollUpButton = document.createElement('button');
-      const scrollDownButton = document.createElement('button');
-      scrollUpButton.className = 'elyra-PythonEditor-scrollTop';
-      scrollUpButton.innerHTML = '↑';
-      scrollDownButton.className = 'elyra-PythonEditor-scrollBottom';
-      scrollDownButton.innerHTML = '↓';
-      scrollUpButton.onclick = function() {
-        scrollingWidget.node.scrollTop = 0;
-      };
-      scrollDownButton.onclick = function() {
-        scrollingWidget.node.scrollTop = scrollingWidget.node.scrollHeight;
-      };
-      this.dockPanel.node.appendChild(scrollUpButton);
-      this.dockPanel.node.appendChild(scrollDownButton);
+      this.createScrollButtons(this.scrollingWidget);
       this.dockPanel.addWidget(this.scrollingWidget, { mode: 'split-bottom' });
 
       const outputTab: TabBar<Widget> = this.dockPanel.tabBars().next();

--- a/packages/python-runner/src/widget.tsx
+++ b/packages/python-runner/src/widget.tsx
@@ -37,6 +37,7 @@ import {
   OutputAreaModel,
   OutputPrompt
 } from '@jupyterlab/outputarea';
+import { ScrollingWidget } from '@jupyterlab/logconsole';
 import {
   RenderMimeRegistry,
   standardRendererFactories as initialFactories
@@ -77,6 +78,7 @@ export class PythonFileEditor extends DocumentWidget<
   private kernelSettings: Kernel.IOptions;
   private dockPanel: DockPanel;
   private outputAreaWidget: OutputArea;
+  private scrollingWidget: ScrollingWidget<OutputArea>;
   private model: any;
   private emptyOutput: boolean;
 
@@ -212,7 +214,10 @@ export class PythonFileEditor extends DocumentWidget<
 
     if (this.dockPanel.isEmpty) {
       // Add a tab to dockPanel
-      this.dockPanel.addWidget(this.outputAreaWidget, { mode: 'split-bottom' });
+      this.scrollingWidget = new ScrollingWidget({
+        content: this.outputAreaWidget
+      });
+      this.dockPanel.addWidget(this.scrollingWidget, { mode: 'split-bottom' });
 
       const outputTab: TabBar<Widget> = this.dockPanel.tabBars().next();
       outputTab.id = 'tab-python-editor-output';

--- a/packages/python-runner/src/widget.tsx
+++ b/packages/python-runner/src/widget.tsx
@@ -214,9 +214,24 @@ export class PythonFileEditor extends DocumentWidget<
 
     if (this.dockPanel.isEmpty) {
       // Add a tab to dockPanel
-      this.scrollingWidget = new ScrollingWidget({
+      const scrollingWidget = new ScrollingWidget({
         content: this.outputAreaWidget
       });
+      this.scrollingWidget = scrollingWidget;
+      const scrollUpButton = document.createElement('button');
+      const scrollDownButton = document.createElement('button');
+      scrollUpButton.className = 'elyra-PythonEditor-scrollTop';
+      scrollUpButton.innerHTML = '↑';
+      scrollDownButton.className = 'elyra-PythonEditor-scrollBottom';
+      scrollDownButton.innerHTML = '↓';
+      scrollUpButton.onclick = function() {
+        scrollingWidget.node.scrollTop = 0;
+      };
+      scrollDownButton.onclick = function() {
+        scrollingWidget.node.scrollTop = scrollingWidget.node.scrollHeight;
+      };
+      this.dockPanel.node.appendChild(scrollUpButton);
+      this.dockPanel.node.appendChild(scrollDownButton);
       this.dockPanel.addWidget(this.scrollingWidget, { mode: 'split-bottom' });
 
       const outputTab: TabBar<Widget> = this.dockPanel.tabBars().next();

--- a/packages/python-runner/style/index.css
+++ b/packages/python-runner/style/index.css
@@ -38,17 +38,31 @@
 .elyra-PythonEditor-scrollTop {
   position: absolute;
   top: 30px;
-  right: 10px;
+  right: 40px;
   z-index: 1;
   font-size: 20px;
-  border-radius: 0px 10px 10px 0px;
+  border-radius: 10px 0px 0px 10px;
+  background-color: #e3e3e3;
+  width: 30px;
+  height: 30px;
+  font: var(--jp-cell-prompt-font-family);
+  border-color: #a3a3a3;
+  border-width: 1px;
+  border-style: solid;
 }
 
 .elyra-PythonEditor-scrollBottom {
   position: absolute;
   top: 30px;
-  right: 40px;
+  right: 10px;
   z-index: 1;
   font-size: 20px;
-  border-radius: 10px 0px 0px 10px;
+  border-radius: 0px 10px 10px 0px;
+  background-color: #e3e3e3;
+  width: 30px;
+  height: 30px;
+  font: var(--jp-cell-prompt-font-family);
+  border-color: #a3a3a3;
+  border-width: 1px;
+  border-style: solid;
 }

--- a/packages/python-runner/style/index.css
+++ b/packages/python-runner/style/index.css
@@ -34,3 +34,21 @@
   padding: var(--jp-code-padding);
   border: var(--jp-border-width) solid transparent;
 }
+
+.elyra-PythonEditor-scrollTop {
+  position: absolute;
+  top: 30px;
+  right: 10px;
+  z-index: 1;
+  font-size: 20px;
+  border-radius: 0px 10px 10px 0px;
+}
+
+.elyra-PythonEditor-scrollBottom {
+  position: absolute;
+  top: 30px;
+  right: 40px;
+  z-index: 1;
+  font-size: 20px;
+  border-radius: 10px 0px 0px 10px;
+}


### PR DESCRIPTION
Uses the ScrollingWidget class from jupyterlab/logconsole package
to enable automatic scrolling when new output appears in python
runner. 

Fixes #82. 
Fixes #355.


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

