### PR TITLE
Remove option to create super node

### DIFF
--- a/packages/application/style/index.css
+++ b/packages/application/style/index.css
@@ -70,4 +70,3 @@ button.elyra-pipelineSubmission-errDisplayButton {
 .jp-Dialog-content {
   resize: both;
 }
-

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -327,6 +327,8 @@ export class PipelineEditor extends React.Component<
 
   contextMenuHandler(source: any, defaultMenu: any): any {
     let customMenu = defaultMenu;
+    // Remove option to create super node
+    customMenu.splice(4, 2);
     if (source.type === 'node') {
       if (source.selectedObjectIds.length > 1) {
         customMenu = customMenu.concat({


### PR DESCRIPTION
Removes the option to create a super node in the context menu of canvas in the pipeline editor. Supernodes can't be easily translated into the pipelines we're creating in the backend so it's simpler if users can't create them from the frontend. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

