### PR TITLE
Add a make release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 
 .PHONY: help purge uninstall clean test-dependencies lint-server lint-ui lint yarn-install build-ui build-server install-server
-.PHONY: install-external-extensions install watch test-server test-ui test-ui-debug test docs-dependencies docs docker-image
+.PHONY: install-external-extensions install watch test-server test-ui test-ui-debug test docs-dependencies docs dist-ui release docker-image
 
 SHELL:=/bin/bash
 
@@ -120,6 +120,17 @@ docs-dependencies:
 docs: docs-dependencies ## Build docs
 	make -C docs html
 
+dist-ui: build-ui
+	mkdir -p dist
+	$(call PACKAGE_LAB_EXTENSION,theme)
+	$(call PACKAGE_LAB_EXTENSION,code-snippet)
+	$(call PACKAGE_LAB_EXTENSION,pipeline-editor)
+	$(call PACKAGE_LAB_EXTENSION,python-runner)
+	cd dist && curl -o jupyterlab-git-$(GIT_VERSION).tgz $$(npm view @jupyterlab/git@$(GIT_VERSION) dist.tarball) && cd -
+	cd dist && curl -o jupyterlab-toc-$(TOC_VERSION).tgz $$(npm view @jupyterlab/toc@$(TOC_VERSION) dist.tarball) && cd -
+
+release: dist-ui build-server ## Build wheel file for release
+
 docker-image: ## Build docker image
 	@mkdir -p build/docker
 	cp etc/docker/Dockerfile build/docker/Dockerfile
@@ -140,4 +151,8 @@ endef
 
 define INSTALL_LAB_EXTENSION
 	cd packages/$1 && jupyter labextension install --no-build .
+endef
+
+define PACKAGE_LAB_EXTENSION
+	export PATH=$$(pwd)/node_modules/.bin:$$PATH && cd packages/$1 && npm run dist && mv *.tgz ../../dist
 endef


### PR DESCRIPTION
Added a make release target that creates dists for the extensions
and includes them in the elyra wheel file for publishing.

Without this the published wheel would not install the front end.

This is specifically not for local builds since the extensions
installed via the wheel file will use the published application
and ui-components libraries.

Fixes #593



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

