### PR TITLE
Add ability to double click to open notebook in pipeline

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -154,6 +154,7 @@ export class PipelineEditor extends React.Component<
     this.toolbarMenuActionHandler = this.toolbarMenuActionHandler.bind(this);
     this.contextMenuHandler = this.contextMenuHandler.bind(this);
     this.contextMenuActionHandler = this.contextMenuActionHandler.bind(this);
+    this.clickActionHandler = this.clickActionHandler.bind(this);
     this.editActionHandler = this.editActionHandler.bind(this);
 
     this.state = { showPropertiesDialog: false, propertiesInfo: {} };
@@ -259,6 +260,7 @@ export class PipelineEditor extends React.Component<
           toolbarMenuActionHandler={this.toolbarMenuActionHandler}
           contextMenuHandler={this.contextMenuHandler}
           contextMenuActionHandler={this.contextMenuActionHandler}
+          clickActionHandler={this.clickActionHandler}
           editActionHandler={this.editActionHandler}
           toolbarConfig={toolbarConfig}
           config={canvasConfig}
@@ -359,6 +361,16 @@ export class PipelineEditor extends React.Component<
         this.closePropertiesDialog();
       } else {
         this.openPropertiesDialog(source);
+      }
+    }
+  }
+
+  clickActionHandler(source: any): void {
+    if (source.clickType === 'DOUBLE_CLICK' && source.objectType === 'node') {
+      const nodes = source.selectedObjectIds;
+      for (let i = 0; i < nodes.length; i++) {
+        const path = this.canvasController.getNode(nodes[i]).app_data.artifact;
+        this.app.commands.execute(commandIDs.openDocManager, { path });
       }
     }
   }


### PR DESCRIPTION
Fixes #467. Adds behavior in pipeline editor to double-click a pipeline to open the notebook editor in a new tab. When multiple nodes are selected, it opens all of them regardless of the node that you double-click. Doesn't work when nodes are in a supernode (double-clicking a node within a supernode does nothing). 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

