### PR TITLE
Fix pipeline op dependencies propagation

### DIFF
--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -174,7 +174,7 @@ class KfpPipelineProcessor(PipelineProcessor):
                                      cos_directory=cos_directory,
                                      cos_pull_archive=operation_artifact_archive,
                                      pipeline_outputs=self._artifact_list_to_str(operation.outputs),
-                                     pipeline_inputs=self._artifact_list_to_str(operation.inputs),
+                                     pipeline_inputs=self._artifact_list_to_str(operation.file_dependencies),
                                      image=operation.image)
 
             notebook_op.container.add_env_variable(V1EnvVar(name='AWS_ACCESS_KEY_ID', value=cos_username))

--- a/elyra/pipeline/tests/pipeline_valid.json
+++ b/elyra/pipeline/tests/pipeline_valid.json
@@ -11,9 +11,13 @@
         {
           "id": "{{uuid}}",
           "type": "{{type}}",
+          "op": "{{op}}",
           "app_data": {
             "artifact": "{{artifact}}",
             "image": "{{image}}",
+            "vars": ["var1=var1", "var2=var2"],
+            "dependencies": ["a.txt", "b.txt", "c.txt"],
+            "outputs": ["d.txt", "e.txt", "f.txt"],
             "ui_data": {
               "label": "{{title}}",
               "x_pos": 75,

--- a/elyra/pipeline/tests/test_pipeline_parser.py
+++ b/elyra/pipeline/tests/test_pipeline_parser.py
@@ -27,7 +27,11 @@ def valid_operation():
                      type='{{type}}',
                      title='{{title}}',
                      artifact='{{artifact}}',
-                     image='{{image}}')
+                     image='{{image}}',
+                     vars=["var1=var1", "var2=var2"],
+                     file_dependencies=["a.txt", "b.txt", "c.txt"],
+                     outputs=["d.txt", "e.txt", "f.txt"],
+                     )
 
 
 def test_valid_pipeline(valid_operation):


### PR DESCRIPTION
Dependencies required by a Notebook in pipeline editor was
not being properly propagated all way to the notebook operation,
thus failing the execution of notebooks that require external 
dependencies from object storage.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

