### PR TITLE
Add additional validation to pipeline parser

### DIFF
--- a/elyra/pipeline/parser.py
+++ b/elyra/pipeline/parser.py
@@ -64,6 +64,13 @@ class PipelineParser(LoggingConfigurable):
                                    PipelineParser._read_pipeline_filetype(pipeline),
                                    PipelineParser._read_pipeline_export(pipeline))
 
+        if not pipeline_object.title:
+            raise SyntaxError('Invalid pipeline: Missing title.')
+        if not pipeline_object.runtime:
+            raise SyntaxError('Invalid pipeline: Missing runtime.')
+        if not pipeline_object.runtime_config:
+            raise SyntaxError('Invalid pipeline: Missing runtime configuration.')
+
         for node in pipeline['nodes']:
             # Supernodes are not supported
             if node['type'] == "super_node":
@@ -86,6 +93,17 @@ class PipelineParser(LoggingConfigurable):
                     outputs=node['app_data'].get('outputs') or [],
                     dependencies=links
                 )
+                # validate that the operation has all required properties
+                if not operation.id:
+                    raise SyntaxError("Invalid pipeline: Missing field 'operation id'.")
+                if not operation.type:
+                    raise SyntaxError("Invalid pipeline: Missing field 'operation type'.")
+                if not operation.artifact:
+                    raise SyntaxError("Invalid pipeline: Missing field 'operation artifact'.")
+                if not operation.image:
+                    raise SyntaxError("Invalid pipeline: Missing field 'operation image'.")
+
+                # add valid operation to list of operations
                 pipeline_object.operations[operation.id] = operation
             except Exception as e:
                 raise SyntaxError("Invalid pipeline: Missing field {}".format(e))

--- a/elyra/pipeline/parser.py
+++ b/elyra/pipeline/parser.py
@@ -64,13 +64,6 @@ class PipelineParser(LoggingConfigurable):
                                    PipelineParser._read_pipeline_filetype(pipeline),
                                    PipelineParser._read_pipeline_export(pipeline))
 
-        if not pipeline_object.title:
-            raise SyntaxError('Invalid pipeline: Missing title.')
-        if not pipeline_object.runtime:
-            raise SyntaxError('Invalid pipeline: Missing runtime.')
-        if not pipeline_object.runtime_config:
-            raise SyntaxError('Invalid pipeline: Missing runtime configuration.')
-
         for node in pipeline['nodes']:
             # Supernodes are not supported
             if node['type'] == "super_node":
@@ -93,16 +86,6 @@ class PipelineParser(LoggingConfigurable):
                     outputs=node['app_data'].get('outputs') or [],
                     dependencies=links
                 )
-                # validate that the operation has all required properties
-                if not operation.id:
-                    raise SyntaxError("Invalid pipeline: Missing field 'operation id'.")
-                if not operation.type:
-                    raise SyntaxError("Invalid pipeline: Missing field 'operation type'.")
-                if not operation.artifact:
-                    raise SyntaxError("Invalid pipeline: Missing field 'operation artifact'.")
-                if not operation.image:
-                    raise SyntaxError("Invalid pipeline: Missing field 'operation image'.")
-
                 # add valid operation to list of operations
                 pipeline_object.operations[operation.id] = operation
             except Exception as e:

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -23,15 +23,15 @@ class Operation(object):
 
         # validate that the operation has all required properties
         if not id:
-            raise SyntaxError("Invalid pipeline: Missing field 'operation id'.")
+            raise ValueError("Invalid pipeline: Missing field 'operation id'.")
         if not type:
-            raise SyntaxError("Invalid pipeline: Missing field 'operation type'.")
+            raise ValueError("Invalid pipeline: Missing field 'operation type'.")
         if not title:
-            raise SyntaxError("Invalid pipeline: Missing field 'operation title'.")
+            raise ValueError("Invalid pipeline: Missing field 'operation title'.")
         if not artifact:
-            raise SyntaxError("Invalid pipeline: Missing field 'operation artifact'.")
+            raise ValueError("Invalid pipeline: Missing field 'operation artifact'.")
         if not image:
-            raise SyntaxError("Invalid pipeline: Missing field 'operation image'.")
+            raise ValueError("Invalid pipeline: Missing field 'operation image'.")
 
         self._id = id
         self._type = type
@@ -128,11 +128,11 @@ class Pipeline(object):
     def __init__(self, id, title, runtime, runtime_config, file_type, export):
 
         if not title:
-            raise SyntaxError('Invalid pipeline: Missing title.')
+            raise ValueError('Invalid pipeline: Missing title.')
         if not runtime:
-            raise SyntaxError('Invalid pipeline: Missing runtime.')
+            raise ValueError('Invalid pipeline: Missing runtime.')
         if not runtime_config:
-            raise SyntaxError('Invalid pipeline: Missing runtime configuration.')
+            raise ValueError('Invalid pipeline: Missing runtime configuration.')
 
         self._id = id
         self._title = title

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -20,6 +20,19 @@ class Operation(object):
 
     def __init__(self, id, type, title, artifact, image, vars=None, file_dependencies=None,
                  recursive_dependencies=False, outputs=None, inputs=None, dependencies=None):
+
+        # validate that the operation has all required properties
+        if not id:
+            raise SyntaxError("Invalid pipeline: Missing field 'operation id'.")
+        if not type:
+            raise SyntaxError("Invalid pipeline: Missing field 'operation type'.")
+        if not title:
+            raise SyntaxError("Invalid pipeline: Missing field 'operation title'.")
+        if not artifact:
+            raise SyntaxError("Invalid pipeline: Missing field 'operation artifact'.")
+        if not image:
+            raise SyntaxError("Invalid pipeline: Missing field 'operation image'.")
+
         self._id = id
         self._type = type
         self._title = title
@@ -113,6 +126,14 @@ class Operation(object):
 class Pipeline(object):
 
     def __init__(self, id, title, runtime, runtime_config, file_type, export):
+
+        if not title:
+            raise SyntaxError('Invalid pipeline: Missing title.')
+        if not runtime:
+            raise SyntaxError('Invalid pipeline: Missing runtime.')
+        if not runtime_config:
+            raise SyntaxError('Invalid pipeline: Missing runtime configuration.')
+
         self._id = id
         self._title = title
         self._runtime = runtime

--- a/elyra/pipeline/tests/test_pipeline_parser.py
+++ b/elyra/pipeline/tests/test_pipeline_parser.py
@@ -147,7 +147,7 @@ def test_missing_pipeline_runtime():
 
 def test_missing_pipeline_runtime_configuration():
     pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
-    pipeline_definition['pipelines'][0]['app_data']['runtime_config'] = ''
+    pipeline_definition['pipelines'][0]['app_data']['runtime-config'] = ''
 
     with pytest.raises(SyntaxError) as e:
         PipelineParser.parse(pipeline_definition)

--- a/elyra/pipeline/tests/test_pipeline_parser.py
+++ b/elyra/pipeline/tests/test_pipeline_parser.py
@@ -31,7 +31,7 @@ def valid_operation():
 
 
 def test_valid_pipeline(valid_operation):
-    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
 
     pipeline = PipelineParser.parse(pipeline_definition)
 
@@ -41,7 +41,7 @@ def test_valid_pipeline(valid_operation):
 
 
 def test_missing_primary():
-    pipeline_definition = __read_pipeline_resource('pipeline_invalid.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_invalid.json')
     pipeline_definition.pop('primary_pipeline')
 
     with pytest.raises(SyntaxError):
@@ -49,7 +49,7 @@ def test_missing_primary():
 
 
 def test_missing_pipelines():
-    pipeline_definition = __read_pipeline_resource('pipeline_invalid.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_invalid.json')
     pipeline_definition.pop('pipelines')
 
     with pytest.raises(SyntaxError):
@@ -57,7 +57,7 @@ def test_missing_pipelines():
 
 
 def test_missing_primary_id():
-    pipeline_definition = __read_pipeline_resource('pipeline_invalid.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_invalid.json')
     # Replace pipeline id with non-matching guid so primary is not found
     pipeline_definition['pipelines'][0]['id'] = "deadbeef-dead-beef-dead-beefdeadbeef"
 
@@ -66,7 +66,7 @@ def test_missing_primary_id():
 
 
 def test_zero_nodes():
-    pipeline_definition = __read_pipeline_resource('pipeline_invalid.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_invalid.json')
     pipeline_definition['pipelines'][0]['nodes'] = []
 
     with pytest.raises(SyntaxError):
@@ -74,7 +74,7 @@ def test_zero_nodes():
 
 
 def test_multinode_pipeline():
-    pipeline_definition = __read_pipeline_resource('pipeline_3_node_sample.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_3_node_sample.json')
 
     pipeline = PipelineParser.parse(pipeline_definition)
 
@@ -82,21 +82,21 @@ def test_multinode_pipeline():
 
 
 def test_supernode_pipelinen():
-    pipeline_definition = __read_pipeline_resource('pipeline_with_supernode.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_with_supernode.json')
 
     with pytest.raises(SyntaxError):
         PipelineParser.parse(pipeline_definition)
 
 
 def test_multiple_pipeline_definition():
-    pipeline_definition = __read_pipeline_resource('pipeline_multiple_pipeline_definitions.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_multiple_pipeline_definitions.json')
 
     with pytest.raises(SyntaxError):
         PipelineParser.parse(pipeline_definition)
 
 
 def test_pipeline_operations_and_handle_artifact_file_details():
-    pipeline_definition = __read_pipeline_resource('pipeline_3_node_sample.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_3_node_sample.json')
 
     pipeline = PipelineParser.parse(pipeline_definition)
 
@@ -108,7 +108,7 @@ def test_pipeline_operations_and_handle_artifact_file_details():
 
 
 def test_pipeline_with_dependencies():
-    pipeline_definition = __read_pipeline_resource('pipeline_3_node_sample_with_dependencies.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_3_node_sample_with_dependencies.json')
 
     pipeline = PipelineParser.parse(pipeline_definition)
 
@@ -116,7 +116,7 @@ def test_pipeline_with_dependencies():
 
 
 def test_pipeline_global_attributes():
-    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
 
     pipeline = PipelineParser.parse(pipeline_definition)
 
@@ -126,7 +126,7 @@ def test_pipeline_global_attributes():
 
 
 def test_missing_pipeline_title():
-    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
     pipeline_definition['pipelines'][0]['app_data']['title'] = ''
 
     with pytest.raises(SyntaxError) as e:
@@ -136,7 +136,7 @@ def test_missing_pipeline_title():
 
 
 def test_missing_pipeline_runtime():
-    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
     pipeline_definition['pipelines'][0]['app_data']['runtime'] = ''
 
     with pytest.raises(SyntaxError) as e:
@@ -146,7 +146,7 @@ def test_missing_pipeline_runtime():
 
 
 def test_missing_pipeline_runtime_configuration():
-    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
     pipeline_definition['pipelines'][0]['app_data']['runtime_config'] = ''
 
     with pytest.raises(SyntaxError) as e:
@@ -156,7 +156,7 @@ def test_missing_pipeline_runtime_configuration():
 
 
 def test_missing_operation_id():
-    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
     pipeline_definition['pipelines'][0]['nodes'][0]['id'] = ''
 
     with pytest.raises(SyntaxError) as e:
@@ -166,7 +166,7 @@ def test_missing_operation_id():
 
 
 def test_missing_operation_type():
-    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
     pipeline_definition['pipelines'][0]['nodes'][0]['type'] = ''
 
     with pytest.raises(SyntaxError) as e:
@@ -176,7 +176,7 @@ def test_missing_operation_type():
 
 
 def test_missing_operation_artifact():
-    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
     pipeline_definition['pipelines'][0]['nodes'][0]['app_data']['artifact'] = ''
 
     with pytest.raises(SyntaxError) as e:
@@ -186,7 +186,7 @@ def test_missing_operation_artifact():
 
 
 def test_missing_operation_image():
-    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
     pipeline_definition['pipelines'][0]['nodes'][0]['app_data']['image'] = ''
 
     with pytest.raises(SyntaxError) as e:
@@ -195,7 +195,7 @@ def test_missing_operation_image():
     assert "Missing field 'operation image'" in str(e.value)
 
 
-def __read_pipeline_resource(pipeline_filename):
+def _read_pipeline_resource(pipeline_filename):
     root = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
     pipeline_path = os.path.join(root, pipeline_filename)
 

--- a/elyra/pipeline/tests/test_pipeline_parser.py
+++ b/elyra/pipeline/tests/test_pipeline_parser.py
@@ -30,18 +30,8 @@ def valid_operation():
                      image='{{image}}')
 
 
-def read_pipeline_resource(pipeline_filename):
-    root = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
-    pipeline_path = os.path.join(root, pipeline_filename)
-
-    with open(pipeline_path, 'r') as f:
-        pipeline_json = json.load(f)
-
-    return pipeline_json
-
-
 def test_valid_pipeline(valid_operation):
-    pipeline_definition = read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
 
     pipeline = PipelineParser.parse(pipeline_definition)
 
@@ -50,17 +40,8 @@ def test_valid_pipeline(valid_operation):
     assert pipeline.operations['{{uuid}}'] == valid_operation
 
 
-def test_missing_artifact():
-    pipeline_definition = read_pipeline_resource('pipeline_invalid.json')
-
-    with pytest.raises(SyntaxError) as e:
-        PipelineParser.parse(pipeline_definition)
-
-    assert "Missing field 'artifact'" in str(e.value)
-
-
 def test_missing_primary():
-    pipeline_definition = read_pipeline_resource('pipeline_invalid.json')
+    pipeline_definition = __read_pipeline_resource('pipeline_invalid.json')
     pipeline_definition.pop('primary_pipeline')
 
     with pytest.raises(SyntaxError):
@@ -68,7 +49,7 @@ def test_missing_primary():
 
 
 def test_missing_pipelines():
-    pipeline_definition = read_pipeline_resource('pipeline_invalid.json')
+    pipeline_definition = __read_pipeline_resource('pipeline_invalid.json')
     pipeline_definition.pop('pipelines')
 
     with pytest.raises(SyntaxError):
@@ -76,7 +57,7 @@ def test_missing_pipelines():
 
 
 def test_missing_primary_id():
-    pipeline_definition = read_pipeline_resource('pipeline_invalid.json')
+    pipeline_definition = __read_pipeline_resource('pipeline_invalid.json')
     # Replace pipeline id with non-matching guid so primary is not found
     pipeline_definition['pipelines'][0]['id'] = "deadbeef-dead-beef-dead-beefdeadbeef"
 
@@ -85,7 +66,7 @@ def test_missing_primary_id():
 
 
 def test_zero_nodes():
-    pipeline_definition = read_pipeline_resource('pipeline_invalid.json')
+    pipeline_definition = __read_pipeline_resource('pipeline_invalid.json')
     pipeline_definition['pipelines'][0]['nodes'] = []
 
     with pytest.raises(SyntaxError):
@@ -93,7 +74,7 @@ def test_zero_nodes():
 
 
 def test_multinode_pipeline():
-    pipeline_definition = read_pipeline_resource('pipeline_3_node_sample.json')
+    pipeline_definition = __read_pipeline_resource('pipeline_3_node_sample.json')
 
     pipeline = PipelineParser.parse(pipeline_definition)
 
@@ -101,21 +82,21 @@ def test_multinode_pipeline():
 
 
 def test_supernode_pipelinen():
-    pipeline_definition = read_pipeline_resource('pipeline_with_supernode.json')
+    pipeline_definition = __read_pipeline_resource('pipeline_with_supernode.json')
 
     with pytest.raises(SyntaxError):
         PipelineParser.parse(pipeline_definition)
 
 
 def test_multiple_pipeline_definition():
-    pipeline_definition = read_pipeline_resource('pipeline_multiple_pipeline_definitions.json')
+    pipeline_definition = __read_pipeline_resource('pipeline_multiple_pipeline_definitions.json')
 
     with pytest.raises(SyntaxError):
         PipelineParser.parse(pipeline_definition)
 
 
 def test_pipeline_operations_and_handle_artifact_file_details():
-    pipeline_definition = read_pipeline_resource('pipeline_3_node_sample.json')
+    pipeline_definition = __read_pipeline_resource('pipeline_3_node_sample.json')
 
     pipeline = PipelineParser.parse(pipeline_definition)
 
@@ -127,7 +108,7 @@ def test_pipeline_operations_and_handle_artifact_file_details():
 
 
 def test_pipeline_with_dependencies():
-    pipeline_definition = read_pipeline_resource('pipeline_3_node_sample_with_dependencies.json')
+    pipeline_definition = __read_pipeline_resource('pipeline_3_node_sample_with_dependencies.json')
 
     pipeline = PipelineParser.parse(pipeline_definition)
 
@@ -135,10 +116,90 @@ def test_pipeline_with_dependencies():
 
 
 def test_pipeline_global_attributes():
-    pipeline_definition = read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
 
     pipeline = PipelineParser.parse(pipeline_definition)
 
     assert pipeline.title == '{{title}}'
     assert pipeline.runtime == '{{runtime}}'
     assert pipeline.runtime_config == '{{runtime-config}}'
+
+
+def test_missing_pipeline_title():
+    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition['pipelines'][0]['app_data']['title'] = ''
+
+    with pytest.raises(SyntaxError) as e:
+        PipelineParser.parse(pipeline_definition)
+
+    assert "Invalid pipeline: Missing title" in str(e.value)
+
+
+def test_missing_pipeline_runtime():
+    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition['pipelines'][0]['app_data']['runtime'] = ''
+
+    with pytest.raises(SyntaxError) as e:
+        PipelineParser.parse(pipeline_definition)
+
+    assert "Invalid pipeline: Missing runtime" in str(e.value)
+
+
+def test_missing_pipeline_runtime_configuration():
+    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition['pipelines'][0]['app_data']['runtime_config'] = ''
+
+    with pytest.raises(SyntaxError) as e:
+        PipelineParser.parse(pipeline_definition)
+
+    assert "Invalid pipeline: Missing runtime configuration" in str(e.value)
+
+
+def test_missing_operation_id():
+    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition['pipelines'][0]['nodes'][0]['id'] = ''
+
+    with pytest.raises(SyntaxError) as e:
+        PipelineParser.parse(pipeline_definition)
+
+    assert "Missing field 'operation id'" in str(e.value)
+
+
+def test_missing_operation_type():
+    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition['pipelines'][0]['nodes'][0]['type'] = ''
+
+    with pytest.raises(SyntaxError) as e:
+        PipelineParser.parse(pipeline_definition)
+
+    assert "Missing field 'operation type'" in str(e.value)
+
+
+def test_missing_operation_artifact():
+    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition['pipelines'][0]['nodes'][0]['app_data']['artifact'] = ''
+
+    with pytest.raises(SyntaxError) as e:
+        PipelineParser.parse(pipeline_definition)
+
+    assert "Missing field 'operation artifact" in str(e.value)
+
+
+def test_missing_operation_image():
+    pipeline_definition = __read_pipeline_resource('pipeline_valid.json')
+    pipeline_definition['pipelines'][0]['nodes'][0]['app_data']['image'] = ''
+
+    with pytest.raises(SyntaxError) as e:
+        PipelineParser.parse(pipeline_definition)
+
+    assert "Missing field 'operation image'" in str(e.value)
+
+
+def __read_pipeline_resource(pipeline_filename):
+    root = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__)))
+    pipeline_path = os.path.join(root, pipeline_filename)
+
+    with open(pipeline_path, 'r') as f:
+        pipeline_json = json.load(f)
+
+    return pipeline_json

--- a/elyra/pipeline/tests/test_pipeline_parser.py
+++ b/elyra/pipeline/tests/test_pipeline_parser.py
@@ -44,7 +44,7 @@ def test_missing_primary():
     pipeline_definition = _read_pipeline_resource('pipeline_invalid.json')
     pipeline_definition.pop('primary_pipeline')
 
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ValueError):
         PipelineParser.parse(pipeline_definition)
 
 
@@ -52,7 +52,7 @@ def test_missing_pipelines():
     pipeline_definition = _read_pipeline_resource('pipeline_invalid.json')
     pipeline_definition.pop('pipelines')
 
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ValueError):
         PipelineParser.parse(pipeline_definition)
 
 
@@ -61,7 +61,7 @@ def test_missing_primary_id():
     # Replace pipeline id with non-matching guid so primary is not found
     pipeline_definition['pipelines'][0]['id'] = "deadbeef-dead-beef-dead-beefdeadbeef"
 
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ValueError):
         PipelineParser.parse(pipeline_definition)
 
 
@@ -69,7 +69,7 @@ def test_zero_nodes():
     pipeline_definition = _read_pipeline_resource('pipeline_invalid.json')
     pipeline_definition['pipelines'][0]['nodes'] = []
 
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ValueError):
         PipelineParser.parse(pipeline_definition)
 
 
@@ -84,14 +84,14 @@ def test_multinode_pipeline():
 def test_supernode_pipelinen():
     pipeline_definition = _read_pipeline_resource('pipeline_with_supernode.json')
 
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ValueError):
         PipelineParser.parse(pipeline_definition)
 
 
 def test_multiple_pipeline_definition():
     pipeline_definition = _read_pipeline_resource('pipeline_multiple_pipeline_definitions.json')
 
-    with pytest.raises(SyntaxError):
+    with pytest.raises(ValueError):
         PipelineParser.parse(pipeline_definition)
 
 
@@ -129,7 +129,7 @@ def test_missing_pipeline_title():
     pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
     pipeline_definition['pipelines'][0]['app_data']['title'] = ''
 
-    with pytest.raises(SyntaxError) as e:
+    with pytest.raises(ValueError) as e:
         PipelineParser.parse(pipeline_definition)
 
     assert "Invalid pipeline: Missing title" in str(e.value)
@@ -139,7 +139,7 @@ def test_missing_pipeline_runtime():
     pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
     pipeline_definition['pipelines'][0]['app_data']['runtime'] = ''
 
-    with pytest.raises(SyntaxError) as e:
+    with pytest.raises(ValueError) as e:
         PipelineParser.parse(pipeline_definition)
 
     assert "Invalid pipeline: Missing runtime" in str(e.value)
@@ -149,7 +149,7 @@ def test_missing_pipeline_runtime_configuration():
     pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
     pipeline_definition['pipelines'][0]['app_data']['runtime-config'] = ''
 
-    with pytest.raises(SyntaxError) as e:
+    with pytest.raises(ValueError) as e:
         PipelineParser.parse(pipeline_definition)
 
     assert "Invalid pipeline: Missing runtime configuration" in str(e.value)
@@ -159,7 +159,7 @@ def test_missing_operation_id():
     pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
     pipeline_definition['pipelines'][0]['nodes'][0]['id'] = ''
 
-    with pytest.raises(SyntaxError) as e:
+    with pytest.raises(ValueError) as e:
         PipelineParser.parse(pipeline_definition)
 
     assert "Missing field 'operation id'" in str(e.value)
@@ -169,7 +169,7 @@ def test_missing_operation_type():
     pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
     pipeline_definition['pipelines'][0]['nodes'][0]['type'] = ''
 
-    with pytest.raises(SyntaxError) as e:
+    with pytest.raises(ValueError) as e:
         PipelineParser.parse(pipeline_definition)
 
     assert "Missing field 'operation type'" in str(e.value)
@@ -179,7 +179,7 @@ def test_missing_operation_artifact():
     pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
     pipeline_definition['pipelines'][0]['nodes'][0]['app_data']['artifact'] = ''
 
-    with pytest.raises(SyntaxError) as e:
+    with pytest.raises(ValueError) as e:
         PipelineParser.parse(pipeline_definition)
 
     assert "Missing field 'operation artifact" in str(e.value)
@@ -189,7 +189,7 @@ def test_missing_operation_image():
     pipeline_definition = _read_pipeline_resource('pipeline_valid.json')
     pipeline_definition['pipelines'][0]['nodes'][0]['app_data']['image'] = ''
 
-    with pytest.raises(SyntaxError) as e:
+    with pytest.raises(ValueError) as e:
         PipelineParser.parse(pipeline_definition)
 
     assert "Missing field 'operation image'" in str(e.value)


### PR DESCRIPTION
Add additional validation to pipeline parser to make
sure submitted pipelines have required operation
fields such as artifact (notebook) to process and
environment (docker image) to use while processing
the artifact (notebook)
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

