### PR TITLE
Return No Content on DELETE, set Location header on POST

### DIFF
--- a/elyra/api/elyra.yaml
+++ b/elyra/api/elyra.yaml
@@ -162,6 +162,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MetadataResource'
+          headers:
+            Location:
+              description: Resource endpoint
+              schema:
+                type: string
+                format: url
         400:
           description: An error (validation, syntax) occurred relative to the instance data
         404:
@@ -258,12 +264,8 @@ paths:
         schema:
           type: string
       responses:
-        200:
-          description: The deleted metadata instance
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MetadataResource'
+        204:
+          description: The resource was successfully deleted
         403:
           description: Deletion of the resource is not permitted
         404:

--- a/elyra/metadata/metadata.py
+++ b/elyra/metadata/metadata.py
@@ -162,7 +162,7 @@ class MetadataManager(LoggingConfigurable):
         return self.metadata_store.save(name, metadata, replace)
 
     def remove(self, name):
-        return self.metadata_store.remove(name)
+        self.metadata_store.remove(name)
 
 
 class MetadataStore(ABC):
@@ -345,8 +345,6 @@ class FileMetadataStore(MetadataStore):
                 raise PermissionError("Removal of metadata resource '{}' in namespace '{}' is not permitted!".
                                       format(resource, self.namespace))
             os.remove(resource)
-
-        return metadata
 
     def _remove_allowed(self, metadata):
         """Determines if the resource of the given instance is allowed to be removed. """

--- a/elyra/metadata/tests/test_handlers.py
+++ b/elyra/metadata/tests/test_handlers.py
@@ -182,6 +182,7 @@ class MetadataHandlerHierarchyTest(MetadataTestBase):
         r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, body=body,
                   method='POST', base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 201
+        assert r.headers.get('location') == r.request.path_url + '/valid'
         metadata = r.json()
         assert metadata == valid
 
@@ -329,10 +330,8 @@ class MetadataHandlerHierarchyTest(MetadataTestBase):
 
         r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'valid',
                   method='DELETE', base_url=self.base_url(), headers=self.auth_headers())
-        assert r.status_code == 200
-        metadata = r.json()
-        metadata.pop('name', None)
-        assert metadata == valid_metadata_json
+        assert r.status_code == 204
+        assert len(r.text) == 0
 
         # Confirm deletion
         r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'valid',
@@ -351,9 +350,8 @@ class MetadataHandlerHierarchyTest(MetadataTestBase):
 
         r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'byo_2',
                   method='DELETE', base_url=self.base_url(), headers=self.auth_headers())
-        assert r.status_code == 200
-        metadata = r.json()
-        assert metadata['display_name'] == 'location'
+        assert r.status_code == 204
+        assert len(r.text) == 0
 
 
 class SchemaHandlerTest(MetadataTestBase):

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -149,20 +149,17 @@ def test_manager_add_remove_valid(tests_manager, metadata_tests_dir):
     assert instance is not None
 
     # And finally, remove it.
-    instance = tests_manager.remove(metadata_name)
-
+    tests_manager.remove(metadata_name)
     assert not os.path.exists(metadata_file)
-    assert instance.resource == metadata_file
 
 
 def test_manager_remove_invalid(tests_manager, metadata_tests_dir):
     # Ensure invalid metadata file isn't validated and is removed.
     create_json_file(metadata_tests_dir, 'remove_invalid.json', invalid_metadata_json)
     metadata_name = 'remove_invalid'
-    instance = tests_manager.remove(metadata_name)
+    tests_manager.remove(metadata_name)
     metadata_file = os.path.join(metadata_tests_dir, 'remove_invalid.json')
     assert not os.path.exists(metadata_file)
-    assert instance.resource == metadata_file
 
 
 def test_manager_remove_missing(tests_manager):
@@ -349,8 +346,7 @@ def test_manager_hierarchy_update(tests_hierarchy_manager, factory_dir, shared_d
     assert byo_2.resource.startswith(str(metadata_tests_dir))
 
     # now remove the updated instance and ensure the shared instance appears
-    instance = tests_hierarchy_manager.remove('byo_2')
-    assert instance.resource == byo_2.resource
+    tests_hierarchy_manager.remove('byo_2')
 
     byo_2 = tests_hierarchy_manager.get('byo_2')
     assert byo_2.resource.startswith(str(shared_dir))
@@ -385,8 +381,7 @@ def test_manager_hierarchy_remove(tests_hierarchy_manager, factory_dir, shared_d
     assert byo_2.resource.startswith(str(metadata_tests_dir))
 
     # Now remove instance.  Should be allowed since it resides in user area
-    instance = tests_hierarchy_manager.remove('byo_2')
-    assert instance.resource == byo_2.resource
+    tests_hierarchy_manager.remove('byo_2')
 
     # Attempt to remove instance from shared area and its protected
     with pytest.raises(PermissionError) as pe:


### PR DESCRIPTION
This change no longer returns the deleted resource (and 200) when
deleting metadata instance and instead returns 204 (No Content).

Also, while researching REST behaviors, I found that we should be
setting the Location header when creating instances.  The value of
which is the endpoint that would be used to fetch that new content:
`/api/metadata/{namespace}/{resource}`.

Resolves #567
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

