### PR TITLE
Simplify / fix frontend tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -5,5 +5,6 @@
   "pluginsFile": "./tests/plugins/index.js",
   "screenshotsFolder": "./build/cypress-tests/screenshots",
   "videosFolder": "./build/cypress-tests/videos",
-  "fixturesFolder": false
+  "fixturesFolder": false,
+  "defaultCommandTimeout": 8000
 }

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -19,16 +19,8 @@ describe('PipelineEditor', () => {
     cy.visit('?token=test&reset');
   });
 
-  it('opens launcher with notebook and pipeline abilities', () => {
-    cy.get('.jp-ToolbarButtonComponent[title="New Launcher"]').click();
-
-    cy.get(
-      '.jp-LauncherCard[data-category="Notebook"][title="Python 3"]:visible'
-    );
-    cy.get('.jp-LauncherCard[title="Pipeline Editor"]:visible');
-  });
-
   it('opens blank notebook', () => {
+    cy.get('.jp-ToolbarButtonComponent[title="New Launcher"]').click();
     cy.get(
       '.jp-LauncherCard[data-category="Notebook"][title="Python 3"]:visible'
     ).click();
@@ -40,11 +32,11 @@ describe('PipelineEditor', () => {
     ).click();
   });
 
-  it('reopens launcher', () => {
-    cy.get('.jp-ToolbarButtonComponent[title="New Launcher"]').click();
-  });
-
   it('opens pipeline editor', () => {
-    cy.get('.jp-LauncherCard[title="Pipeline Editor"]:visible').click();
+    cy.get(
+      '.p-TabBar-content > [data-id="launcher-0"] > .p-TabBar-tabCloseIcon:visible'
+    ).click({ multiple: true });
+    cy.get('.jp-ToolbarButtonComponent[title="New Launcher"]').click();
+    cy.get('.jp-Launcher-cardContainer > [title="Pipeline Editor"]').click();
   });
 });

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -37,6 +37,8 @@ describe('PipelineEditor', () => {
       '.p-TabBar-content > [data-id="launcher-0"] > .p-TabBar-tabCloseIcon:visible'
     ).click({ multiple: true });
     cy.get('.jp-ToolbarButtonComponent[title="New Launcher"]').click();
-    cy.get('.jp-Launcher-cardContainer > [title="Pipeline Editor"]').click();
+    cy.get('.jp-Launcher-cardContainer > [title="Pipeline Editor"]')
+      .scrollIntoView()
+      .click();
   });
 });


### PR DESCRIPTION
Cleans up the frontend cypress tests by removing some unnecessary calls, combining some functions, and adding a line to close all launcher tabs so that the code can be more reliable. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

