### PR TITLE
Enhance stacktrace formatting in error dialog

### DIFF
--- a/packages/application/src/submission.tsx
+++ b/packages/application/src/submission.tsx
@@ -220,7 +220,7 @@ class ErrorDialogContent extends React.Component<IErrorDialogProps, any> {
             this.state.expanded ? ERROR_DETAILS_VISIBLE : ERROR_DETAILS_HIDDEN
           }
         >
-          {this.props.traceback}
+          <pre>{this.props.traceback}</pre>
         </div>
       </div>
     ) : null;


### PR DESCRIPTION
Enhance the formatting of the stacktrace on the error dialog details:

Before:
![image](https://user-images.githubusercontent.com/382917/79079896-a57ca680-7cc6-11ea-97c6-65dda5220a21.png)

After:
![image](https://user-images.githubusercontent.com/382917/79030524-3e3be680-7b4e-11ea-9bb8-2ba5afeb5e23.png)


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

