### PR TITLE
Detect invalid json instances and log error

### DIFF
--- a/elyra/metadata/metadata.py
+++ b/elyra/metadata/metadata.py
@@ -261,7 +261,7 @@ class FileMetadataStore(MetadataStore):
         # Now that its written, attempt to load it so, if a schema is present, we can validate it.
         try:
             self._load_from_resource(resource)
-        except ValidationError:
+        except (ValidationError, ValueError):
             self.log.error("Removing metadata resource '{}' due to previous error.".format(resource))
             # If we just created the directory, include that during cleanup
             if created_namespace_dir:
@@ -343,12 +343,22 @@ class FileMetadataStore(MetadataStore):
 
     def _load_from_resource(self, resource, validate_metadata=True, include_invalid=False):
         # This is always called with an existing resource (path) so no need to check existence.
-        self.log.debug("Loading metadata resource from: '{}'".format(resource))
-        with io.open(resource, 'r', encoding='utf-8') as f:
-            metadata_json = json.load(f)
 
         # Always take name from resource so resources can be copied w/o having to change content
         name = os.path.splitext(os.path.basename(resource))[0]
+
+        self.log.debug("Loading metadata resource from: '{}'".format(resource))
+        with io.open(resource, 'r', encoding='utf-8') as f:
+            try:
+                metadata_json = json.load(f)
+            except ValueError as jde:  # JSONDecodeError is raised, but it derives from ValueError
+                # If the JSON file cannot load, there's nothing we can do other than log and raise since
+                # we aren't able to even instantiate an instance of Metadata.  Because errors are ignored
+                # when getting multiple items, it's okay to raise.  The singleton searches (by handlers)
+                # already catch ValueError and map to 404, so we're good there as well.
+                self.log.error("JSON failed to load for metadata '{}' in namespace '{}' with error: {}.".
+                               format(name, self.namespace, jde))
+                raise jde
 
         reason = None
         if validate_metadata:


### PR DESCRIPTION
Although there's nothing we can do wrt to invalid JSON, we _can_ log an error message.  This should only happen when manually creating an instance (outside tools and REST API).

When mixed with actual schema validation exceptions, the log entries will look like this in such cases, but the instances will not be included in the results.
Log Entries...
```
[E 2020-05-13 10:36:52,191.191] Schema validation failed for metadata 'foofoo' in namespace 'runtimes' with error: None is not of type 'string'.
[E 2020-05-13 10:36:52,198.198] Schema validation failed for metadata 'barbar' in namespace 'runtimes' with error: 'xxx' is too short.
[E 2020-05-13 10:36:52,201.201] JSON failed to load for metadata 'foo' in namespace 'runtimes' with error: Expecting ',' delimiter: line 10 column 5 (char 318).
[E 2020-05-13 10:36:58,946.946] JSON failed to load for metadata 'another' in namespace 'runtimes' with error: Expecting property name enclosed in double quotes: line 2 column 5 (char 6).
[E 2020-05-13 10:36:59,477.477] JSON failed to load for metadata 'invalid' in namespace 'runtimes' with error: Expecting property name enclosed in double quotes: line 2 column 5 (char 6).
[E 2020-05-13 10:36:59,996.996] JSON failed to load for metadata 'valid' in namespace 'runtimes' with error: Expecting property name enclosed in double quotes: line 2 column 5 (char 6).
```
Results:
```
Available metadata instances for runtimes (includes invalid):

Schema   Instance  Resource                                                     
------   --------  --------                                                     
kfp      barbar    /Users/kbates/Library/Jupyter/metadata/runtimes/barbar.json  **INVALID** (ValidationError)
kfp      foodoo    /Users/kbates/Library/Jupyter/metadata/runtimes/foodoo.json  
kfp      foofoo    /Users/kbates/Library/Jupyter/metadata/runtimes/foofoo.json  **INVALID** (ValidationError)
kfp      kf_1      /Users/kbates/Library/Jupyter/metadata/runtimes/kf_1.json    
```
Fixes #522



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

