### PR TITLE
Added lint rule for sort imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,13 @@
         " * limitations under the License.",
         " "
       ]
+    ],
+    "import/order": [
+      "error",
+      {
+        "alphabetize": { "order": "asc", "caseInsensitive": true },
+        "newlines-between": "always-and-inside-groups"
+      }
     ]
   },
   "overrides": [
@@ -51,7 +58,7 @@
     }
   ],
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "header"],
+  "plugins": ["@typescript-eslint", "header", "import"],
   "settings": {
     "react": {
       "version": "detect"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint": "^6.5.0",
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-header": "^3.0.0",
+    "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-react": "^7.18.3",
     "husky": "^2.3.0",
     "lerna": "^3.16.4",

--- a/packages/notebook-scheduler/src/SubmitNotebook.ts
+++ b/packages/notebook-scheduler/src/SubmitNotebook.ts
@@ -13,19 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Dialog, showDialog, ToolbarButton } from '@jupyterlab/apputils';
-import { DocumentRegistry } from '@jupyterlab/docregistry';
-import { INotebookModel, NotebookPanel } from '@jupyterlab/notebook';
-import { JupyterFrontEnd } from '@jupyterlab/application';
-import { JSONObject, JSONValue } from '@phosphor/coreutils';
-import { Widget } from '@phosphor/widgets';
-import { IDisposable } from '@phosphor/disposable';
-
 import {
   FrontendServices,
   NotebookParser,
   SubmissionHandler
 } from '@elyra/application';
+
+import { JupyterFrontEnd } from '@jupyterlab/application';
+import { Dialog, showDialog, ToolbarButton } from '@jupyterlab/apputils';
+import { DocumentRegistry } from '@jupyterlab/docregistry';
+import { INotebookModel, NotebookPanel } from '@jupyterlab/notebook';
+
+import { JSONObject, JSONValue } from '@phosphor/coreutils';
+import { IDisposable } from '@phosphor/disposable';
+import { Widget } from '@phosphor/widgets';
 
 import Utils from './utils';
 

--- a/packages/notebook-scheduler/src/utils.ts
+++ b/packages/notebook-scheduler/src/utils.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import uuid4 from 'uuid/v4';
+
 import pipeline_template from './pipeline-template.json';
 import { ISubmitNotebookOptions } from './SubmitNotebook';
 

--- a/packages/pipeline-editor/src/index.tsx
+++ b/packages/pipeline-editor/src/index.tsx
@@ -15,6 +15,17 @@
  */
 
 import {
+  FrontendServices,
+  NotebookParser,
+  SubmissionHandler
+} from '@elyra/application';
+import {
+  CommonCanvas,
+  CanvasController,
+  CommonProperties
+} from '@elyra/canvas';
+
+import {
   JupyterFrontEnd,
   JupyterFrontEndPlugin,
   ILayoutRestorer
@@ -41,26 +52,17 @@ import { toArray } from '@phosphor/algorithm';
 import { IDragEvent } from '@phosphor/dragdrop';
 import { Widget, PanelLayout } from '@phosphor/widgets';
 
-import {
-  CommonCanvas,
-  CanvasController,
-  CommonProperties
-} from '@elyra/canvas';
 import '@elyra/canvas/dist/common-canvas.min.css';
-import {
-  FrontendServices,
-  NotebookParser,
-  SubmissionHandler
-} from '@elyra/application';
 import 'carbon-components/css/carbon-components.min.css';
 import '../style/index.css';
 
-import * as palette from './palette.json';
-import * as properties from './properties.json';
-import * as i18nData from './en.json';
 import * as React from 'react';
 
 import { IntlProvider } from 'react-intl';
+
+import * as i18nData from './en.json';
+import * as palette from './palette.json';
+import * as properties from './properties.json';
 
 const PIPELINE_ICON_CLASS = 'jp-MaterialIcon elyra-PipelineIcon';
 const PIPELINE_CLASS = 'elyra-PipelineEditor';

--- a/packages/python-runner/src/PythonRunner.ts
+++ b/packages/python-runner/src/PythonRunner.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { Kernel } from '@jupyterlab/services';
-import { CodeEditor } from '@jupyterlab/codeeditor';
 import { Dialog, showDialog } from '@jupyterlab/apputils';
+import { CodeEditor } from '@jupyterlab/codeeditor';
+import { Kernel } from '@jupyterlab/services';
 
 /**
  * Class: An enhanced Python Script Editor that enables developing and running the script

--- a/packages/python-runner/src/index.ts
+++ b/packages/python-runner/src/index.ts
@@ -21,13 +21,13 @@ import {
   JupyterFrontEndPlugin,
   ILayoutRestorer
 } from '@jupyterlab/application';
+import { WidgetTracker, ICommandPalette } from '@jupyterlab/apputils';
 import { CodeEditor, IEditorServices } from '@jupyterlab/codeeditor';
 import { ISettingRegistry } from '@jupyterlab/coreutils';
-import { FileEditor } from '@jupyterlab/fileeditor';
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
+import { FileEditor } from '@jupyterlab/fileeditor';
 import { ILauncher } from '@jupyterlab/launcher';
 import { IMainMenu } from '@jupyterlab/mainmenu';
-import { WidgetTracker, ICommandPalette } from '@jupyterlab/apputils';
 
 import {
   ITableOfContentsRegistry,

--- a/packages/python-runner/src/widget.tsx
+++ b/packages/python-runner/src/widget.tsx
@@ -15,33 +15,32 @@
  */
 
 import '../style/index.css';
-import React from 'react';
 
-import { FileEditor } from '@jupyterlab/fileeditor';
-import {
-  ABCWidgetFactory,
-  DocumentRegistry,
-  DocumentWidget
-} from '@jupyterlab/docregistry';
-import { CodeEditor, IEditorServices } from '@jupyterlab/codeeditor';
 import {
   ToolbarButton,
   ReactWidget,
   showDialog,
   Dialog
 } from '@jupyterlab/apputils';
-import { HTMLSelect } from '@jupyterlab/ui-components';
-import { Kernel } from '@jupyterlab/services';
+import { CodeEditor, IEditorServices } from '@jupyterlab/codeeditor';
+import {
+  ABCWidgetFactory,
+  DocumentRegistry,
+  DocumentWidget
+} from '@jupyterlab/docregistry';
+import { FileEditor } from '@jupyterlab/fileeditor';
+import { ScrollingWidget } from '@jupyterlab/logconsole';
 import {
   OutputArea,
   OutputAreaModel,
   OutputPrompt
 } from '@jupyterlab/outputarea';
-import { ScrollingWidget } from '@jupyterlab/logconsole';
 import {
   RenderMimeRegistry,
   standardRendererFactories as initialFactories
 } from '@jupyterlab/rendermime';
+import { Kernel } from '@jupyterlab/services';
+import { HTMLSelect } from '@jupyterlab/ui-components';
 import {
   BoxLayout,
   PanelLayout,
@@ -49,6 +48,8 @@ import {
   DockPanel,
   TabBar
 } from '@phosphor/widgets';
+
+import React from 'react';
 
 import { PythonRunner } from './PythonRunner';
 


### PR DESCRIPTION
Imports are sorted alphabetically and grouped by source
(external, internal, parent dir, local dir) enforcing a newline
between groups. In addition it allows newline within groups so we
can manually seperate groups by external source (ie lab vs lumino)



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

