### PR TITLE
[user guide] Fix broken img  href in enhanced-python-support.html   

### DIFF
--- a/docs/source/user_guide/enhanced-python-support.md
+++ b/docs/source/user_guide/enhanced-python-support.md
@@ -37,5 +37,5 @@ allowing users to run their scripts with remote kernels with more specialized re
 
 The Elyra python editor is based on the JupyterLab editor which is currently based on CodeMirror.
 
-<img src="../source/images/python-runner-components.png" alt="Python Editor Components" width="50%" height="50%">
+<img src="../images/python-runner-components.png" alt="Python Editor Components" width="50%" height="50%">
 


### PR DESCRIPTION
Fixes the broken img href `Python Editor Components` in https://elyra.readthedocs.io/en/latest/user_guide/enhanced-python-support.html 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

