### PR TITLE
Protect metadata namespace instance via file permissions

### DIFF
--- a/elyra/metadata/metadata.py
+++ b/elyra/metadata/metadata.py
@@ -309,7 +309,7 @@ class FileMetadataStore(MetadataStore):
             created_namespace_dir = True
 
         try:
-            with io.open(resource, 'w', encoding='utf-8') as f:
+            with jupyter_core.paths.secure_write(resource) as f:
                 f.write(metadata.prepare_write())  # Only persist necessary items
         except Exception:
             if created_namespace_dir:
@@ -493,7 +493,6 @@ class SchemaManager(SingletonConfigurable):
         return schemas
 
     def get_schema(self, namespace, schema_name):
-        schema_json = None
         self.log.debug("SchemaManager: Fetching schema '{}' from namespace '{}'".format(schema_name, namespace))
         if not self.is_valid_namespace(namespace):
             raise ValueError("Namespace '{}' is not in the list of valid namespaces: '{}'".

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -123,14 +123,21 @@ def test_manager_list_all_none(tests_manager, metadata_tests_dir):
 def test_manager_add_remove_valid(tests_manager, metadata_tests_dir):
     metadata_name = 'valid_add_remove'
 
+    # Remove metadata_tests_dir and ensure it gets created with appropriate perms.
+    shutil.rmtree(metadata_tests_dir)
+
     metadata = Metadata(**valid_metadata_json)
 
     instance = tests_manager.add(metadata_name, metadata)
     assert instance is not None
+    dir_mode = oct(os.stat(metadata_tests_dir).st_mode & 0o777777)  # Be sure to include other attributes
+    assert dir_mode == "0o40700"  # and ensure this is a directory with only rwx by owner enabled
 
     # Ensure file was created
     metadata_file = os.path.join(metadata_tests_dir, 'valid_add_remove.json')
     assert os.path.exists(metadata_file)
+    file_mode = oct(os.stat(metadata_file).st_mode & 0o777777)  # Be sure to include other attributes
+    assert file_mode == "0o100600"  # and ensure this is a regular file with only rw by owner enabled
 
     with open(metadata_file, 'r', encoding='utf-8') as f:
         valid_add = json.loads(f.read())

--- a/etc/scripts/protect-metadata.sh
+++ b/etc/scripts/protect-metadata.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Determine the directory from which to start the chmod operation
+data_dir=`jupyter --data-dir`
+metadata_dir=${data_dir}"/metadata"
+
+# For each item (including directories) remove its permissions for groups
+# and others, leaving only the user (owner) permissions in place.
+echo "Changing permissions on metadata files under ${metadata_dir}..."
+find ${metadata_dir} -print -exec chmod go-rwx {} \;
+
+exit 0


### PR DESCRIPTION
Metadata instances are now written using jupyter_core's secure_write()
method - which produces a mode of 0600 (read/write by owner only) and
also works on Windows where Unix permissions don't exist (for when
Windows is supported).

A script can be pulled from the repository to adjust permissions on
existing metadata instances (as necessary).

Resolves #563

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

