### PR TITLE
 Properly include dependencies recursively

### DIFF
--- a/elyra/util/archive.py
+++ b/elyra/util/archive.py
@@ -55,19 +55,18 @@ def create_temp_archive(archive_name, source_dir, files=None, recursive=False):
         if '*' in files:
             return tarinfo
 
-        # if tarinfo.name == os.path.basename(operation.artifact):
-        #    return tarinfo
-
         for dependency in files:
             if dependency:
                 if dependency.startswith('*'):
                     # handle check for extension wildcard
                     if tarinfo.name.endswith(dependency.replace('*.', '.')):
                         return tarinfo
-                else:
+                elif tarinfo.name == dependency:
                     # handle check for specific file
-                    if tarinfo.name == dependency:
-                        return tarinfo
+                    return tarinfo
+                elif recursive:
+                    # handle recursive
+                    return tarinfo
 
         return None
 

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -398,6 +398,9 @@ export class PipelineEditor extends React.Component<
             'image'
           ] = this.propertiesInfo.parameterDef.current_parameters.image;
           data.nodeTemplate.app_data['vars'] = vars;
+          data.nodeTemplate.app_data[
+            'recursive_dependencies'
+          ] = this.propertiesInfo.parameterDef.current_parameters.recursive_dependencies;
 
           this.canvasController.editActionHandler(data);
 


### PR DESCRIPTION
There were a couple of issues when supporting dependencies
recursively. First, the property was not being saved/propagated.
After that, because the code was including the notebook as one
of the files on the dependency array, the algorithm needed to be
updated to include subdirs when processing the dependencies.
Note, there was no problem if recursive was `true` and no file
dependencies were passed.

Fixes #472
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

