### PR TITLE
Add support for writable metadata via REST and hierarchical location behavior

### DIFF
--- a/elyra/api/elyra.yaml
+++ b/elyra/api/elyra.yaml
@@ -235,6 +235,8 @@ paths:
             application/json:
               schema:
                 type: string
+        400:
+          description: The operation is not supported
         404:
           description: The resource to update was not found
         500:

--- a/elyra/api/elyra.yaml
+++ b/elyra/api/elyra.yaml
@@ -138,6 +138,39 @@ paths:
           content: {}
         500:
           description: Unexpected error.
+    post:
+      tags:
+      - metadata
+      summary: Create a metadata instance in a given namespace
+      parameters:
+      - name: namespace
+        in: path
+        description: The name of the namespace
+        required: true
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MetadataResourceBodyPost'
+
+      responses:
+        201:
+          description: Returns the resource (path) to the created instance
+          content:
+            application/json:
+              schema:
+                type: string
+        400:
+          description: An error (validation, syntax) occurred relative to the instance data
+        404:
+          description: Namespace not found
+        409:
+          description: Resource already exists
+        500:
+          description: Unexpected error.
 
   /api/metadata/{namespace}/{resource}:
     get:
@@ -171,9 +204,121 @@ paths:
         500:
           description: Unexpected error.
 
+    put:
+      tags:
+        - metadata
+      summary: Update a given metadata resource within a given namespace
+      parameters:
+        - name: namespace
+          in: path
+          description: The name of the namespace
+          required: true
+          schema:
+            type: string
+        - name: resource
+          in: path
+          description: The name of the resource in a given namespace
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MetadataResourceBodyPut'
+
+      responses:
+        200:
+          description: Returns the resource (path) of the updated instance
+          content:
+            application/json:
+              schema:
+                type: string
+        404:
+          description: The resource to update was not found
+        500:
+          description: Unexpected error.
+
+    delete:
+      tags:
+      - metadata
+      summary: Delete a given metadata resource from a given namespace
+      parameters:
+      - name: namespace
+        in: path
+        description: The name of the namespace
+        required: true
+        schema:
+          type: string
+      - name: resource
+        in: path
+        description: The name of the resource in a given namespace
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Returns the resource (path) of the deleted instance
+          content:
+            application/json:
+              schema:
+                type: string
+        403:
+          description: Deletion of the resource is not permitted
+        404:
+          description: The resource was not found
+        500:
+          description: Unexpected error.
+
+
 components:
   schemas:
+    MetadataResourceBodyPost:
+      description: The set of properties comprising the request body for POST
+      required:
+        - display_name
+        - name
+        - schema_name
+        - metadata
+      type: object
+      properties:
+        name:
+          type: string
+          description: The canonical name of the resource
+        display_name:
+          type: string
+          description: The display name of the resource
+        schema_name:
+          type: string
+          description: The schema name used to validate the resource
+        metadata:
+          type: object
+          properties: {}
+          description: A free-form dictionary consisting of additional information
+            about the resource.
+
+    MetadataResourceBodyPut:
+      description: The set of properties comprising the request body for PUT; no field is required
+      type: object
+      properties:
+        name:
+          type: string
+          description: The canonical name of the resource
+        display_name:
+          type: string
+          description: The display name of the resource
+        schema_name:
+          type: string
+          description: The schema name used to validate the resource
+        metadata:
+          type: object
+          properties: {}
+          description: A free-form dictionary consisting of additional information
+            about the resource.
+
     MetadataResource:
+      description: The set of properties comprising a metadata resource entity
       required:
       - display_name
       - name
@@ -198,8 +343,9 @@ components:
           properties: {}
           description: A free-form dictionary consisting of additional information
             about the resource.
-      description: The set of properties comprising a namespace resource entity
+
     SchemaResource:
+      description: The set of properties comprising a schema resource entity
       required:
       - name
       - namespace
@@ -216,7 +362,7 @@ components:
           properties: {}
           description: A free-form dictionary consisting of additional information
             about the resource.
-      description: The set of properties comprising a namespace resource entity
+
   parameters:
     namespace:
       name: namespace

--- a/elyra/api/elyra.yaml
+++ b/elyra/api/elyra.yaml
@@ -67,7 +67,7 @@ paths:
                 properties:
                   namespace:
                     type: array
-                    description: The name of the namespace.
+                    description: The schema instances within the namespace
                     items:
                       $ref: '#/components/schemas/SchemaResource'
         404:
@@ -96,8 +96,7 @@ paths:
           type: string
       responses:
         200:
-          description: Returns the schema instance for a given resource in a given
-            namespace
+          description: The named schema instance within the namespace
           content:
             application/json:
               schema:
@@ -122,7 +121,7 @@ paths:
           type: string
       responses:
         200:
-          description: Returns the metadata instances for a given namespace
+          description: The metadata instances within the namespace
           content:
             application/json:
               schema:
@@ -158,11 +157,11 @@ paths:
 
       responses:
         201:
-          description: Returns the resource (path) to the created instance
+          description: The newly-created metadata instance
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/MetadataResource'
         400:
           description: An error (validation, syntax) occurred relative to the instance data
         404:
@@ -192,8 +191,7 @@ paths:
           type: string
       responses:
         200:
-          description: Returns the metadata instances for a given resource in a given
-            namespace
+          description: The named metadata instance within the namespace
           content:
             application/json:
               schema:
@@ -230,11 +228,11 @@ paths:
 
       responses:
         200:
-          description: Returns the resource (path) of the updated instance
+          description: The updated metadata instance
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/MetadataResource'
         400:
           description: The operation is not supported
         404:
@@ -261,11 +259,11 @@ paths:
           type: string
       responses:
         200:
-          description: Returns the resource (path) of the deleted instance
+          description: The deleted metadata instance
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/MetadataResource'
         403:
           description: Deletion of the resource is not permitted
         404:
@@ -329,17 +327,13 @@ components:
       properties:
         name:
           type: string
-          description: The canonical name of the resource
+          description: The canonical name of the metadata resource
         display_name:
           type: string
-          description: The display name of the resource
+          description: The display name of the metadata resource
         schema_name:
           type: string
-          description: The schema name used to validate the resource
-        resource:
-          type: string
-          description: Path to json file containing resource definition
-          format: filename
+          description: The schema name used to validate the metadata resource
         metadata:
           type: object
           properties: {}
@@ -355,10 +349,13 @@ components:
       properties:
         namespace:
           type: string
-          description: The namespace of the resource
+          description: The namespace of the schema resource
         name:
           type: string
-          description: The canonical name of the resource
+          description: The canonical name of the schema resource
+        title:
+          type: string
+          description: The title of the schema resource
         properties:
           type: object
           properties: {}

--- a/elyra/metadata/handlers.py
+++ b/elyra/metadata/handlers.py
@@ -122,8 +122,6 @@ class MetadataResourceHandler(HttpErrorMixin, APIHandler):
             model = metadata_manager.add(resource, instance, replace=True)
         except (ValidationError, ValueError, FileNotFoundError) as err:
             raise web.HTTPError(404, str(err))
-        except FileExistsError as err:
-            raise web.HTTPError(409, str(err))
         except Exception as ex:
             raise web.HTTPError(500, repr(ex))
 

--- a/elyra/metadata/handlers.py
+++ b/elyra/metadata/handlers.py
@@ -116,10 +116,16 @@ class MetadataResourceHandler(HttpErrorMixin, APIHandler):
             # convert to dictionary and update current with desired changes
             updates = current.to_dict()
             updates.update(payload)
+            # Check if name is in the payload and varies from resource, if so, raise 400
+            if 'name' in payload and payload['name'] != resource:
+                raise NotImplementedError("The attempt to rename instance '{}' to '{}' is not supported.".
+                                          format(resource, payload['name']))
             instance = Metadata(**updates)
             self.log.debug("MetadataHandler: Updating metadata instance '{}' in namespace '{}'...".
                            format(resource, namespace))
             model = metadata_manager.add(resource, instance, replace=True)
+        except (NotImplementedError) as err:
+            raise web.HTTPError(400, str(err))
         except (ValidationError, ValueError, FileNotFoundError) as err:
             raise web.HTTPError(404, str(err))
         except Exception as ex:

--- a/elyra/metadata/metadata.py
+++ b/elyra/metadata/metadata.py
@@ -329,9 +329,20 @@ class FileMetadataStore(MetadataStore):
 
         resource = metadata.resource
         if resource:
+            # Since multiple folders are in play, we only allow removal if the resource is in
+            # the first directory in the list (i.e., most "near" the user)
+            if not self._remove_allowed(metadata):
+                raise PermissionError("Removal of metadata resource '{}' in namespace '{}' is not permitted!".
+                                      format(resource, self.namespace))
             os.remove(resource)
 
         return resource
+
+    def _remove_allowed(self, metadata):
+        """Determines if the resource of the given instance is allowed to be removed. """
+        allowed_resource = os.path.join(self.preferred_metadata_dir, metadata.name)
+        current_resource = os.path.splitext(metadata.resource)[0]
+        return allowed_resource == current_resource
 
     def _load_metadata_resources(self, name=None, validate_metadata=True, include_invalid=False):
         """Loads metadata files with .json suffix and return requested items.

--- a/elyra/metadata/metadata.py
+++ b/elyra/metadata/metadata.py
@@ -156,7 +156,7 @@ class MetadataManager(LoggingConfigurable):
     def get(self, name):
         return self.metadata_store.read(name)
 
-    def add(self, name, metadata, replace=True):
+    def add(self, name, metadata, replace=False):
         return self.metadata_store.save(name, metadata, replace)
 
     def remove(self, name):
@@ -194,7 +194,7 @@ class MetadataStore(ABC):
         pass
 
     @abstractmethod
-    def save(self, name, metadata, replace=True):
+    def save(self, name, metadata, replace=False):
         pass
 
     @abstractmethod
@@ -260,7 +260,7 @@ class FileMetadataStore(MetadataStore):
             raise ValueError('Name of metadata was not provided')
         return self._load_metadata_resources(name=name)
 
-    def save(self, name, metadata, replace=True):
+    def save(self, name, metadata, replace=False):
         if not name:
             raise ValueError('Name of metadata was not provided.')
 

--- a/elyra/metadata/metadata.py
+++ b/elyra/metadata/metadata.py
@@ -317,7 +317,7 @@ class FileMetadataStore(MetadataStore):
         # Now that its written, attempt to load it so, if a schema is present, we can validate it.
         try:
             self._load_from_resource(resource)
-        except (ValidationError, ValueError) as ve:
+        except (ValidationError, ValueError, FileNotFoundError) as ve:
             self.log.error("Removing metadata resource '{}' due to previous error.".format(resource))
             # If we just created the directory, include that during cleanup
             if created_namespace_dir:
@@ -330,11 +330,9 @@ class FileMetadataStore(MetadataStore):
 
     def remove(self, name):
         self.log.info("Removing metadata resource '{}' from namespace '{}'.".format(name, self.namespace))
-        try:
-            metadata = self._load_metadata_resources(name=name, validate_metadata=False)  # Don't validate on remove
-        except FileNotFoundError:
-            self.log.warning("Metadata resource '{}' in namespace '{}' was not found!".format(name, self.namespace))
-            return
+
+        # Let exceptions (FileNotFound) propagate
+        metadata = self._load_metadata_resources(name=name, validate_metadata=False)  # Don't validate on remove
 
         resource = metadata.resource
         if resource:

--- a/elyra/metadata/metadata_app.py
+++ b/elyra/metadata/metadata_app.py
@@ -67,7 +67,7 @@ class NamespaceList(NamespaceBase):
         include_invalid = not self.valid_only_flag.value
         try:
             metadata_instances = self.metadata_manager.get_all_metadata_summary(include_invalid=include_invalid)
-        except KeyError:
+        except FileNotFoundError:
             metadata_instances = None
 
         if not metadata_instances:
@@ -129,7 +129,7 @@ class NamespaceRemove(NamespaceBase):
         name = self.name_option.value
         try:
             self.metadata_manager.get(name)
-        except KeyError as ke:
+        except FileNotFoundError as ke:
             self.log_and_exit(ke)
         except ValidationError:  # Probably deleting invalid instance
             pass

--- a/elyra/metadata/metadata_app.py
+++ b/elyra/metadata/metadata_app.py
@@ -71,8 +71,8 @@ class NamespaceList(NamespaceBase):
             metadata_instances = None
 
         if not metadata_instances:
-            print("No metadata instances available for {} at: '{}'"
-                  .format(self.namespace, self.metadata_manager.get_metadata_location))
+            print("No metadata instances available for {} in: '{}'"
+                  .format(self.namespace, self.metadata_manager.get_metadata_locations))
             return
 
         validity_clause = "includes invalid" if include_invalid else "valid only"

--- a/elyra/metadata/tests/conftest.py
+++ b/elyra/metadata/tests/conftest.py
@@ -21,7 +21,7 @@ import jupyter_core.paths
 
 from notebook.utils import url_path_join
 from tornado.escape import url_escape
-from elyra.metadata.metadata import MetadataManager, FileMetadataStore, SchemaManager, METADATA_TEST_NAMESPACE
+from elyra.metadata import MetadataManager, FileMetadataStore, SchemaManager, METADATA_TEST_NAMESPACE
 from .test_utils import valid_metadata_json, invalid_metadata_json, another_metadata_json, create_json_file
 
 

--- a/elyra/metadata/tests/conftest.py
+++ b/elyra/metadata/tests/conftest.py
@@ -120,6 +120,7 @@ def setup_hierarchy(environ, factory_dir):
     create_json_file(factory_dir, 'byo_2.json', byo_instance)
     create_json_file(factory_dir, 'byo_3.json', byo_instance)
 
+
 @pytest.fixture
 def tests_manager(setup_namespace):
     return MetadataManager(namespace=METADATA_TEST_NAMESPACE)

--- a/elyra/metadata/tests/conftest.py
+++ b/elyra/metadata/tests/conftest.py
@@ -22,7 +22,8 @@ import jupyter_core.paths
 from notebook.utils import url_path_join
 from tornado.escape import url_escape
 from elyra.metadata import MetadataManager, FileMetadataStore, SchemaManager, METADATA_TEST_NAMESPACE
-from .test_utils import valid_metadata_json, invalid_metadata_json, another_metadata_json, create_json_file
+from .test_utils import valid_metadata_json, invalid_metadata_json, another_metadata_json, byo_metadata_json, \
+    create_json_file
 
 
 # BEGIN - Remove once transition to jupyter_server occurs
@@ -40,16 +41,10 @@ config_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "config"))
 runtime_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "runtime"))
 root_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "root_dir"))
 template_dir = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "templates"))
-system_jupyter_path = pytest.fixture(
-    lambda tmp_path: mkdir(tmp_path, "share", "jupyter")
-)
-env_jupyter_path = pytest.fixture(
-    lambda tmp_path: mkdir(tmp_path, "env", "share", "jupyter")
-)
+system_jupyter_path = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "share", "jupyter"))
+env_jupyter_path = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "env", "share", "jupyter"))
 system_config_path = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "etc", "jupyter"))
-env_config_path = pytest.fixture(
-    lambda tmp_path: mkdir(tmp_path, "env", "etc", "jupyter")
-)
+env_config_path = pytest.fixture(lambda tmp_path: mkdir(tmp_path, "env", "etc", "jupyter"))
 
 
 @pytest.fixture
@@ -73,13 +68,9 @@ def environ(
     monkeypatch.setenv("JUPYTER_DATA_DIR", str(data_dir))
     monkeypatch.setenv("JUPYTER_RUNTIME_DIR", str(runtime_dir))
     monkeypatch.setenv("METADATA_TESTING", "1")  # enable metadata-tests namespace
-    monkeypatch.setattr(
-        jupyter_core.paths, "SYSTEM_JUPYTER_PATH", [str(system_jupyter_path)]
-    )
+    monkeypatch.setattr(jupyter_core.paths, "SYSTEM_JUPYTER_PATH", [str(system_jupyter_path)])
     monkeypatch.setattr(jupyter_core.paths, "ENV_JUPYTER_PATH", [str(env_jupyter_path)])
-    monkeypatch.setattr(
-        jupyter_core.paths, "SYSTEM_CONFIG_PATH", [str(system_config_path)]
-    )
+    monkeypatch.setattr(jupyter_core.paths, "SYSTEM_CONFIG_PATH", [str(system_config_path)])
     monkeypatch.setattr(jupyter_core.paths, "ENV_CONFIG_PATH", [str(env_config_path)])
 
 
@@ -109,6 +100,8 @@ def fetch(request, *parts, **kwargs):
 
 metadata_tests_dir = pytest.fixture(lambda data_dir: mkdir(data_dir, "metadata", METADATA_TEST_NAMESPACE))
 metadata_bogus_dir = pytest.fixture(lambda data_dir: mkdir(data_dir, "metadata", "bogus"))
+shared_dir = pytest.fixture(lambda system_jupyter_path: mkdir(system_jupyter_path, "metadata", METADATA_TEST_NAMESPACE))
+factory_dir = pytest.fixture(lambda env_jupyter_path: mkdir(env_jupyter_path, "metadata", METADATA_TEST_NAMESPACE))
 
 
 @pytest.fixture
@@ -119,7 +112,21 @@ def setup_namespace(environ, metadata_tests_dir):
 
 
 @pytest.fixture
+def setup_hierarchy(environ, factory_dir):
+    # Only populate factory info
+    byo_instance = byo_metadata_json
+    byo_instance['display_name'] = 'factory'
+    create_json_file(factory_dir, 'byo_1.json', byo_instance)
+    create_json_file(factory_dir, 'byo_2.json', byo_instance)
+    create_json_file(factory_dir, 'byo_3.json', byo_instance)
+
+@pytest.fixture
 def tests_manager(setup_namespace):
+    return MetadataManager(namespace=METADATA_TEST_NAMESPACE)
+
+
+@pytest.fixture
+def tests_hierarchy_manager(setup_hierarchy):
     return MetadataManager(namespace=METADATA_TEST_NAMESPACE)
 
 

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -143,9 +143,9 @@ def test_manager_add_remove_valid(tests_manager, metadata_tests_dir):
 
     # Attempt to create again w/o replace, then replace it.
     with pytest.raises(PermissionError):
-        tests_manager.add(metadata_name, metadata, replace=False)
+        tests_manager.add(metadata_name, metadata)
 
-    resource = tests_manager.add(metadata_name, metadata)
+    resource = tests_manager.add(metadata_name, metadata, replace=True)
     assert resource is not None
 
     # And finally, remove it.
@@ -280,7 +280,10 @@ def test_manager_hierarchy_create(tests_hierarchy_manager, metadata_tests_dir):
     # Create a copy of existing factory instance and ensure its in the user area
     metadata = Metadata(**byo_metadata_json)
     metadata.display_name = 'user'
-    resource = tests_hierarchy_manager.add('byo_2', metadata)
+    with pytest.raises(PermissionError):
+        resource = tests_hierarchy_manager.add('byo_2', metadata)
+
+    resource = tests_hierarchy_manager.add('byo_2', metadata, replace=True)
     assert resource is not None
     assert resource.startswith(str(metadata_tests_dir))
 
@@ -300,7 +303,7 @@ def test_manager_hierarchy_create(tests_hierarchy_manager, metadata_tests_dir):
 
     metadata = Metadata(**byo_metadata_json)
     metadata.display_name = 'user'
-    resource = tests_hierarchy_manager.add('byo_3', metadata)
+    resource = tests_hierarchy_manager.add('byo_3', metadata, replace=True)
     assert resource is not None
     assert resource.startswith(str(metadata_tests_dir))
 
@@ -327,7 +330,7 @@ def test_manager_hierarchy_update(tests_hierarchy_manager, factory_dir, shared_d
 
     byo_2.display_name = 'user'
     with pytest.raises(PermissionError):
-        tests_hierarchy_manager.add('byo_2', byo_2, replace=False)
+        tests_hierarchy_manager.add('byo_2', byo_2)
 
     # Repeat with replacement enabled
     resource = tests_hierarchy_manager.add('byo_2', byo_2, replace=True)
@@ -360,7 +363,7 @@ def test_manager_hierarchy_remove(tests_hierarchy_manager, factory_dir, shared_d
 
     metadata = Metadata(**byo_metadata_json)
     metadata.display_name = 'user'
-    resource = tests_hierarchy_manager.add('byo_2', metadata)
+    resource = tests_hierarchy_manager.add('byo_2', metadata, replace=True)
     assert resource is not None
     assert resource.startswith(str(metadata_tests_dir))
 

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -125,8 +125,8 @@ def test_manager_add_remove_valid(tests_manager, metadata_tests_dir):
 
     metadata = Metadata(**valid_metadata_json)
 
-    resource = tests_manager.add(metadata_name, metadata)
-    assert resource is not None
+    instance = tests_manager.add(metadata_name, metadata)
+    assert instance is not None
 
     # Ensure file was created
     metadata_file = os.path.join(metadata_tests_dir, 'valid_add_remove.json')
@@ -145,24 +145,24 @@ def test_manager_add_remove_valid(tests_manager, metadata_tests_dir):
     with pytest.raises(FileExistsError):
         tests_manager.add(metadata_name, metadata)
 
-    resource = tests_manager.add(metadata_name, metadata, replace=True)
-    assert resource is not None
+    instance = tests_manager.add(metadata_name, metadata, replace=True)
+    assert instance is not None
 
     # And finally, remove it.
-    resource = tests_manager.remove(metadata_name)
+    instance = tests_manager.remove(metadata_name)
 
     assert not os.path.exists(metadata_file)
-    assert resource == metadata_file
+    assert instance.resource == metadata_file
 
 
 def test_manager_remove_invalid(tests_manager, metadata_tests_dir):
     # Ensure invalid metadata file isn't validated and is removed.
     create_json_file(metadata_tests_dir, 'remove_invalid.json', invalid_metadata_json)
     metadata_name = 'remove_invalid'
-    resource = tests_manager.remove(metadata_name)
+    instance = tests_manager.remove(metadata_name)
     metadata_file = os.path.join(metadata_tests_dir, 'remove_invalid.json')
     assert not os.path.exists(metadata_file)
-    assert resource == metadata_file
+    assert instance.resource == metadata_file
 
 
 def test_manager_remove_missing(tests_manager):
@@ -285,9 +285,9 @@ def test_manager_hierarchy_create(tests_hierarchy_manager, metadata_tests_dir):
     with pytest.raises(FileExistsError):
         tests_hierarchy_manager.add('byo_2', metadata)
 
-    resource = tests_hierarchy_manager.add('byo_2', metadata, replace=True)
-    assert resource is not None
-    assert resource.startswith(str(metadata_tests_dir))
+    instance = tests_hierarchy_manager.add('byo_2', metadata, replace=True)
+    assert instance is not None
+    assert instance.resource.startswith(str(metadata_tests_dir))
 
     metadata_list = tests_hierarchy_manager.get_all()
     assert len(metadata_list) == 3
@@ -305,9 +305,9 @@ def test_manager_hierarchy_create(tests_hierarchy_manager, metadata_tests_dir):
 
     metadata = Metadata(**byo_metadata_json)
     metadata.display_name = 'user'
-    resource = tests_hierarchy_manager.add('byo_3', metadata, replace=True)
-    assert resource is not None
-    assert resource.startswith(str(metadata_tests_dir))
+    instance = tests_hierarchy_manager.add('byo_3', metadata, replace=True)
+    assert instance is not None
+    assert instance.resource.startswith(str(metadata_tests_dir))
 
     metadata_list = tests_hierarchy_manager.get_all()
     assert len(metadata_list) == 3
@@ -335,9 +335,9 @@ def test_manager_hierarchy_update(tests_hierarchy_manager, factory_dir, shared_d
         tests_hierarchy_manager.add('byo_2', byo_2)
 
     # Repeat with replacement enabled
-    resource = tests_hierarchy_manager.add('byo_2', byo_2, replace=True)
-    assert resource is not None
-    assert resource.startswith(str(metadata_tests_dir))
+    instance = tests_hierarchy_manager.add('byo_2', byo_2, replace=True)
+    assert instance is not None
+    assert instance.resource.startswith(str(metadata_tests_dir))
 
     # now "slip in" a shared instance behind the updated version and ensure
     # the updated version is what's returned.
@@ -349,8 +349,8 @@ def test_manager_hierarchy_update(tests_hierarchy_manager, factory_dir, shared_d
     assert byo_2.resource.startswith(str(metadata_tests_dir))
 
     # now remove the updated instance and ensure the shared instance appears
-    resource = tests_hierarchy_manager.remove('byo_2')
-    assert resource == byo_2.resource
+    instance = tests_hierarchy_manager.remove('byo_2')
+    assert instance.resource == byo_2.resource
 
     byo_2 = tests_hierarchy_manager.get('byo_2')
     assert byo_2.resource.startswith(str(shared_dir))
@@ -365,9 +365,9 @@ def test_manager_hierarchy_remove(tests_hierarchy_manager, factory_dir, shared_d
 
     metadata = Metadata(**byo_metadata_json)
     metadata.display_name = 'user'
-    resource = tests_hierarchy_manager.add('byo_2', metadata, replace=True)
-    assert resource is not None
-    assert resource.startswith(str(metadata_tests_dir))
+    instance = tests_hierarchy_manager.add('byo_2', metadata, replace=True)
+    assert instance is not None
+    assert instance.resource.startswith(str(metadata_tests_dir))
 
     # Confirm on in user is found...
     metadata_list = tests_hierarchy_manager.get_all()
@@ -385,8 +385,8 @@ def test_manager_hierarchy_remove(tests_hierarchy_manager, factory_dir, shared_d
     assert byo_2.resource.startswith(str(metadata_tests_dir))
 
     # Now remove instance.  Should be allowed since it resides in user area
-    resource = tests_hierarchy_manager.remove('byo_2')
-    assert resource == byo_2.resource
+    instance = tests_hierarchy_manager.remove('byo_2')
+    assert instance.resource == byo_2.resource
 
     # Attempt to remove instance from shared area and its protected
     with pytest.raises(PermissionError) as pe:

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -142,8 +142,8 @@ def test_manager_add_remove_valid(tests_manager, metadata_tests_dir):
         assert valid_add['schema_name'] == "metadata-test"
 
     # Attempt to create again w/o replace, then replace it.
-    resource = tests_manager.add(metadata_name, metadata, replace=False)
-    assert resource is None
+    with pytest.raises(PermissionError):
+        tests_manager.add(metadata_name, metadata, replace=False)
 
     resource = tests_manager.add(metadata_name, metadata)
     assert resource is not None
@@ -326,8 +326,8 @@ def test_manager_hierarchy_update(tests_hierarchy_manager, factory_dir, shared_d
     assert byo_2.resource.startswith(str(factory_dir))
 
     byo_2.display_name = 'user'
-    resource = tests_hierarchy_manager.add('byo_2', byo_2, replace=False)
-    assert resource is None
+    with pytest.raises(PermissionError):
+        tests_hierarchy_manager.add('byo_2', byo_2, replace=False)
 
     # Repeat with replacement enabled
     resource = tests_hierarchy_manager.add('byo_2', byo_2, replace=True)

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -319,6 +319,38 @@ def test_manager_hierarchy_create(tests_hierarchy_manager, metadata_tests_dir):
     assert byo_2.resource.startswith(str(metadata_tests_dir))
 
 
+def test_manager_hierarchy_update(tests_hierarchy_manager, factory_dir, shared_dir, metadata_tests_dir):
+
+    # Create a copy of existing factory instance and ensure its in the user area
+    byo_2 = tests_hierarchy_manager.get('byo_2')
+    assert byo_2.resource.startswith(str(factory_dir))
+
+    byo_2.display_name = 'user'
+    resource = tests_hierarchy_manager.add('byo_2', byo_2, replace=False)
+    assert resource is None
+
+    # Repeat with replacement enabled
+    resource = tests_hierarchy_manager.add('byo_2', byo_2, replace=True)
+    assert resource is not None
+    assert resource.startswith(str(metadata_tests_dir))
+
+    # now "slip in" a shared instance behind the updated version and ensure
+    # the updated version is what's returned.
+    byo_instance = byo_metadata_json
+    byo_instance['display_name'] = 'shared'
+    create_json_file(shared_dir, 'byo_2.json', byo_instance)
+
+    byo_2 = tests_hierarchy_manager.get('byo_2')
+    assert byo_2.resource.startswith(str(metadata_tests_dir))
+
+    # now remove the updated instance and ensure the shared instance appears
+    resource = tests_hierarchy_manager.remove('byo_2')
+    assert resource == byo_2.resource
+
+    byo_2 = tests_hierarchy_manager.get('byo_2')
+    assert byo_2.resource.startswith(str(shared_dir))
+
+
 def test_manager_hierarchy_remove(tests_hierarchy_manager, factory_dir, shared_dir, metadata_tests_dir):
 
     # Create additional instances in shared and user areas

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -168,8 +168,8 @@ def test_manager_remove_invalid(tests_manager, metadata_tests_dir):
 def test_manager_remove_missing(tests_manager):
     # Ensure removal of missing metadata file is handled.
     metadata_name = 'missing'
-    resource = tests_manager.remove(metadata_name)
-    assert resource is None
+    with pytest.raises(FileNotFoundError):
+        tests_manager.remove(metadata_name)
 
 
 def test_manager_read_valid_by_name(tests_manager, metadata_tests_dir):

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -142,7 +142,7 @@ def test_manager_add_remove_valid(tests_manager, metadata_tests_dir):
         assert valid_add['schema_name'] == "metadata-test"
 
     # Attempt to create again w/o replace, then replace it.
-    with pytest.raises(PermissionError):
+    with pytest.raises(FileExistsError):
         tests_manager.add(metadata_name, metadata)
 
     resource = tests_manager.add(metadata_name, metadata, replace=True)
@@ -188,7 +188,7 @@ def test_manager_read_invalid_by_name(tests_manager):
 
 def test_manager_read_missing_by_name(tests_manager):
     metadata_name = 'missing'
-    with pytest.raises(KeyError):
+    with pytest.raises(FileNotFoundError):
         tests_manager.get(metadata_name)
 
 
@@ -277,11 +277,13 @@ def test_manager_hierarchy_fetch(tests_hierarchy_manager, factory_dir, shared_di
 
 def test_manager_hierarchy_create(tests_hierarchy_manager, metadata_tests_dir):
 
-    # Create a copy of existing factory instance and ensure its in the user area
+    # Note, this is really more of an update test (replace = True), since you cannot "create" an
+    # instance if it already exists - which, in this case, it exists in the factory area
+
     metadata = Metadata(**byo_metadata_json)
     metadata.display_name = 'user'
-    with pytest.raises(PermissionError):
-        resource = tests_hierarchy_manager.add('byo_2', metadata)
+    with pytest.raises(FileExistsError):
+        tests_hierarchy_manager.add('byo_2', metadata)
 
     resource = tests_hierarchy_manager.add('byo_2', metadata, replace=True)
     assert resource is not None
@@ -329,7 +331,7 @@ def test_manager_hierarchy_update(tests_hierarchy_manager, factory_dir, shared_d
     assert byo_2.resource.startswith(str(factory_dir))
 
     byo_2.display_name = 'user'
-    with pytest.raises(PermissionError):
+    with pytest.raises(FileExistsError):
         tests_hierarchy_manager.add('byo_2', byo_2)
 
     # Repeat with replacement enabled
@@ -453,7 +455,7 @@ def test_filestore_read_invalid_by_name(filestore):
 
 def test_filestore_read_missing_by_name(filestore):
     metadata_name = 'missing'
-    with pytest.raises(KeyError):
+    with pytest.raises(FileNotFoundError):
         filestore.read(metadata_name)
 
 
@@ -486,7 +488,7 @@ def test_schema_manager_all(schema_manager):
     assert bar_schema == modified_schema
 
     schema_manager.remove_schema(METADATA_TEST_NAMESPACE, "metadata-test")
-    with pytest.raises(KeyError):
+    with pytest.raises(FileNotFoundError):
         schema_manager.get_schema(METADATA_TEST_NAMESPACE, "metadata-test")
 
     schema_manager.clear_all()  # Ensure test schema has been restored

--- a/elyra/metadata/tests/test_metadata_app.py
+++ b/elyra/metadata/tests/test_metadata_app.py
@@ -28,7 +28,7 @@ os.environ["METADATA_TESTING"] = "1"  # Enable metadata-tests namespace
 
 
 @pytest.fixture()
-def mock_runtime_dir():
+def mock_data_dir():
     runtime_dir = mkdtemp(prefix="runtime_")
     orig_data_dir = os.environ.get("JUPYTER_DATA_DIR")
     os.environ["JUPYTER_DATA_DIR"] = runtime_dir
@@ -78,21 +78,21 @@ def test_install_help(script_runner):
     assert ret.stderr == ''
 
 
-def test_install_no_schema_name(script_runner, mock_runtime_dir):
+def test_install_no_schema_name(script_runner, mock_data_dir):
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_NAMESPACE)
     assert ret.success is False
     assert ret.stdout.startswith("'--schema_name' is a required parameter.")
     assert ret.stderr == ''
 
 
-def test_install_no_name(script_runner, mock_runtime_dir):
+def test_install_no_name(script_runner, mock_data_dir):
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_NAMESPACE, '--schema_name=metadata-test')
     assert ret.success is False
     assert ret.stdout.startswith("'--name' is a required parameter.")
     assert ret.stderr == ''
 
 
-def test_install_invalid_name(script_runner, mock_runtime_dir):
+def test_install_invalid_name(script_runner, mock_data_dir):
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_NAMESPACE, '--schema_name=metadata-test',
                             '--name=UPPER_CASE_NOT_ALLOWED', '--display_name=display_name',
                             '--required_test=required_value')
@@ -102,8 +102,8 @@ def test_install_invalid_name(script_runner, mock_runtime_dir):
     assert "Name of metadata must be lowercase alphanumeric" in ret.stdout
 
 
-def test_install_simple(script_runner, mock_runtime_dir):
-    expected_file = os.path.join(mock_runtime_dir, 'metadata', METADATA_TEST_NAMESPACE,
+def test_install_simple(script_runner, mock_data_dir):
+    expected_file = os.path.join(mock_data_dir, 'metadata', METADATA_TEST_NAMESPACE,
                                  'test-metadata_42_valid-name.json')
     # Cleanup from any potential previous failures
     if os.path.exists(expected_file):
@@ -115,7 +115,7 @@ def test_install_simple(script_runner, mock_runtime_dir):
     assert ret.success
     assert "Metadata instance 'test-metadata_42_valid-name' for schema 'metadata-test' has been written" in ret.stdout
 
-    assert os.path.isdir(os.path.join(mock_runtime_dir, 'metadata', METADATA_TEST_NAMESPACE))
+    assert os.path.isdir(os.path.join(mock_data_dir, 'metadata', METADATA_TEST_NAMESPACE))
     assert os.path.isfile(expected_file)
 
     with open(expected_file, "r") as fd:
@@ -126,8 +126,8 @@ def test_install_simple(script_runner, mock_runtime_dir):
         assert instance_json["metadata"]["number_default_test"] == 42  # defaults will always persist
 
 
-def test_install_and_replace(script_runner, mock_runtime_dir):
-    expected_file = os.path.join(mock_runtime_dir, 'metadata', METADATA_TEST_NAMESPACE,
+def test_install_and_replace(script_runner, mock_data_dir):
+    expected_file = os.path.join(mock_data_dir, 'metadata', METADATA_TEST_NAMESPACE,
                                  'test-metadata_42_valid-name.json')
     # Cleanup from any potential previous failures
     if os.path.exists(expected_file):
@@ -155,7 +155,7 @@ def test_install_and_replace(script_runner, mock_runtime_dir):
     assert ret.success
     assert "Metadata instance 'test-metadata_42_valid-name' for schema 'metadata-test' has been written" in ret.stdout
 
-    assert os.path.isdir(os.path.join(mock_runtime_dir, 'metadata', METADATA_TEST_NAMESPACE))
+    assert os.path.isdir(os.path.join(mock_data_dir, 'metadata', METADATA_TEST_NAMESPACE))
     assert os.path.isfile(expected_file)
 
     with open(expected_file, "r") as fd:
@@ -180,7 +180,7 @@ def test_list_bad_argument(script_runner):
     assert ret.stderr == ''
 
 
-def test_list_instances(script_runner, mock_runtime_dir):
+def test_list_instances(script_runner, mock_data_dir):
     metadata_manager = MetadataManager(namespace=METADATA_TEST_NAMESPACE)
 
     ret = script_runner.run('elyra-metadata', 'list', METADATA_TEST_NAMESPACE)
@@ -220,7 +220,7 @@ def test_list_instances(script_runner, mock_runtime_dir):
     metadata_manager.remove('valid2')
     metadata_manager.remove('another2')
     # Include an invalid file as well
-    metadata_dir = os.path.join(mock_runtime_dir, 'metadata', METADATA_TEST_NAMESPACE)
+    metadata_dir = os.path.join(mock_data_dir, 'metadata', METADATA_TEST_NAMESPACE)
     create_json_file(metadata_dir, 'invalid.json', invalid_metadata_json)
 
     ret = script_runner.run('elyra-metadata', 'list', METADATA_TEST_NAMESPACE)
@@ -275,7 +275,7 @@ def test_remove_missing(script_runner):
     assert ret.success
 
 
-def test_remove_instance(script_runner, mock_runtime_dir):
+def test_remove_instance(script_runner, mock_data_dir):
     metadata_manager = MetadataManager(namespace=METADATA_TEST_NAMESPACE)
 
     valid = Metadata(**valid_metadata_json)
@@ -303,11 +303,11 @@ def test_remove_instance(script_runner, mock_runtime_dir):
 
 # Begin property tests...
 
-def test_required(script_runner, mock_runtime_dir):
+def test_required(script_runner, mock_data_dir):
     # Doesn't use PropertyTester due to its unique test since all other tests require this property
     name = "required"
 
-    expected_file = os.path.join(mock_runtime_dir, 'metadata', METADATA_TEST_NAMESPACE, name + '.json')
+    expected_file = os.path.join(mock_data_dir, 'metadata', METADATA_TEST_NAMESPACE, name + '.json')
     # Cleanup from any potential previous failures
     if os.path.exists(expected_file):
         os.remove(expected_file)
@@ -325,7 +325,7 @@ def test_required(script_runner, mock_runtime_dir):
     assert ret.success
     assert "Metadata instance '" + name + "' for schema 'metadata-test' has been written" in ret.stdout
 
-    assert os.path.isdir(os.path.join(mock_runtime_dir, 'metadata', METADATA_TEST_NAMESPACE))
+    assert os.path.isdir(os.path.join(mock_data_dir, 'metadata', METADATA_TEST_NAMESPACE))
     assert os.path.isfile(expected_file)
 
     with open(expected_file, "r") as fd:
@@ -335,11 +335,11 @@ def test_required(script_runner, mock_runtime_dir):
         assert instance_json["metadata"]["required_test"] == "required_value"
 
 
-def test_number_default(script_runner, mock_runtime_dir):
+def test_number_default(script_runner, mock_data_dir):
     # Doesn't use PropertyTester due to its unique test (no failure, needs --replace, etc.)
     name = "number_default"
 
-    expected_file = os.path.join(mock_runtime_dir, 'metadata', METADATA_TEST_NAMESPACE, name + '.json')
+    expected_file = os.path.join(mock_data_dir, 'metadata', METADATA_TEST_NAMESPACE, name + '.json')
     # Cleanup from any potential previous failures
     if os.path.exists(expected_file):
         os.remove(expected_file)
@@ -352,7 +352,7 @@ def test_number_default(script_runner, mock_runtime_dir):
     assert ret.success
     assert "Metadata instance '" + name + "' for schema 'metadata-test' has been written" in ret.stdout
 
-    assert os.path.isdir(os.path.join(mock_runtime_dir, 'metadata', METADATA_TEST_NAMESPACE))
+    assert os.path.isdir(os.path.join(mock_data_dir, 'metadata', METADATA_TEST_NAMESPACE))
     assert os.path.isfile(expected_file)
 
     with open(expected_file, "r") as fd:
@@ -369,7 +369,7 @@ def test_number_default(script_runner, mock_runtime_dir):
     assert ret.success
     assert "Metadata instance '" + name + "' for schema 'metadata-test' has been written" in ret.stdout
 
-    assert os.path.isdir(os.path.join(mock_runtime_dir, 'metadata', METADATA_TEST_NAMESPACE))
+    assert os.path.isdir(os.path.join(mock_data_dir, 'metadata', METADATA_TEST_NAMESPACE))
     assert os.path.isfile(expected_file)
 
     with open(expected_file, "r") as fd:
@@ -379,103 +379,103 @@ def test_number_default(script_runner, mock_runtime_dir):
         assert instance_json["metadata"]["number_default_test"] == 7.2
 
 
-def test_uri(script_runner, mock_runtime_dir):
+def test_uri(script_runner, mock_data_dir):
     prop_test = PropertyTester("uri")
     prop_test.negative_value = "//invalid-uri"
     prop_test.negative_stdout = "Property used to test uri formatting; format: uri"
     prop_test.negative_stderr = "'//invalid-uri' is not a 'uri'"
     prop_test.positive_value = "http://localhost:31823/v1/models?version=2017-02-13"
-    prop_test.run(script_runner, mock_runtime_dir)
+    prop_test.run(script_runner, mock_data_dir)
 
 
-def test_integer_exclusivity(script_runner, mock_runtime_dir):
+def test_integer_exclusivity(script_runner, mock_data_dir):
     prop_test = PropertyTester("integer_exclusivity")
     prop_test.negative_value = 3
     prop_test.negative_stdout = "Property used to test integers with exclusivity restrictions; " \
                                 "exclusiveMinimum: 3, exclusiveMaximum: 10"
     prop_test.negative_stderr = "3 is less than or equal to the minimum of 3"
     prop_test.positive_value = 7
-    prop_test.run(script_runner, mock_runtime_dir)
+    prop_test.run(script_runner, mock_data_dir)
 
 
-def test_integer_multiple(script_runner, mock_runtime_dir):
+def test_integer_multiple(script_runner, mock_data_dir):
     prop_test = PropertyTester("integer_multiple")
     prop_test.negative_value = 32
     prop_test.negative_stdout = "Property used to test integers with multipleOf restrictions; multipleOf: 7"
     prop_test.negative_stderr = "32 is not a multiple of 7"
     prop_test.positive_value = 42
-    prop_test.run(script_runner, mock_runtime_dir)
+    prop_test.run(script_runner, mock_data_dir)
 
 
-def test_number_range(script_runner, mock_runtime_dir):
+def test_number_range(script_runner, mock_data_dir):
     prop_test = PropertyTester("number_range")
     prop_test.negative_value = 2.7
     prop_test.negative_stdout = "Property used to test numbers with range; minimum: 3, maximum: 10"
     prop_test.negative_stderr = "2.7 is less than the minimum of 3"
     prop_test.positive_value = 7.2
-    prop_test.run(script_runner, mock_runtime_dir)
+    prop_test.run(script_runner, mock_data_dir)
 
 
-def test_const(script_runner, mock_runtime_dir):
+def test_const(script_runner, mock_data_dir):
     prop_test = PropertyTester("const")
     prop_test.negative_value = 2.718
     prop_test.negative_stdout = "Property used to test properties with const; const: 3.14"
     prop_test.negative_stderr = "3.14 was expected"
     prop_test.positive_value = 3.14
-    prop_test.run(script_runner, mock_runtime_dir)
+    prop_test.run(script_runner, mock_data_dir)
 
 
-def test_string_length(script_runner, mock_runtime_dir):
+def test_string_length(script_runner, mock_data_dir):
     prop_test = PropertyTester("string_length")
     prop_test.negative_value = "12345678901"
     prop_test.negative_stdout = "Property used to test strings with length restrictions; minLength: 3, maxLength: 10"
     prop_test.negative_stderr = "'12345678901' is too long"
     prop_test.positive_value = "123456"
-    prop_test.run(script_runner, mock_runtime_dir)
+    prop_test.run(script_runner, mock_data_dir)
 
 
-def test_enum(script_runner, mock_runtime_dir):
+def test_enum(script_runner, mock_data_dir):
     prop_test = PropertyTester("enum")
     prop_test.negative_value = "jupyter"
     prop_test.negative_stdout = "Property used to test properties with enums; enum: ['elyra', 'rocks']"
     prop_test.negative_stderr = "'jupyter' is not one of ['elyra', 'rocks']"
     prop_test.positive_value = "rocks"
-    prop_test.run(script_runner, mock_runtime_dir)
+    prop_test.run(script_runner, mock_data_dir)
 
 
-def test_array(script_runner, mock_runtime_dir):
+def test_array(script_runner, mock_data_dir):
     prop_test = PropertyTester("array")
     prop_test.negative_value = [1, 2, 2]
     prop_test.negative_stdout = "Property used to test array with item restrictions; " \
                                 "minItems: 3, maxItems: 10, uniqueItems: True"
     prop_test.negative_stderr = "[1, 2, 2] has non-unique elements"
     prop_test.positive_value = [1, 2, 3, 4, 5]
-    prop_test.run(script_runner, mock_runtime_dir)
+    prop_test.run(script_runner, mock_data_dir)
 
 
-def test_object(script_runner, mock_runtime_dir):
+def test_object(script_runner, mock_data_dir):
     prop_test = PropertyTester("object")
     prop_test.negative_value = {'prop1': 2, 'prop2': 3}
     prop_test.negative_stdout = "Property used to test object elements with properties restrictions; " \
                                 "minProperties: 3, maxProperties: 10"
     prop_test.negative_stderr = "{'prop1': 2, 'prop2': 3} does not have enough properties"
     prop_test.positive_value = {'prop1': 2, 'prop2': 3, 'prop3': 4, 'prop4': 5}
-    prop_test.run(script_runner, mock_runtime_dir)
+    prop_test.run(script_runner, mock_data_dir)
 
 
-def test_boolean(script_runner, mock_runtime_dir):
+def test_boolean(script_runner, mock_data_dir):
     prop_test = PropertyTester("boolean")
     prop_test.negative_value = "bogus_boolean"
     prop_test.negative_stdout = "Property used to test boolean values"
     prop_test.negative_stderr = "'bogus_boolean' is not of type 'boolean'"
     prop_test.positive_value = True
-    prop_test.run(script_runner, mock_runtime_dir)
+    prop_test.run(script_runner, mock_data_dir)
 
 
-def test_null(script_runner, mock_runtime_dir):
+def test_null(script_runner, mock_data_dir):
     prop_test = PropertyTester("null")
     prop_test.negative_value = "bogus_null"
     prop_test.negative_stdout = "Property used to test null types"
     prop_test.negative_stderr = "'bogus_null' is not of type 'null'"
     prop_test.positive_value = None
-    prop_test.run(script_runner, mock_runtime_dir)
+    prop_test.run(script_runner, mock_data_dir)

--- a/elyra/metadata/tests/test_metadata_app.py
+++ b/elyra/metadata/tests/test_metadata_app.py
@@ -265,11 +265,12 @@ def test_remove_missing(script_runner):
     # Create an instance so that the namespace exists.
     metadata_manager = MetadataManager(namespace=METADATA_TEST_NAMESPACE)
     valid = Metadata(**valid_metadata_json)
-    metadata_manager.add('valid', valid)
+    metadata_manager.add('valid', valid, replace=True)
 
     ret = script_runner.run('elyra-metadata', 'remove', METADATA_TEST_NAMESPACE, '--name=missing')
     assert ret.success is False
-    assert ret.stdout == '"Metadata \'missing\' in namespace \'{}\' was not found!"\n'.format(METADATA_TEST_NAMESPACE)
+    assert ret.stdout.startswith("Metadata \'missing\' in namespace \'{}\' was not found!".
+                                 format(METADATA_TEST_NAMESPACE))
     assert ret.stderr == ''
 
     # Now cleanup original instance.

--- a/elyra/metadata/tests/test_metadata_app.py
+++ b/elyra/metadata/tests/test_metadata_app.py
@@ -22,7 +22,7 @@ import shutil
 from tempfile import mkdtemp
 from elyra.metadata import Metadata, MetadataManager, METADATA_TEST_NAMESPACE
 from .test_utils import PropertyTester, create_json_file, valid_metadata_json, \
-    another_metadata_json, invalid_metadata_json
+    another_metadata_json, invalid_metadata_json, invalid_no_display_name_json
 
 os.environ["METADATA_TESTING"] = "1"  # Enable metadata-tests namespace
 
@@ -144,9 +144,8 @@ def test_install_and_replace(script_runner, mock_data_dir):
                             '--name=test-metadata_42_valid-name', '--display_name=display_name',
                             '--required_test=required_value')
     assert ret.success is False
-    assert "A failure occurred saving metadata instance 'test-metadata_42_valid-name' for schema 'metadata-test'." \
-           in ret.stdout
-    assert "already exists. Use the replace flag to overwrite" in ret.stderr
+    assert "The following exception occurred saving metadata instance 'test-metadata_42_valid-name'" \
+           " for schema 'metadata-test':" in ret.stdout
 
     # Re-attempt with replace flag - success expected
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_NAMESPACE, '--schema_name=metadata-test',
@@ -219,21 +218,24 @@ def test_list_instances(script_runner, mock_data_dir):
     # Remove the '2' runtimes and reconfirm smaller set
     metadata_manager.remove('valid2')
     metadata_manager.remove('another2')
-    # Include an invalid file as well
+    # Include two additional invalid files as well - one for uri failure, andother missing display_name
     metadata_dir = os.path.join(mock_data_dir, 'metadata', METADATA_TEST_NAMESPACE)
     create_json_file(metadata_dir, 'invalid.json', invalid_metadata_json)
+    create_json_file(metadata_dir, 'no_display_name.json', invalid_no_display_name_json)
 
     ret = script_runner.run('elyra-metadata', 'list', METADATA_TEST_NAMESPACE)
     assert ret.success
     lines = ret.stdout.split('\n')
-    assert len(lines) == 8  # always 5 more than the actual runtime count
+    assert len(lines) == 9  # always 5 more than the actual runtime count
     assert lines[0] == "Available metadata instances for {} (includes invalid):".format(METADATA_TEST_NAMESPACE)
-    line_elements = [line.split() for line in lines[4:7]]
+    line_elements = [line.split() for line in lines[4:8]]
     assert line_elements[0][1] == "another"
     assert line_elements[1][1] == "invalid"
     assert line_elements[1][3] == "**INVALID**"
     assert line_elements[1][4] == "(ValidationError)"
-    assert line_elements[2][1] == "valid"
+    assert line_elements[2][3] == "**INVALID**"
+    assert line_elements[2][4] == "(ValidationError)"
+    assert line_elements[3][1] == "valid"
 
     ret = script_runner.run('elyra-metadata', 'list', METADATA_TEST_NAMESPACE, '--valid-only')
     assert ret.success

--- a/elyra/metadata/tests/test_metadata_app.py
+++ b/elyra/metadata/tests/test_metadata_app.py
@@ -187,7 +187,7 @@ def test_list_instances(script_runner, mock_data_dir):
     assert ret.success
     lines = ret.stdout.split('\n')
     assert len(lines) == 2  # always 2 more than the actual runtime count
-    assert lines[0].startswith("No metadata instances available for {} at:".format(METADATA_TEST_NAMESPACE))
+    assert lines[0].startswith("No metadata instances available for {} in:".format(METADATA_TEST_NAMESPACE))
 
     valid = Metadata(**valid_metadata_json)
     resource = metadata_manager.add('valid', valid)

--- a/elyra/metadata/tests/test_utils.py
+++ b/elyra/metadata/tests/test_utils.py
@@ -52,7 +52,7 @@ invalid_metadata_json = {
 
 # Contains all values corresponding to test schema...
 complete_metadata_json = {
-    "schema_name": "test",
+    "schema_name": "metadata-test",
     "display_name": "complete metadata instance",
     "metadata": {
         "required_test": "required_value",
@@ -78,8 +78,20 @@ complete_metadata_json = {
 # Minimal json to be built upon for each property test.  Only
 # required values are specified.
 minmal_metadata_json = {
-    "schema_name": "test",
+    "schema_name": "metadata-test",
     "display_name": "complete metadata instance",
+    "metadata": {
+        "required_test": "required_value"
+    }
+}
+
+
+# Bring-your-own metadata template used to test hierarchical writes.  The
+# display_name field will be updated to reflect the location's instance
+# in the hierarchy
+byo_metadata_json = {
+    "schema_name": "metadata-test",
+    "display_name": "location",
     "metadata": {
         "required_test": "required_value"
     }

--- a/elyra/metadata/tests/test_utils.py
+++ b/elyra/metadata/tests/test_utils.py
@@ -129,6 +129,14 @@ def get_schema(schema_name):
     return schema_json
 
 
+def get_instance(instances, field, value):
+    """Given a list of instances (dicts), return the dictionary where field == value."""
+    for inst in instances:
+        if inst[field] == value:
+            return inst
+    assert False, "Value '{}' for field '{}' was not found in instances!".format(value, field)
+
+
 class PropertyTester(object):
     """Helper class used by elyra_md tests to test each of the properties in the test.json schema. """
     name = None             # prefixed with 'test_' is test name, post-fixed with '_test' is schema property name

--- a/elyra/metadata/tests/test_utils.py
+++ b/elyra/metadata/tests/test_utils.py
@@ -50,6 +50,14 @@ invalid_metadata_json = {
     }
 }
 
+invalid_no_display_name_json = {
+    'schema_name': 'metadata-test',
+    'metadata': {
+        'uri_test': '//localhost:8081/',
+        'required_test': "required_value"
+    }
+}
+
 # Contains all values corresponding to test schema...
 complete_metadata_json = {
     "schema_name": "metadata-test",

--- a/elyra/metadata/tests/test_utils.py
+++ b/elyra/metadata/tests/test_utils.py
@@ -143,8 +143,8 @@ class PropertyTester(object):
         self.name = name
         self.property = name + "_test"
 
-    def run(self, script_runner, mock_runtime_dir):
-        expected_file = os.path.join(mock_runtime_dir, 'metadata', METADATA_TEST_NAMESPACE, self.name + '.json')
+    def run(self, script_runner, mock_data_dir):
+        expected_file = os.path.join(mock_data_dir, 'metadata', METADATA_TEST_NAMESPACE, self.name + '.json')
         # Cleanup from any potential previous failures
         if os.path.exists(expected_file):
             os.remove(expected_file)
@@ -168,7 +168,7 @@ class PropertyTester(object):
         assert ret.success is self.positive_res
         assert "Metadata instance '" + self.name + "' for schema 'metadata-test' has been written" in ret.stdout
 
-        assert os.path.isdir(os.path.join(mock_runtime_dir, 'metadata', METADATA_TEST_NAMESPACE))
+        assert os.path.isdir(os.path.join(mock_data_dir, 'metadata', METADATA_TEST_NAMESPACE))
         assert os.path.isfile(expected_file)
 
         with open(expected_file, "r") as fd:


### PR DESCRIPTION
These changes introduce support for creating, updating, and deleting metadata instances via the REST API.  It also builds on the changes first introduced in PR #462 by introducing the notion of a hierarchy of locations in which metadata instances are searched.

The REST endpoints are (note, the current body structures should be updated, not listing here):
`POST /api/metadata/{namespace}`
`PUT /api/metadata/{namespace}/{resource}`
`DELETE /api/metadata/{namespace}/{resource}`

Metadata instances can reside at three levels: Factory, Shared and User.

**Factory:** Metadata at the factory level will reside in the python environment's location and are created when installing elyra.  This location derives from the active Python's `sys.prefix` and will be found in `sys.prefix/share/jupyter/metadata`. These instances should be treated as read-only.  These metadata instances are returned relative to their respective namespace **only if same-named instances do not exist at any other level**.

**Shared:** Metadata at the shared level will typically reside in either of two locations (although their actual paths vary by platform type).  For Unix-based systems, this will typically be `/usr/local/share/jupyter/metadata` or `/usr/share/juptyer/metadata`, both are valid.  These instances are meant for sharing across users (e.g., code-snippets).  No tooling currently exists to create these instances, so administrators must copy instances to these locations.  These metadata instances are returned relative to their respective namespace **only if same-named instances do not exist at the user level**.

**User:** Metadata at the user level resides in a subdirectory relative to the user running the application.  These will reside in a subdirectory of the user's HOME which also varies by platform.  This is where tools write, update, and delete instances from.

Note: The hierarchy is hidden from the user, for the most part.  However, attempts to delete an instance that resides in either Shared or Factory levels will result in a `PermissionError` (403).  Likewise, attempts to create or update an instance where `replace=False` but instances do exist in Shared or Factory, will also fail with `FileExistsError` (409).

The REST API semantics for POST and PUT are essentially the same as create and update semantics.  That is, POST (create) requires that the _logical_ instance (at **any** level) not already exist and, similarly, PUT (update) requires that the _logical_ instance (at **any** level) **does** exist.  Under the covers this both call the `add()` method with `replace=False` and `replace=True`, respectively.

**TODO:**
- [x] Better define the body on POST and PUT
- [x] Add Swagger entries

Resolves #483 
Fixes #538 
Fixes #543

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

