### PR TITLE
added minor fix to read secure flag from params instead of constant

### DIFF
--- a/elyra/util/cos.py
+++ b/elyra/util/cos.py
@@ -48,7 +48,7 @@ class CosClient(LoggingConfigurable):
         self.client = Minio(endpoint=self.endpoint.netloc,
                             access_key=self.access_key,
                             secret_key=self.secret_key,
-                            secure=False)
+                            secure=self.secure)
 
         # Make a bucket with the make_bucket API call.
         try:


### PR DESCRIPTION

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

