### PR TITLE
Recursevily include operation outputs

### DIFF
--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -200,9 +200,9 @@ class KfpPipelineProcessor(PipelineProcessor):
 
             notebook_ops[operation.id] = notebook_op
 
-            self.log.info("NotebookOp Created for Component %s \n", operation.id)
+            self.log.info("NotebookOp Created for Component '%s' (%s) \n", operation.title, operation.id)
 
-            # upload operation dependencies to object store
+            # upload operation dependencies to object storage
             try:
                 dependency_archive_path = self._generate_dependency_archive(operation)
                 cos_client = CosClient(config=runtime_configuration)
@@ -213,7 +213,7 @@ class KfpPipelineProcessor(PipelineProcessor):
                 self.log.error("Error uploading artifacts to object storage.", exc_info=True)
                 raise
 
-            self.log.info("Pipeline dependencies have been uploaded to object store")
+            self.log.info("Pipeline dependencies have been uploaded to object storage")
 
         # Process dependencies after all the operations have been created
         for pipeline_operation in pipeline.operations.values():
@@ -261,6 +261,5 @@ class KfpPipelineProcessor(PipelineProcessor):
             runtime_configuration = MetadataManager(namespace=MetadataManager.NAMESPACE_RUNTIMES).get(name)
             return runtime_configuration
         except BaseException as err:
-            self.log.error('Error retrieving runtime configuration for {}'.format(name),
-                           exc_info=True)
+            self.log.error('Error retrieving runtime configuration for {}'.format(name), exc_info=True)
             raise RuntimeError('Error retrieving runtime configuration for {}', err)

--- a/elyra/util/archive.py
+++ b/elyra/util/archive.py
@@ -59,7 +59,7 @@ def create_temp_archive(archive_name, source_dir, files=None, recursive=False):
             if dependency:
                 if dependency.startswith('*'):
                     # handle check for extension wildcard
-                    if tarinfo.name.endswith(dependency.replace('*.', '.')):
+                    if tarinfo.name.endswith(dependency.replace('*', '')):
                         return tarinfo
                 elif tarinfo.name == dependency:
                     # handle check for specific file


### PR DESCRIPTION
Two small changes for Pipeline runtime:
    
* Add support for recursive dependency propagation
    
Currently, a pipeline operation automatically inherits
its parent outputs. This changes the scope of inheritance
so that the operation will inherit all its predecessor's
outputs (parent, grandparent, etc)

*  Enhance flexibility of wildcard usage
    
Enhance flexibility of wildcard usage enabling not
only dependencies like '*.csv' as well as '*data.csv"

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

