### PR TITLE
Add basic tests for all frontend elyra extensions

### DIFF
--- a/tests/integration/codesnippet.ts
+++ b/tests/integration/codesnippet.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+describe('CodeSnippets', () => {
+  it('opens jupyterlab', () => {
+    cy.visit('?token=test&reset');
+  });
+
+  it('opens code snippets extension', () => {
+    cy.get('[title="Code Snippet"]').click();
+  });
+});

--- a/tests/integration/git.ts
+++ b/tests/integration/git.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+describe('Git', () => {
+  it('opens jupyterlab', () => {
+    cy.visit('?token=test&reset');
+  });
+
+  it('opens git extension', () => {
+    cy.get('[title="Git"]').click();
+  });
+});

--- a/tests/integration/pythoneditor.ts
+++ b/tests/integration/pythoneditor.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+describe('PythonEditor', () => {
+  it('opens jupyterlab', () => {
+    cy.visit('?token=test&reset');
+  });
+
+  it('opens blank python', () => {
+    cy.get('[title="Create a new python file"][tabindex="100"]').click();
+  });
+});

--- a/tests/integration/submitbutton.ts
+++ b/tests/integration/submitbutton.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018-2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+describe('SubmitButton', () => {
+  it('opens jupyterlab', () => {
+    cy.visit('?token=test&reset');
+  });
+
+  it('opens blank notebook', () => {
+    cy.get(
+      '.jp-LauncherCard[data-category="Notebook"][title="Python 3"]:visible'
+    ).click();
+  });
+
+  it('presses the submit notebook buttton', () => {
+    cy.contains('Submit Notebook').click();
+  });
+
+  it('shows a dialog after pressing submit notebook', () => {
+    cy.get('.jp-Dialog');
+  });
+});

--- a/tests/integration/toc.ts
+++ b/tests/integration/toc.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018-2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+describe('Toc', () => {
+  it('opens jupyterlab', () => {
+    cy.visit('?token=test&reset');
+  });
+
+  it('opens ToC extension', () => {
+    cy.get('[title="Table of Contents"]').click();
+  });
+});


### PR DESCRIPTION
Adds basic cypress tests to open the python editor, code snippets, and submit button extensions.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

