### PR TITLE
Add lock to kernel startup

### DIFF
--- a/packages/python-runner/src/widget.tsx
+++ b/packages/python-runner/src/widget.tsx
@@ -61,6 +61,7 @@ const OUTPUT_AREA_ERROR_CLASS = 'elyra-PythonEditor-OutputArea-error';
 const OUTPUT_AREA_CHILD_CLASS = 'elyra-PythonEditor-OutputArea-child';
 const OUTPUT_AREA_OUTPUT_CLASS = 'elyra-PythonEditor-OutputArea-output';
 const OUTPUT_AREA_PROMPT_CLASS = 'elyra-PythonEditor-OutputArea-prompt';
+const RUN_BUTTON_CLASS = 'elyra-PythonEditor-Run';
 const RUN_ICON_CLASS = 'jp-RunIcon';
 const STOP_ICON_CLASS = 'jp-StopIcon';
 const DROPDOWN_CLASS = 'jp-Notebook-toolbarCellTypeDropdown bp3-minimal';
@@ -91,7 +92,7 @@ export class PythonFileEditor extends DocumentWidget<
     super(options);
     this.addClass(PYTHON_FILE_EDITOR_CLASS);
     this.model = this.content.model;
-    this.runner = new PythonRunner(this.model);
+    this.runner = new PythonRunner(this.model, this.id);
     this.kernelSettings = { name: null };
     this.emptyOutput = true;
 
@@ -111,6 +112,7 @@ export class PythonFileEditor extends DocumentWidget<
     );
 
     const runButton = new ToolbarButton({
+      className: RUN_BUTTON_CLASS,
       iconClassName: RUN_ICON_CLASS,
       onClick: this.runPython,
       tooltip: 'Run'

--- a/packages/python-runner/src/widget.tsx
+++ b/packages/python-runner/src/widget.tsx
@@ -118,7 +118,6 @@ export class PythonFileEditor extends DocumentWidget<
       iconClassName: RUN_ICON_CLASS,
       onClick: this.runPython,
       tooltip: 'Run'
-      // enabled: false
     });
 
     const stopButton = new ToolbarButton({


### PR DESCRIPTION
Currently if you try to start a new run while the kernel is starting
it wint stop the previous run and the two runs output will be spliced

This adds a "lock" around starting the kernel, the lock prevents
users from starting a new run by both disabling both the run button
and the `runPython()` function if statement.

Fixes #394
Fixes #398


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

