### PR TITLE
Fix python editor interupted run bug

### DIFF
--- a/packages/python-runner/src/widget.tsx
+++ b/packages/python-runner/src/widget.tsx
@@ -179,6 +179,7 @@ export class PythonFileEditor extends DocumentWidget<
    * Function: Clears existing output area.
    */
   private resetOutputArea = (): void => {
+    this.runner.shutDownKernel();
     // TODO: hide this.layout(), or set its height to 0
     this.dockPanel.hide();
     this.outputAreaWidget.model.clear();
@@ -241,18 +242,19 @@ export class PythonFileEditor extends DocumentWidget<
       outputTab.id = 'tab-python-editor-output';
       outputTab.currentTitle.label = 'Python Console Output';
       outputTab.currentTitle.closable = true;
-      const options = {
-        name: 'stdout',
-        output_type: 'stream',
-        text: ['Waiting for kernel to start...']
-      };
-      this.outputAreaWidget.model.add(options);
-      this.updatePromptText(' ');
-      this.setOutputAreaClasses();
       outputTab.disposed.connect((sender, args) => {
         this.resetOutputArea();
       }, this);
     }
+
+    const options = {
+      name: 'stdout',
+      output_type: 'stream',
+      text: ['Waiting for kernel to start...']
+    };
+    this.outputAreaWidget.model.add(options);
+    this.updatePromptText(' ');
+    this.setOutputAreaClasses();
   };
 
   /**


### PR DESCRIPTION
Current there is a multi-faceted bug in the python runner:
- The `Waiting for kernel to start...` prompt doesn't display when the
output tab is already open
- Closing the output tab mid-run pasues the run rather than stop it,
meaning when the user next clicks run it continues the previous run
instead of starting a new one
- The `Waiting for kernel to start...` prompt in displayed and not
cleared in this "continued" state
- clicking stop while the tab is closed "fixes" the above issues.

The solution is:
- Always stop the run before clearing the output (ie closing tab or
clicking run again mid-run)
- Display the The `Waiting for kernel to start...` prompt every time
the `displayOutputArea` is called, not just on initalization



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

