### PR TITLE
Remove dev workflow details from README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ limitations under the License.
 # Contributing
 
 Welcome to Elyra! If you are interested in contributing to the [Elyra code repo](README.md)
-then checkout the [Contributor's Guide](https://github.com/elyra-ai/community/blob/master/contributing.md)
+then checkout the [Contributor's Guide](https://github.com/elyra-ai/community/blob/master/contributing.md).
 
 The [Elyra community repo](https://github.com/elyra-ai/community) contains information on how the community
 is organized and other information that is pertinent to contributing.

--- a/README.md
+++ b/README.md
@@ -108,34 +108,15 @@ After verifying Elyra has been installed, start Elyra with:
 jupyter lab
 ```
 
-## Development Workflow
-### Building
+## Contributing to Elyra
+If you are interested in helping make Elyra better, we encourage you to take a look at our 
+[Contributing](CONTRIBUTING.md) page,  
+[Development Workflow](docs/source/developer-guide/development-workflow.md) documentation, and 
+invite you to attend our weekly dev community meetings.
 
-`Elyra` is divided in two parts, a collection of Jupyter Notebook backend extensions,
-and their respective JupyterLab UI extensions. Our JupyterLab extensions are located in our `packages`
-directory. 
+### Weekly Dev Community Meeting 
+Join us weekly to discuss Elyra development topics.  Everyone is welcome and participation is optional.
 
-#### Requirements
-
-* [Yarn](https://yarnpkg.com/lang/en/docs/install) 
-
-#### Installation
-
-```bash
-make clean install
-```
-
-You can check that the notebook server extension was successful installed with:
-```bash
-jupyter serverextension list
-```
-
-You can check that the JupyterLab extension was successful installed with:
-```bash
-jupyter labextension list
-```
-
-### Weekly Dev Community Meeting
 **When**: Thursdays at [9AM PST](https://www.thetimezoneconverter.com/?t=9%3A00%20am&tz=San%20Francisco&)
 
 **Where**: [Zoom](https://zoom.us/j/99736674253) (Meeting ID: 997 3667 4253)

--- a/docs/source/developer_guide/development-workflow.md
+++ b/docs/source/developer_guide/development-workflow.md
@@ -16,10 +16,10 @@ limitations under the License.
 {% endcomment %}
 -->
 ## Development Workflow
+This section describes the steps necessary to build Elyra in a development environment. 
 
 ### Building
-
-`Elyra` is divided in two parts, a collection of Jupyter Notebook backend extensions,
+Elyra is divided in two parts, a collection of Jupyter Notebook backend extensions,
 and their respective JupyterLab UI extensions. Our JupyterLab extensions are located in our `packages`
 directory. 
 


### PR DESCRIPTION
Reduced duplication by removing the details of the Development Workflow section of the README as they were also replicated in the docs.

Since a link was necessary, I changed the section to more about _contributing_ so that we could tie in the dev meeting invitation.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

