### PR TITLE
Remove folders then files during make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,15 +30,15 @@ help:
 
 clean: ## Make a clean source tree
 	rm -rf build *.egg-info yarn-error.log
-	rm -rf $$(find . -name dist)
+	rm -rf $$(find . -name node_modules -type d -maxdepth 3)
+	rm -rf $$(find . -name dist -type d)
+	rm -rf $$(find . -name lib -type d)
+	rm -rf $$(find . -name __pycache__ -type d)
 	rm -rf $$(find . -name *.tgz)
-	rm -rf $$(find . -name lib)
-	rm -rf $$(find . -name node_modules)
 	rm -rf $$(find . -name tsconfig.tsbuildinfo)
 	rm -rf $$(find . -name *.lock)
 	rm -rf $$(find . -name package-lock.json)
 	rm -rf $$(find . -name .pytest_cache)
-	rm -rf $$(find . -name __pycache__)
 
 # Prepares Elyra for build/packaging/installation
 yarn-install:

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,10 @@ help:
 
 clean: ## Make a clean source tree
 	rm -rf build *.egg-info yarn-error.log
-	rm -rf $$(find . -name node_modules -type d -maxdepth 3)
-	rm -rf $$(find . -name dist -type d)
-	rm -rf $$(find . -name lib -type d)
+	rm -rf node_modules lib dist
+	rm -rf $$(find packages -name node_modules -type d -maxdepth 2)
+	rm -rf $$(find packages -name dist -type d)
+	rm -rf $$(find packages -name lib -type d)
 	rm -rf $$(find . -name __pycache__ -type d)
 	rm -rf $$(find . -name *.tgz)
 	rm -rf $$(find . -name tsconfig.tsbuildinfo)


### PR DESCRIPTION
Speed up `make clean` by deleting specific folders before searching for individual files to delete

 (in support of #177)

This change updates the `make clean` script to deletes the folders first then the files that way searching for the files it takes less time as it will need to search through less folders.

The biggest improvement is seen when the `node_modules` is deleted first as it can contain many files and nested folders.


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

