### PR TITLE
Fix caret directions in pipeline error dialog

### DIFF
--- a/packages/application/src/submission.tsx
+++ b/packages/application/src/submission.tsx
@@ -17,10 +17,7 @@
 import { showDialog, Dialog } from '@jupyterlab/apputils';
 import { URLExt } from '@jupyterlab/coreutils';
 import { ServerConnection } from '@jupyterlab/services';
-import {
-  caretDownEmptyThinIcon,
-  caretUpEmptyThinIcon
-} from '@jupyterlab/ui-components';
+import { caretDownIcon, caretRightIcon } from '@jupyterlab/ui-components';
 
 import * as React from 'react';
 
@@ -211,12 +208,9 @@ class ErrorDialogContent extends React.Component<IErrorDialogProps, any> {
             }}
           >
             {this.state.expanded ? (
-              <caretUpEmptyThinIcon.react tag="span" elementPosition="center" />
+              <caretDownIcon.react tag="span" elementPosition="center" />
             ) : (
-              <caretDownEmptyThinIcon.react
-                tag="span"
-                elementPosition="center"
-              />
+              <caretRightIcon.react tag="span" elementPosition="center" />
             )}
           </button>
           {'Error details: '}


### PR DESCRIPTION
Change in the pipeline error dialog for expandable error:
Caret right when not expanded
Caret down when expanded

Fixes #450 

Images with fix:
<img width="445" alt="Screen Shot 2020-04-28 at 11 45 50 PM" src="https://user-images.githubusercontent.com/29576529/80560018-798f3f80-89ad-11ea-816f-f6e7f4b9c262.png">
<img width="543" alt="Screen Shot 2020-04-28 at 11 46 03 PM" src="https://user-images.githubusercontent.com/29576529/80560026-7d22c680-89ad-11ea-871c-f749bc0339f6.png">


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

