### PR TITLE
Declare mixins first, move mixin to shared file

### DIFF
--- a/elyra/metadata/mixins.py
+++ b/elyra/metadata/mixins.py
@@ -1,0 +1,29 @@
+#
+# Copyright 2018-2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+class AppUtilMixin(object):
+
+    def _log_and_exit(self, msg, exit_status=1, display_help=False):
+        self.log.error(msg)
+        if display_help:
+            print()
+            self.print_help()
+        self.exit(exit_status)
+
+    def _confirm_required(self, name, value):
+        if value is None or len(value) == 0:
+            self._log_and_exit("'{}' is a required parameter.".format(name), display_help=True)

--- a/elyra/metadata/mixins.py
+++ b/elyra/metadata/mixins.py
@@ -17,13 +17,13 @@
 
 class AppUtilMixin(object):
 
-    def _log_and_exit(self, msg, exit_status=1, display_help=False):
+    def log_and_exit(self, msg, exit_status=1, display_help=False):
         self.log.error(msg)
         if display_help:
             print()
             self.print_help()
         self.exit(exit_status)
 
-    def _confirm_required(self, name, value):
+    def confirm_required(self, name, value):
         if value is None or len(value) == 0:
-            self._log_and_exit("'{}' is a required parameter.".format(name), display_help=True)
+            self.log_and_exit("'{}' is a required parameter.".format(name), display_help=True)

--- a/elyra/metadata/runtime.py
+++ b/elyra/metadata/runtime.py
@@ -15,6 +15,7 @@
 #
 
 from .metadata import Metadata, MetadataManager
+from .mixins import AppUtilMixin
 
 from traitlets.config.application import Application
 from jupyter_core.application import base_flags
@@ -29,21 +30,7 @@ class Runtime(Metadata):
     namespace = 'runtimes'
 
 
-class AppUtilMixin(object):
-
-    def _log_and_exit(self, msg, exit_status=1, display_help=False):
-        self.log.error(msg)
-        if display_help:
-            print()
-            self.print_help()
-        self.exit(exit_status)
-
-    def _confirm_required(self, name, value):
-        if value is None or len(value) == 0:
-            self._log_and_exit("'{}' is a required parameter.".format(name), display_help=True)
-
-
-class ListRuntimes(Application, AppUtilMixin):
+class ListRuntimes(AppUtilMixin, Application):
     version = __version__
     description = """List installed external runtime metadata."""
 
@@ -97,7 +84,7 @@ class ListRuntimes(Application, AppUtilMixin):
                                         invalid))
 
 
-class RemoveRuntime(Application, AppUtilMixin):
+class RemoveRuntime(AppUtilMixin, Application):
     version = __version__
     description = """Remove external runtime metadata."""
 
@@ -124,7 +111,7 @@ class RemoveRuntime(Application, AppUtilMixin):
         self._confirm_required("name", self.name)
 
 
-class Kfp(Application, AppUtilMixin):
+class Kfp(AppUtilMixin, Application):
     version = __version__
     description = """Install runtime metadata for Kubeflow pipelines."""
 
@@ -215,7 +202,7 @@ class Kfp(Application, AppUtilMixin):
         self._confirm_required("cos_bucket", self.cos_bucket)
 
 
-class Airflow(Application, AppUtilMixin):
+class Airflow(AppUtilMixin, Application):
     version = __version__
     description = """Install runtime metadata for Airflow pipelines."""
     flags = {}

--- a/elyra/metadata/runtime.py
+++ b/elyra/metadata/runtime.py
@@ -108,7 +108,7 @@ class RemoveRuntime(AppUtilMixin, Application):
         self.metadata_manager.remove(self.name)
 
     def _validate_parameters(self):
-        self._confirm_required("name", self.name)
+        self.confirm_required("name", self.name)
 
 
 class Kfp(AppUtilMixin, Application):
@@ -186,20 +186,20 @@ class Kfp(AppUtilMixin, Application):
             print("Metadata for {} runtime '{}' has been written to: {}".format(self.schema_name, self.name, resource))
         else:
             if ex_msg:
-                self._log_and_exit("The following exception occurred while saving metadata '{}' for {} runtime: {}"
-                                   .format(self.name, self.schema_name, ex_msg), display_help=True)
+                self.log_and_exit("The following exception occurred while saving metadata '{}' for {} runtime: {}"
+                                  .format(self.name, self.schema_name, ex_msg), display_help=True)
             else:
-                self._log_and_exit("A failure occurred while saving metadata '{}' for {} runtime.  Check log output."
-                                   .format(self.name, self.schema_name), display_help=True)
+                self.log_and_exit("A failure occurred while saving metadata '{}' for {} runtime.  Check log output."
+                                  .format(self.name, self.schema_name), display_help=True)
 
     def _validate_parameters(self):
-        self._confirm_required("name", self.name)
-        self._confirm_required("display_name", self.display_name)
-        self._confirm_required("api_endpoint", self.api_endpoint)
-        self._confirm_required("cos_endpoint", self.cos_endpoint)
-        self._confirm_required("cos_username", self.cos_username)
-        self._confirm_required("cos_password", self.cos_password)
-        self._confirm_required("cos_bucket", self.cos_bucket)
+        self.confirm_required("name", self.name)
+        self.confirm_required("display_name", self.display_name)
+        self.confirm_required("api_endpoint", self.api_endpoint)
+        self.confirm_required("cos_endpoint", self.cos_endpoint)
+        self.confirm_required("cos_username", self.cos_username)
+        self.confirm_required("cos_password", self.cos_password)
+        self.confirm_required("cos_bucket", self.cos_bucket)
 
 
 class Airflow(AppUtilMixin, Application):
@@ -221,7 +221,7 @@ class Airflow(AppUtilMixin, Application):
     }
 
     def start(self):
-        self._log_and_exit("Support for airflow pipelines is not implemented at this time.")
+        self.log_and_exit("Support for airflow pipelines is not implemented at this time.")
 
 
 class InstallRuntime(Application):


### PR DESCRIPTION
Mixins should be listed in class definition lists prior to the superclass.  Since other components may also need mixins, they have been moved to a new file.

The wrong mixin order was realized while reviewing #241.  That's where I noticed `AppUtilMixin` was getting duplicated as well, thus its move into `mixins.py`.


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

