### PR TITLE
Add support for markdown tables in docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx>=1.8
 sphinx_rtd_theme
 recommonmark
+sphinx-markdown-tables

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,7 +43,8 @@ release = version_ns['__version__']
 # ones.
 extensions = [
     "sphinx_rtd_theme",
-    "recommonmark"
+    "recommonmark",
+    "sphinx_markdown_tables"
 ]
 
 source_suffix = {


### PR DESCRIPTION
Enable markdown tables to be properly rendered in HTML docs

Fixes: https://github.com/elyra-ai/elyra/issues/486

Added the `sphinx-markdown-tables` extension so that markdown table are supported in docs generated with Sphinx 

Before:
<img width="1107" alt="image" src="https://user-images.githubusercontent.com/13156555/81014470-e92c8100-8e2a-11ea-8c3f-a6df0b94aa84.png">

After:
<img width="1105" alt="image" src="https://user-images.githubusercontent.com/13156555/81016225-06af1a00-8e2e-11ea-9245-d84144e3f464.png">


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

