### PR TITLE
Fix display of written resource via elyra-metadata app

### DIFF
--- a/elyra/metadata/metadata_app.py
+++ b/elyra/metadata/metadata_app.py
@@ -199,14 +199,15 @@ class NamespaceInstall(NamespaceBase):
                             display_name=display_name, metadata=metadata)
 
         ex_msg = None
-        resource = None
+        new_instance = None
         try:
-            resource = self.metadata_manager.add(name, instance, replace=self.replace_flag.value)
+            new_instance = self.metadata_manager.add(name, instance, replace=self.replace_flag.value)
         except Exception as ex:
             ex_msg = str(ex)
 
-        if resource:
-            print("Metadata instance '{}' for schema '{}' has been written to: {}".format(name, schema_name, resource))
+        if new_instance:
+            print("Metadata instance '{}' for schema '{}' has been written to: {}"
+                  .format(name, schema_name, new_instance.resource))
         else:
             if ex_msg:
                 self.log_and_exit("The following exception occurred saving metadata instance '{}' for schema '{}': {}"

--- a/elyra/metadata/tests/test_metadata_app.py
+++ b/elyra/metadata/tests/test_metadata_app.py
@@ -138,6 +138,7 @@ def test_install_and_replace(script_runner, mock_data_dir):
                             '--required_test=required_value')
     assert ret.success
     assert "Metadata instance 'test-metadata_42_valid-name' for schema 'metadata-test' has been written" in ret.stdout
+    assert expected_file in ret.stdout
 
     # Re-attempt w/o replace flag - failure expected
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_NAMESPACE, '--schema_name=metadata-test',


### PR DESCRIPTION
The changes for writable metadata (#539) changed the return value for metadata.add operations.  This affected what was displayed when instances were created using the application and no tests validated the actual file (resource) portion of that display. 

After #539, and prior to this change, installed metadata would yield this message:
```
Metadata instance 'power_of_x' for schema 'code-snippet' has been written to: <elyra.metadata.metadata.Metadata object at 0x7fa2287f0390>
```
with this change, the expected result occurs:
```
Metadata instance 'power_of_y' for schema 'code-snippet' has been written to: /Users/kbates/Library/Jupyter/metadata/code-snippets/power_of_y.json
```
This fixes that issue.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

