### PR TITLE
Add order-imports support for lint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,12 @@
         " * limitations under the License.",
         " "
       ]
+    ],
+    "import/order": [
+      "error",
+      {
+        "newlines-between": "always"
+      }
     ]
   },
   "overrides": [
@@ -51,7 +57,7 @@
     }
   ],
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "header"],
+  "plugins": ["@typescript-eslint", "header", "import"],
   "settings": {
     "react": {
       "version": "detect"

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,7 @@
 {
+  "**/*{.ts,.tsx}": [
+    "organize-imports-cli",
+  ],
   "**/*{.ts,.tsx,.js,.jsx,.css,.json}": [
     "prettier --write",
     "git add"

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,7 +1,4 @@
 {
-  "**/*{.ts,.tsx}": [
-    "organize-imports-cli",
-  ],
   "**/*{.ts,.tsx,.js,.jsx,.css,.json}": [
     "prettier --write",
     "git add"

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ lint-server: test-dependencies
 	flake8 elyra
 
 lint-ui:
+	export PATH=$$(pwd)/node_modules/.bin:$$PATH && lerna run organize-imports
 	yarn run prettier
 	yarn run eslint
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint": "^6.5.0",
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-header": "^3.0.0",
+    "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-react": "^7.18.3",
     "husky": "^2.3.0",
     "lerna": "^3.16.4",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "husky": "^2.3.0",
     "lerna": "^3.16.4",
     "lint-staged": "^9.5.0",
+    "organize-imports-cli": "^0.7.0",
     "prettier": "^1.19.1",
     "rimraf": "^2.6.3",
     "start-server-and-test": "1.7.9",

--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -26,10 +26,12 @@
     "build": "tsc",
     "dist": "npm pack .",
     "clean": "rimraf lib && rimraf node_modules && rimraf yarn.lock && rimraf yarn-error.log && rimraf tsconfig.tsbuildinfo",
+    "organize-imports": "organize-imports-cli tsconfig.json",
     "prepare": "npm run clean && npm run build",
     "watch": "tsc -w"
   },
   "devDependencies": {
+    "organize-imports-cli": "^0.7.0",
     "rimraf": "^2.6.3",
     "typescript": "~3.5.2"
   },

--- a/packages/application/src/submission.tsx
+++ b/packages/application/src/submission.tsx
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { showDialog, Dialog } from '@jupyterlab/apputils';
+import { Dialog, showDialog } from '@jupyterlab/apputils';
 import { URLExt } from '@jupyterlab/coreutils';
 import { ServerConnection } from '@jupyterlab/services';
-
 import * as React from 'react';
 
 const MESSAGE_DISPLAY = 'elyra-pipelineSubmission-messageDisplay';

--- a/packages/notebook-scheduler/package.json
+++ b/packages/notebook-scheduler/package.json
@@ -27,6 +27,7 @@
     "build": "tsc",
     "dist": "npm pack .",
     "clean": "rimraf lib && rimraf node_modules && rimraf yarn.lock && rimraf yarn-error.log && rimraf tsconfig.tsbuildinfo",
+    "organize-imports": "organize-imports-cli tsconfig.json",
     "prepare": "npm run clean && npm run build",
     "watch": "tsc -w"
   },
@@ -43,6 +44,7 @@
     "uuid": "^3.4.0"
   },
   "devDependencies": {
+    "organize-imports-cli": "^0.7.0",
     "rimraf": "^2.6.3",
     "typescript": "~3.5.2"
   },

--- a/packages/notebook-scheduler/src/SubmitNotebook.ts
+++ b/packages/notebook-scheduler/src/SubmitNotebook.ts
@@ -13,20 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Dialog, showDialog, ToolbarButton } from '@jupyterlab/apputils';
-import { DocumentRegistry } from '@jupyterlab/docregistry';
-import { INotebookModel, NotebookPanel } from '@jupyterlab/notebook';
-import { JupyterFrontEnd } from '@jupyterlab/application';
-import { JSONObject, JSONValue } from '@phosphor/coreutils';
-import { Widget } from '@phosphor/widgets';
-import { IDisposable } from '@phosphor/disposable';
-
 import {
   FrontendServices,
   NotebookParser,
   SubmissionHandler
 } from '@elyra/application';
-
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { Dialog, showDialog, ToolbarButton } from '@jupyterlab/apputils';
+import { DocumentRegistry } from '@jupyterlab/docregistry';
+import { INotebookModel, NotebookPanel } from '@jupyterlab/notebook';
+import { JSONObject, JSONValue } from '@phosphor/coreutils';
+import { IDisposable } from '@phosphor/disposable';
+import { Widget } from '@phosphor/widgets';
 import Utils from './utils';
 
 /**

--- a/packages/notebook-scheduler/src/SubmitNotebook.ts
+++ b/packages/notebook-scheduler/src/SubmitNotebook.ts
@@ -25,6 +25,7 @@ import { INotebookModel, NotebookPanel } from '@jupyterlab/notebook';
 import { JSONObject, JSONValue } from '@phosphor/coreutils';
 import { IDisposable } from '@phosphor/disposable';
 import { Widget } from '@phosphor/widgets';
+
 import Utils from './utils';
 
 /**

--- a/packages/notebook-scheduler/src/index.tsx
+++ b/packages/notebook-scheduler/src/index.tsx
@@ -19,10 +19,8 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import { ICommandPalette } from '@jupyterlab/apputils';
-
-import { SubmitNotebookButtonExtension } from './SubmitNotebook';
-
 import '../style/index.css';
+import { SubmitNotebookButtonExtension } from './SubmitNotebook';
 
 const NOTEBOOK_SCHEDULER_NAMESPACE = 'elyra-notebook_scheduler_extension';
 

--- a/packages/notebook-scheduler/src/index.tsx
+++ b/packages/notebook-scheduler/src/index.tsx
@@ -19,6 +19,7 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import { ICommandPalette } from '@jupyterlab/apputils';
+
 import '../style/index.css';
 import { SubmitNotebookButtonExtension } from './SubmitNotebook';
 

--- a/packages/notebook-scheduler/src/utils.ts
+++ b/packages/notebook-scheduler/src/utils.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import uuid4 from 'uuid/v4';
+
 import pipeline_template from './pipeline-template.json';
 import { ISubmitNotebookOptions } from './SubmitNotebook';
 

--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -27,6 +27,7 @@
     "build": "tsc",
     "dist": "npm pack .",
     "clean": "rimraf lib && rimraf node_modules && rimraf yarn.lock && rimraf yarn-error.log && rimraf tsconfig.tsbuildinfo",
+    "organize-imports": "organize-imports-cli tsconfig.json",
     "prepare": "npm run clean && npm run build ",
     "watch": "tsc -w"
   },
@@ -59,6 +60,7 @@
     "@types/react": "^16.8.23",
     "@types/react-dom": "^16.8.5",
     "@types/react-intl": "^2.3.0",
+    "organize-imports-cli": "^0.7.0",
     "rimraf": "^2.6.3",
     "source-map-loader": "^0.2.4",
     "ts-loader": "^6.2.1",

--- a/packages/pipeline-editor/src/index.tsx
+++ b/packages/pipeline-editor/src/index.tsx
@@ -53,6 +53,7 @@ import { PanelLayout, Widget } from '@phosphor/widgets';
 import 'carbon-components/css/carbon-components.min.css';
 import * as React from 'react';
 import { IntlProvider } from 'react-intl';
+
 import '../style/index.css';
 import * as i18nData from './en.json';
 import * as palette from './palette.json';

--- a/packages/pipeline-editor/src/index.tsx
+++ b/packages/pipeline-editor/src/index.tsx
@@ -15,20 +15,31 @@
  */
 
 import {
+  FrontendServices,
+  NotebookParser,
+  SubmissionHandler
+} from '@elyra/application';
+import {
+  CanvasController,
+  CommonCanvas,
+  CommonProperties
+} from '@elyra/canvas';
+import '@elyra/canvas/dist/common-canvas.min.css';
+import {
+  ILayoutRestorer,
   JupyterFrontEnd,
-  JupyterFrontEndPlugin,
-  ILayoutRestorer
+  JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import {
-  ICommandPalette,
-  showDialog,
   Dialog,
+  ICommandPalette,
   ReactWidget,
+  showDialog,
   WidgetTracker
 } from '@jupyterlab/apputils';
 import {
-  DocumentRegistry,
   ABCWidgetFactory,
+  DocumentRegistry,
   DocumentWidget
 } from '@jupyterlab/docregistry';
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
@@ -36,31 +47,16 @@ import { ILauncher } from '@jupyterlab/launcher';
 import { IMainMenu } from '@jupyterlab/mainmenu';
 import { NotebookPanel } from '@jupyterlab/notebook';
 import { IconRegistry, IIconRegistry } from '@jupyterlab/ui-components';
-
 import { toArray } from '@phosphor/algorithm';
 import { IDragEvent } from '@phosphor/dragdrop';
-import { Widget, PanelLayout } from '@phosphor/widgets';
-
-import {
-  CommonCanvas,
-  CanvasController,
-  CommonProperties
-} from '@elyra/canvas';
-import '@elyra/canvas/dist/common-canvas.min.css';
-import {
-  FrontendServices,
-  NotebookParser,
-  SubmissionHandler
-} from '@elyra/application';
+import { PanelLayout, Widget } from '@phosphor/widgets';
 import 'carbon-components/css/carbon-components.min.css';
+import * as React from 'react';
+import { IntlProvider } from 'react-intl';
 import '../style/index.css';
-
+import * as i18nData from './en.json';
 import * as palette from './palette.json';
 import * as properties from './properties.json';
-import * as i18nData from './en.json';
-import * as React from 'react';
-
-import { IntlProvider } from 'react-intl';
 
 const PIPELINE_ICON_CLASS = 'jp-MaterialIcon elyra-PipelineIcon';
 const PIPELINE_CLASS = 'elyra-PipelineEditor';

--- a/packages/python-runner/package.json
+++ b/packages/python-runner/package.json
@@ -27,6 +27,7 @@
     "build": "tsc",
     "dist": "npm pack .",
     "clean": "rimraf lib && rimraf node_modules && rimraf yarn.lock && rimraf yarn-error.log && rimraf tsconfig.tsbuildinfo",
+    "organize-imports": "organize-imports-cli tsconfig.json",
     "prepare": "npm run clean && npm run build",
     "watch": "tsc -w"
   },
@@ -45,6 +46,7 @@
     "@phosphor/widgets": "^1.8.0"
   },
   "devDependencies": {
+    "organize-imports-cli": "^0.7.0",
     "rimraf": "^2.6.3",
     "typescript": "~3.5.2"
   },

--- a/packages/python-runner/src/PythonRunner.ts
+++ b/packages/python-runner/src/PythonRunner.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { Kernel } from '@jupyterlab/services';
-import { CodeEditor } from '@jupyterlab/codeeditor';
 import { Dialog, showDialog } from '@jupyterlab/apputils';
+import { CodeEditor } from '@jupyterlab/codeeditor';
+import { Kernel } from '@jupyterlab/services';
 
 /**
  * Class: An enhanced Python Script Editor that enables developing and running the script

--- a/packages/python-runner/src/index.ts
+++ b/packages/python-runner/src/index.ts
@@ -14,31 +14,26 @@
  * limitations under the License.
  */
 
-import '../style/index.css';
-
 import {
+  ILayoutRestorer,
   JupyterFrontEnd,
-  JupyterFrontEndPlugin,
-  ILayoutRestorer
+  JupyterFrontEndPlugin
 } from '@jupyterlab/application';
+import { ICommandPalette, WidgetTracker } from '@jupyterlab/apputils';
 import { CodeEditor, IEditorServices } from '@jupyterlab/codeeditor';
 import { ISettingRegistry } from '@jupyterlab/coreutils';
-import { FileEditor } from '@jupyterlab/fileeditor';
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
+import { FileEditor } from '@jupyterlab/fileeditor';
 import { ILauncher } from '@jupyterlab/launcher';
 import { IMainMenu } from '@jupyterlab/mainmenu';
-import { WidgetTracker, ICommandPalette } from '@jupyterlab/apputils';
-
 import {
   ITableOfContentsRegistry,
   TableOfContentsRegistry
 } from '@jupyterlab/toc';
-
 import { createPythonGenerator } from '@jupyterlab/toc/lib/generators';
-
 import { JSONObject } from '@phosphor/coreutils';
-
-import { PythonFileEditorFactory, PythonFileEditor } from './widget';
+import '../style/index.css';
+import { PythonFileEditor, PythonFileEditorFactory } from './widget';
 
 const PYTHON_ICON_CLASS = 'jp-PythonIcon';
 const PYTHON_FACTORY = 'PyEditor';

--- a/packages/python-runner/src/index.ts
+++ b/packages/python-runner/src/index.ts
@@ -32,6 +32,7 @@ import {
 } from '@jupyterlab/toc';
 import { createPythonGenerator } from '@jupyterlab/toc/lib/generators';
 import { JSONObject } from '@phosphor/coreutils';
+
 import '../style/index.css';
 import { PythonFileEditor, PythonFileEditorFactory } from './widget';
 

--- a/packages/python-runner/src/widget.tsx
+++ b/packages/python-runner/src/widget.tsx
@@ -47,6 +47,7 @@ import {
   Widget
 } from '@phosphor/widgets';
 import React from 'react';
+
 import '../style/index.css';
 import { PythonRunner } from './PythonRunner';
 

--- a/packages/python-runner/src/widget.tsx
+++ b/packages/python-runner/src/widget.tsx
@@ -14,42 +14,40 @@
  * limitations under the License.
  */
 
-import '../style/index.css';
-import React from 'react';
-
-import { FileEditor } from '@jupyterlab/fileeditor';
+import {
+  Dialog,
+  ReactWidget,
+  showDialog,
+  ToolbarButton
+} from '@jupyterlab/apputils';
+import { CodeEditor, IEditorServices } from '@jupyterlab/codeeditor';
 import {
   ABCWidgetFactory,
   DocumentRegistry,
   DocumentWidget
 } from '@jupyterlab/docregistry';
-import { CodeEditor, IEditorServices } from '@jupyterlab/codeeditor';
-import {
-  ToolbarButton,
-  ReactWidget,
-  showDialog,
-  Dialog
-} from '@jupyterlab/apputils';
-import { HTMLSelect } from '@jupyterlab/ui-components';
-import { Kernel } from '@jupyterlab/services';
+import { FileEditor } from '@jupyterlab/fileeditor';
+import { ScrollingWidget } from '@jupyterlab/logconsole';
 import {
   OutputArea,
   OutputAreaModel,
   OutputPrompt
 } from '@jupyterlab/outputarea';
-import { ScrollingWidget } from '@jupyterlab/logconsole';
 import {
   RenderMimeRegistry,
   standardRendererFactories as initialFactories
 } from '@jupyterlab/rendermime';
+import { Kernel } from '@jupyterlab/services';
+import { HTMLSelect } from '@jupyterlab/ui-components';
 import {
   BoxLayout,
-  PanelLayout,
-  Widget,
   DockPanel,
-  TabBar
+  PanelLayout,
+  TabBar,
+  Widget
 } from '@phosphor/widgets';
-
+import React from 'react';
+import '../style/index.css';
 import { PythonRunner } from './PythonRunner';
 
 /**


### PR DESCRIPTION
Invoke the cli tool for Typescript Ordered Imports on lint and add a lint rule to separate import groups by external and internal imports since ordered-imports removes all newline between imports.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

