### PR TITLE
Add error dialog when no runtimes found

### DIFF
--- a/packages/application/src/submission.tsx
+++ b/packages/application/src/submission.tsx
@@ -68,7 +68,7 @@ export class SubmissionHandler {
 
   static noMetadataError(metadataName: string): Promise<Dialog.IResult<any>> {
     return showDialog({
-      title: 'Error retrieving metadata',
+      title: 'Could not submit',
       body: <p>No {metadataName} metadata has been configured.</p>,
       buttons: [Dialog.okButton()]
     });

--- a/packages/application/src/submission.tsx
+++ b/packages/application/src/submission.tsx
@@ -66,6 +66,14 @@ export class SubmissionHandler {
     });
   }
 
+  static noMetadataError(metadataName: string): Promise<Dialog.IResult<any>> {
+    return showDialog({
+      title: 'Error retrieving ' + metadataName,
+      body: <p>No {metadataName} metadata has been configured</p>,
+      buttons: [Dialog.okButton()]
+    });
+  }
+
   static makeGetRequest(
     requestExt: string,
     submissionType: string,

--- a/packages/application/src/submission.tsx
+++ b/packages/application/src/submission.tsx
@@ -68,8 +68,8 @@ export class SubmissionHandler {
 
   static noMetadataError(metadataName: string): Promise<Dialog.IResult<any>> {
     return showDialog({
-      title: 'Error retrieving ' + metadataName,
-      body: <p>No {metadataName} metadata has been configured</p>,
+      title: 'Error retrieving metadata',
+      body: <p>No {metadataName} metadata has been configured.</p>,
       buttons: [Dialog.okButton()]
     });
   }

--- a/packages/notebook-scheduler/src/SubmitNotebook.ts
+++ b/packages/notebook-scheduler/src/SubmitNotebook.ts
@@ -81,7 +81,11 @@ export class SubmitNotebookButtonExtension
     SubmissionHandler.makeGetRequest(
       'api/metadata/runtimes',
       'pipeline',
-      (response: any) =>
+      (response: any) => {
+        if (Object.keys(response.runtimes).length === 0) {
+          return SubmissionHandler.noMetadataError('runtimes');
+        }
+
         showDialog({
           title: 'Submit notebook',
           body: new SubmitNotebook(envVars, response.runtimes),
@@ -104,7 +108,8 @@ export class SubmitNotebookButtonExtension
             result.value.runtime_config,
             'notebook'
           );
-        })
+        });
+      }
     );
   };
 

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -425,7 +425,11 @@ export class PipelineEditor extends React.Component<
     SubmissionHandler.makeGetRequest(
       'api/metadata/runtimes',
       'pipeline',
-      (response: any) =>
+      (response: any) => {
+        if (Object.keys(response.runtimes).length === 0) {
+          return SubmissionHandler.noMetadataError('runtimes');
+        }
+
         showDialog({
           title: 'Run pipeline',
           body: new PipelineSubmissionDialog({ runtimes: response.runtimes }),
@@ -451,7 +455,8 @@ export class PipelineEditor extends React.Component<
             result.value.runtime_config,
             'pipeline'
           );
-        })
+        });
+      }
     );
   }
 


### PR DESCRIPTION
Currently when no runtimes are configured the submission forms
display and empty dropdown, which would eventually cause a backend
error upon submission.

This adds a check and error dialog in that case.

This will be further improved upon with the implementation of #271

Fixes #393



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

