### PR TITLE
Bumping kfp requirement to 0.5.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,9 @@ setup_args = dict(
     packages=find_packages(),
     install_requires=[
         "jupyter_core>=4.0,<5.0",
-        "kfp==0.2.2",
+        "kfp==0.5.1",
         "urllib3==1.24.2",
-        "kfp-notebook>=0.8.1",
-        "kfp-server-api==0.1.18.3",
+        "kfp-notebook>=0.8.2",
         "minio>=5.0.7",
         'nbdime>=2.0.0',
         'jupyterlab>=2.0.0',


### PR DESCRIPTION
Kfp pipeline upload parsing error is resolved with this version.
This will also allow us to remove kfp-server-api requirement and
the need for us to pin it. Also bumping kfp-notebook to latest.

Fixes #378



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

