### PR TITLE
Update JupyterLab Git extension to version 0.9.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ npm-packages: lerna-build
 	$(call PACKAGE_LAB_EXTENSION,notebook-scheduler)
 	$(call PACKAGE_LAB_EXTENSION,pipeline-editor)
 	$(call PACKAGE_LAB_EXTENSION,python-runner)
-	cd dist && curl -o jupyterlab-git-0.9.0.tgz $$(npm view @jupyterlab/git@0.9.0 dist.tarball) && cd -
+	cd dist && curl -o jupyterlab-git-0.9.1.tgz $$(npm view @jupyterlab/git@0.9.1 dist.tarball) && cd -
 	cd dist && curl -o jupyterlab-toc-2.0.0.tgz $$(npm view @jupyterlab/toc@2.0.0 dist.tarball) && cd -
 
 bdist: npm-packages


### PR DESCRIPTION
The 0.9.1 release pin the nbdime dependency to the
version that supports JupyterLab 1.x.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

