### PR TITLE
Update pipeline node tooltip to display boolean props

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -78,7 +78,7 @@ const NodeProperties = (properties: any): React.ReactElement => {
         if (Array.isArray(value)) {
           value = value.join('\n');
         } else if (typeof value === 'boolean') {
-          value = value ? 'checked' : 'unchecked';
+          value = value ? 'Yes' : 'No';
         }
         return (
           <React.Fragment key={idx}>

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -74,20 +74,22 @@ const NodeProperties = (properties: any): React.ReactElement => {
   return (
     <dl className={NODE_TOOLTIP_CLASS}>
       {Object.keys(properties).map((key, idx) => {
+        let value = properties[key];
+        if (Array.isArray(value)) {
+          value = value.join('\n');
+        } else if (typeof value === 'boolean') {
+          value = value ? 'checked' : 'unchecked';
+        }
         return (
           <React.Fragment key={idx}>
             <dd>{key}</dd>
-            <dt>
-              {Array.isArray(properties[key])
-                ? properties[key].join('\n')
-                : properties[key]}
-            </dt>
+            <dt>{value}</dt>
           </React.Fragment>
         );
       })}
     </dl>
   );
-}
+};
 
 export const commandIDs = {
   openPipelineEditor: 'pipeline-editor:open',


### PR DESCRIPTION
Properly display the state of checkbox/boolean properties in the tooltip of pipeline nodes.
Checkbox fields now show value as `checked` or `unchecked` accordingly

Fixes #541 


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

