### PR TITLE
Add restorer to code snippet extension

### DIFF
--- a/packages/code-snippet/src/index.ts
+++ b/packages/code-snippet/src/index.ts
@@ -20,7 +20,8 @@ import { codeSnippetIcon } from '@elyra/application';
 
 import {
   JupyterFrontEnd,
-  JupyterFrontEndPlugin
+  JupyterFrontEndPlugin,
+  ILayoutRestorer
 } from '@jupyterlab/application';
 import { ICommandPalette } from '@jupyterlab/apputils';
 
@@ -36,8 +37,12 @@ const CODE_SNIPPET_EXTENSION_ID = 'elyra-code-snippet-extension';
 export const code_snippet_extension: JupyterFrontEndPlugin<void> = {
   id: CODE_SNIPPET_EXTENSION_ID,
   autoStart: true,
-  requires: [ICommandPalette],
-  activate: (app: JupyterFrontEnd, palette: ICommandPalette) => {
+  requires: [ICommandPalette, ILayoutRestorer],
+  activate: (
+    app: JupyterFrontEnd,
+    palette: ICommandPalette,
+    restorer: ILayoutRestorer
+  ) => {
     console.log('Elyra - code-snippet extension is activated!');
 
     const getCurrentWidget = (): Widget => {
@@ -48,6 +53,8 @@ export const code_snippet_extension: JupyterFrontEndPlugin<void> = {
     codeSnippetWidget.id = CODE_SNIPPET_EXTENSION_ID;
     codeSnippetWidget.title.icon = codeSnippetIcon;
     codeSnippetWidget.title.caption = 'Code Snippet';
+
+    restorer.add(codeSnippetWidget, CODE_SNIPPET_EXTENSION_ID);
 
     // Rank has been chosen somewhat arbitrarily to give priority to the running
     // sessions widget in the sidebar.


### PR DESCRIPTION
Adds behavior of reopening the code snippets extension on reloading
jupyter lab (if code snippets was already open). Fixes #432 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

