### PR TITLE
Align headers for metadata list CLI

### DIFF
--- a/elyra/metadata/metadata_app.py
+++ b/elyra/metadata/metadata_app.py
@@ -99,8 +99,12 @@ class NamespaceList(NamespaceBase):
                 max_resource_len = max(len(instance.resource), max_resource_len)
 
             print()
-            print("%s   %s  %s  " % ('Schema', 'Instance', 'Resource'))
-            print("%s   %s  %s  " % ('------', '--------', '--------'))
+            print("%s   %s  %s  " % ('Schema'.ljust(max_schema_name_len),
+                                     'Instance'.ljust(max_name_len),
+                                     'Resource'.ljust(max_resource_len)))
+            print("%s   %s  %s  " % ('------'.ljust(max_schema_name_len),
+                                     '--------'.ljust(max_name_len),
+                                     '--------'.ljust(max_resource_len)))
             for instance in sorted_instances:
                 invalid = ""
                 if instance.reason and len(instance.reason) > 0:


### PR DESCRIPTION
Properly align headers when displaying the metadata list using the CLI

Fixes: #508 

Before:
```
(elyra-py37) vaughan:elyra va$ elyra-metadata list runtime-images
Available metadata instances for runtime-images (includes invalid):

Schema  Instance  Resource                                                                                                        
------  --------  --------                                                                                                        
runtime-image   anaconda               /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/anaconda.json               
runtime-image   miniconda              /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/miniconda.json              
runtime-image   pandas                 /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/pandas.json                 
runtime-image   pytorch-devel          /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/pytorch-devel.json          
runtime-image   pytorch-runtime        /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/pytorch-runtime.json        
runtime-image   tensorflow_2x_gpu_py3  /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/tensorflow_2x_gpu_py3.json  
runtime-image   tensorflow_2x_py3      /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/tensorflow_2x_py3.json      
runtime-image   tensorflow_gpu_py3     /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/tensorflow_gpu_py3.json     
runtime-image   tensorflow_py3         /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/tensorflow_py3.json         
(elyra-py37) vaughan:elyra va$ 
```

After:
```
(elyra-py37) vaughan:elyra va$ elyra-metadata list runtime-images
Available metadata instances for runtime-images (includes invalid):

Schema          Instance               Resource                                                                                                        
------          --------               --------                                                                                                        
runtime-image   anaconda               /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/anaconda.json               
runtime-image   miniconda              /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/miniconda.json              
runtime-image   pandas                 /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/pandas.json                 
runtime-image   pytorch-devel          /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/pytorch-devel.json          
runtime-image   pytorch-runtime        /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/pytorch-runtime.json        
runtime-image   tensorflow_2x_gpu_py3  /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/tensorflow_2x_gpu_py3.json  
runtime-image   tensorflow_2x_py3      /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/tensorflow_2x_py3.json      
runtime-image   tensorflow_gpu_py3     /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/tensorflow_gpu_py3.json     
runtime-image   tensorflow_py3         /Users/va/blue/tools/anaconda/envs/elyra-py37/share/jupyter/metadata/runtime-images/tensorflow_py3.json         
(elyra-py37) vaughan:elyra va$ 
```

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

