### PR TITLE
Update `/api` endpoints and swagger docs

### DIFF
--- a/docs/source/developer_guide/metadata.md
+++ b/docs/source/developer_guide/metadata.md
@@ -108,13 +108,13 @@ A REST API is available for easy integration with frontend components:
 Retrieve all metadata for a given namespace:
 
 ```REST
-GET /api/metadata/<namespace>
+GET /elyra/metadata/<namespace>
 ```
 
 Retrieve a given metadata resource from a given namespace:
 
 ```REST
-GET /api/metadata/<namespace>/<resource>
+GET /elyra/metadata/<namespace>/<resource>
 ```
 
 

--- a/elyra/__init__.py
+++ b/elyra/__init__.py
@@ -35,16 +35,16 @@ def load_jupyter_server_extension(nb_server_app):
     web_app = nb_server_app.web_app
     host_pattern = '.*$'
     web_app.add_handlers(host_pattern, [
-        (url_path_join(web_app.settings['base_url'], r'/api/{}'.format(YamlSpecHandler.get_resource_metadata()[0])),
+        (url_path_join(web_app.settings['base_url'], r'/elyra/{}'.format(YamlSpecHandler.get_resource_metadata()[0])),
          YamlSpecHandler),
-        (url_path_join(web_app.settings['base_url'], r'/api/metadata/%s' % (namespace_regex)), MetadataHandler),
-        (url_path_join(web_app.settings['base_url'], r'/api/metadata/%s/%s' % (namespace_regex, resource_regex)),
+        (url_path_join(web_app.settings['base_url'], r'/elyra/metadata/%s' % (namespace_regex)), MetadataHandler),
+        (url_path_join(web_app.settings['base_url'], r'/elyra/metadata/%s/%s' % (namespace_regex, resource_regex)),
          MetadataResourceHandler),
-        (url_path_join(web_app.settings['base_url'], r'/api/schema/%s' % (namespace_regex)), SchemaHandler),
-        (url_path_join(web_app.settings['base_url'], r'/api/schema/%s/%s' % (namespace_regex, resource_regex)),
+        (url_path_join(web_app.settings['base_url'], r'/elyra/schema/%s' % (namespace_regex)), SchemaHandler),
+        (url_path_join(web_app.settings['base_url'], r'/elyra/schema/%s/%s' % (namespace_regex, resource_regex)),
          SchemaResourceHandler),
-        (url_path_join(web_app.settings['base_url'], r'/api/namespace'), NamespaceHandler),
-        (url_path_join(web_app.settings['base_url'], r'/api/pipeline/schedule'), PipelineSchedulerHandler),
-        (url_path_join(web_app.settings['base_url'], r'/api/pipeline/export'), PipelineExportHandler),
+        (url_path_join(web_app.settings['base_url'], r'/elyra/namespace'), NamespaceHandler),
+        (url_path_join(web_app.settings['base_url'], r'/elyra/pipeline/schedule'), PipelineSchedulerHandler),
+        (url_path_join(web_app.settings['base_url'], r'/elyra/pipeline/export'), PipelineExportHandler),
     ])
 

--- a/elyra/api/elyra.yaml
+++ b/elyra/api/elyra.yaml
@@ -9,7 +9,7 @@ info:
 
 paths:
 
-  /api/elyra.yaml:
+  /elyra/elyra.yaml:
     get:
       tags:
       - api
@@ -24,7 +24,7 @@ paths:
         500:
           description: Unexpected error.
 
-  /api/namespace:
+  /elyra/namespace:
     get:
       tags:
       - namespace
@@ -45,7 +45,7 @@ paths:
         500:
           description: Unexpected error.
 
-  /api/schema/{namespace}:
+  /elyra/schema/{namespace}:
     get:
       tags:
       - schema
@@ -76,7 +76,7 @@ paths:
         500:
           description: Unexpected error.
 
-  /api/schema/{namespace}/{resource}:
+  /elyra/schema/{namespace}/{resource}:
     get:
       tags:
       - schema
@@ -107,7 +107,7 @@ paths:
         500:
           description: Unexpected error.
 
-  /api/metadata/{namespace}:
+  /elyra/metadata/{namespace}:
     get:
       tags:
       - metadata
@@ -177,7 +177,7 @@ paths:
         500:
           description: Unexpected error.
 
-  /api/metadata/{namespace}/{resource}:
+  /elyra/metadata/{namespace}/{resource}:
     get:
       tags:
       - metadata

--- a/elyra/api/elyra.yaml
+++ b/elyra/api/elyra.yaml
@@ -449,19 +449,19 @@ components:
     PipelineScheduleResponse:
       description: The set of properties comprising a pipeline processor response entity
       required:
-      - run-url
-      - object-storage-url
-      - object-storage-path
+      - run_url
+      - object_storage_url
+      - object_storage_path
       type: object
       properties:
-        run-url:
+        run_url:
           type: string
           description: The runtime URL to access the pipeline experiment
-        object-storage-url:
+        object_storage_url:
           type: string
           description: The object storage URL to access the pipeline outputs
             and processed notebooks
-        object-storage-path:
+        object_storage_path:
           type: string
           description: The object storage working directory path where the pipeline outputs
             and processed notebooks are located

--- a/elyra/api/elyra.yaml
+++ b/elyra/api/elyra.yaml
@@ -273,6 +273,51 @@ paths:
         500:
           description: Unexpected error.
 
+  /elyra/pipeline/schedule:
+    post:
+      tags:
+      - pipeline
+      summary: Execute pipelines as batch jobs
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PipelineResource'
+      responses:
+        200:
+          description: The pipeline processor response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PipelineScheduleResponse'
+
+  /elyra/pipeline/export:
+    post:
+      tags:
+      - pipeline
+      summary: Export pipeline
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PipelineExportBodyPost'
+      responses:
+        200:
+          description: The pipeline export response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    description: Pipeline export status
+                  message:
+                    type: string
+                    description: Pipeline export message
+
 
 components:
   schemas:
@@ -363,6 +408,84 @@ components:
           properties: {}
           description: A free-form dictionary consisting of additional information
             about the resource.
+
+    PipelineResource:
+      description: The set of properties comprising a pipeline resource entity
+      required:
+        - primary_pipeline
+        - pipelines
+      type: object
+      properties:
+        primary_pipeline:
+          type: string
+          description: The primary pipeline id
+        pipelines:
+          type: array
+          description: A set of pipeline definitions
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                description: The unique identifier of the pipeline
+              name:
+                type: string
+                description: The name of the pipeline
+              nodes:
+                type: array
+                description: The set of nodes in the pipeline
+                items:
+                  type: object
+                  properties: {}
+                  description: The node configuration
+              runtime:
+                type: string
+                description: The runtime type for the pipeline
+              runtime-config:
+                type: object
+                properties: {}
+                description: Runtime configuration that should be used to submit the pipeline
+
+    PipelineScheduleResponse:
+      description: The set of properties comprising a pipeline processor response entity
+      required:
+      - run-url
+      - object-storage-url
+      - object-storage-path
+      type: object
+      properties:
+        run-url:
+          type: string
+          description: The runtime URL to access the pipeline experiment
+        object-storage-url:
+          type: string
+          description: The object storage URL to access the pipeline outputs
+            and processed notebooks
+        object-storage-path:
+          type: string
+          description: The object storage working directory path where the pipeline outputs
+            and processed notebooks are located
+
+    PipelineExportBodyPost:
+      description: The set of properties comprising the request body for POST
+      required:
+        - pipeline
+        - export_format
+        - export_path
+        - overwrite
+      type: object
+      properties:
+        pipeline:
+          $ref: '#/components/schemas/PipelineResource'
+        export_format:
+          type: string
+          description: Pipeline export format
+        export_path:
+          type: string
+          description: Pipeline export path
+        overwrite:
+          type: boolean
+          description: True if existing export should be overwritten
 
   parameters:
     namespace:

--- a/elyra/metadata/handlers.py
+++ b/elyra/metadata/handlers.py
@@ -65,7 +65,7 @@ class MetadataHandler(HttpErrorMixin, APIHandler):
 
         self.set_status(201)
         self.set_header("Content-Type", 'application/json')
-        location = url_path_join(self.base_url, 'api', 'metadata', namespace, metadata.name)
+        location = url_path_join(self.base_url, 'elyra', 'metadata', namespace, metadata.name)
         self.set_header('Location', location)
         self.finish(metadata.to_dict(trim=True))
 

--- a/elyra/metadata/tests/test_handlers.py
+++ b/elyra/metadata/tests/test_handlers.py
@@ -68,7 +68,7 @@ class MetadataHandlerTest(MetadataTestBase):
         # Validate missing is not found
 
         # Remove self.request (and other 'self.' prefixes) once transition to jupyter_server occurs
-        r = fetch(self.request, 'api', 'metadata', 'bogus', 'missing',
+        r = fetch(self.request, 'elyra', 'metadata', 'bogus', 'missing',
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 404
         assert "Namespace 'bogus' is not in the list of valid namespaces:" in r.text
@@ -76,21 +76,21 @@ class MetadataHandlerTest(MetadataTestBase):
 
     def test_missing_instance(self):
         # Validate missing is not found
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'missing',
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'missing',
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 404
         assert "Metadata 'missing' in namespace '{}' was not found!".format(METADATA_TEST_NAMESPACE) in r.text
 
     def test_invalid_instance(self):
         # Validate invalid throws 404 with validation message
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'invalid',
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'invalid',
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 404
         assert "Schema validation failed for metadata 'invalid'" in r.text
 
     def test_valid_instance(self):
         # Ensure valid metadata can be found
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'valid',
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'valid',
                   base_url=self.base_url(), headers=self.auth_headers())
 
         assert r.status_code == 200
@@ -100,7 +100,7 @@ class MetadataHandlerTest(MetadataTestBase):
 
     def test_get_instances(self):
         # Ensure all valid metadata can be found
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE,
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE,
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 200
         metadata = r.json()
@@ -115,14 +115,14 @@ class MetadataHandlerTest(MetadataTestBase):
     def test_get_empty_namespace_instances(self):
         # Delete the metadata dir contents and attempt listing metadata
         shutil.rmtree(self.metadata_tests_dir)
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE,
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE,
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 404
         assert "Metadata namespace '{}' was not found!".format(METADATA_TEST_NAMESPACE) in r.text
 
         # Now create empty namespace
         os.makedirs(self.metadata_tests_dir)
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE,
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE,
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 200
         metadata = r.json()
@@ -157,7 +157,7 @@ class MetadataHandlerHierarchyTest(MetadataTestBase):
 
     def test_get_hierarchy_instances(self):
         # Ensure all valid metadata can be found
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE,
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE,
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 200
         metadata = r.json()
@@ -179,7 +179,7 @@ class MetadataHandlerHierarchyTest(MetadataTestBase):
         valid['name'] = 'valid'
         body = json.dumps(valid)
 
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, body=body,
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, body=body,
                   method='POST', base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 201
         assert r.headers.get('location') == r.request.path_url + '/valid'
@@ -194,13 +194,13 @@ class MetadataHandlerHierarchyTest(MetadataTestBase):
         byo_instance['name'] = 'byo_2'
         body = json.dumps(byo_instance)
 
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, body=body,
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, body=body,
                   method='POST', base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 409
         assert "already exists" in r.text
 
         # Confirm the instance was not changed
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE,
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE,
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 200
         metadata = r.json()
@@ -219,7 +219,7 @@ class MetadataHandlerHierarchyTest(MetadataTestBase):
         invalid['name'] = 'invalid'
         body = json.dumps(invalid)
 
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, body=body,
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, body=body,
                   method='POST', base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 400
         assert "Schema validation failed for metadata" in r.text
@@ -233,7 +233,7 @@ class MetadataHandlerHierarchyTest(MetadataTestBase):
         missing_schema.pop('display_name')
         body = json.dumps(missing_schema)
 
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, body=body,
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, body=body,
                   method='POST', base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 404
 
@@ -252,7 +252,7 @@ class MetadataHandlerHierarchyTest(MetadataTestBase):
         body = json.dumps(valid)
 
         # Update instance
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'valid', body=body,
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'valid', body=body,
                   method='PUT', base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 404
 
@@ -260,14 +260,14 @@ class MetadataHandlerHierarchyTest(MetadataTestBase):
         create_json_file(self.metadata_tests_dir, 'valid.json', valid_metadata_json)
 
         # Update instance
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'valid', body=body,
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'valid', body=body,
                   method='PUT', base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 200
         instance = r.json()
         assert instance['metadata']['number_range_test'] == 7
 
         # Confirm update via fetch
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'valid',
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'valid',
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 200
         instance = r.json()
@@ -284,12 +284,12 @@ class MetadataHandlerHierarchyTest(MetadataTestBase):
         body = json.dumps(byo_instance)
 
         # Because this is considered an update, replacement is enabled.
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'byo_2', body=body,
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'byo_2', body=body,
                   method='PUT', base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 200
 
         # Confirm the instances and ensure byo_2 is in USER area
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE,
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE,
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 200
         metadata = r.json()
@@ -306,13 +306,13 @@ class MetadataHandlerHierarchyTest(MetadataTestBase):
         byo_2['name'] = 'byo_2_renamed'
         body = json.dumps(byo_2)
 
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'byo_2', body=body,
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'byo_2', body=body,
                   method='PUT', base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 400
         assert "The attempt to rename instance" in r.text
 
         # Confirm no update occurred
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'byo_2',
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'byo_2',
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 200
         instance = r.json()
@@ -322,33 +322,33 @@ class MetadataHandlerHierarchyTest(MetadataTestBase):
         """Create a simple instance - not conflicting with factory instances and delete it. """
 
         # First, attempt to delete non-existent resource, exception expected.
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'missing',
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'missing',
                   method='DELETE', base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 404
 
         create_json_file(self.metadata_tests_dir, 'valid.json', valid_metadata_json)
 
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'valid',
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'valid',
                   method='DELETE', base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 204
         assert len(r.text) == 0
 
         # Confirm deletion
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'valid',
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'valid',
                   method='DELETE', base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 404
 
     def test_delete_hierarchy_instance(self):
         """Create a simple instance - that conflicts with factory instances and delete it only if local. """
 
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'byo_2',
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'byo_2',
                   method='DELETE', base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 403
 
         # create local instance, delete should succeed
         create_json_file(self.metadata_tests_dir, 'byo_2.json', byo_metadata_json)
 
-        r = fetch(self.request, 'api', 'metadata', METADATA_TEST_NAMESPACE, 'byo_2',
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'byo_2',
                   method='DELETE', base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 204
         assert len(r.text) == 0
@@ -362,14 +362,14 @@ class SchemaHandlerTest(MetadataTestBase):
         # Validate missing is not found
 
         # Remove self.request (and other 'self.' prefixes) once transition to jupyter_server occurs
-        r = fetch(self.request, 'api', 'schema', 'bogus',
+        r = fetch(self.request, 'elyra', 'schema', 'bogus',
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 404
         assert "Namespace 'bogus' is not in the list of valid namespaces:" in r.text
 
     def test_missing_runtimes_schema(self):
         # Validate missing is not found
-        r = fetch(self.request, 'api', 'schema', 'runtimes', 'missing',
+        r = fetch(self.request, 'elyra', 'schema', 'runtimes', 'missing',
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 404
         assert "Schema 'missing' in namespace 'runtimes' was not found!" in r.text
@@ -399,7 +399,7 @@ class SchemaHandlerTest(MetadataTestBase):
         self._get_namespace_schema(METADATA_TEST_NAMESPACE, 'metadata-test')
 
     def _get_namespace_schemas(self, namespace, expected):
-        r = fetch(self.request, 'api', 'schema', namespace,
+        r = fetch(self.request, 'elyra', 'schema', namespace,
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 200
         namespace_schemas = r.json()
@@ -411,7 +411,7 @@ class SchemaHandlerTest(MetadataTestBase):
             assert get_instance(schemas, 'name', expected_schema)
 
     def _get_namespace_schema(self, namespace, expected):
-        r = fetch(self.request, 'api', 'schema', namespace, expected,
+        r = fetch(self.request, 'elyra', 'schema', namespace, expected,
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 200
         namespace_schema = r.json()
@@ -427,7 +427,7 @@ class NamespaceHandlerTest(MetadataTestBase):
     def test_get_namespaces(self):
         expected_namespaces = ['runtimes', 'code-snippets']
 
-        r = fetch(self.request, 'api', 'namespace',
+        r = fetch(self.request, 'elyra', 'namespace',
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 200
         namespaces = r.json()

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -109,9 +109,9 @@ class PipelineProcessorResponse(object):
         return self._object_storage_path
 
     def to_json(self):
-        return {"run-url": self.run_url,
-                "object-storage-url": self.object_storage_url,
-                "object-storage-path": self.object_storage_path
+        return {"run_url": self.run_url,
+                "object_storage_url": self.object_storage_url,
+                "object_storage_path": self.object_storage_path
                 }
 
 

--- a/packages/application/src/services.tsx
+++ b/packages/application/src/services.tsx
@@ -33,7 +33,7 @@ export class FrontendServices {
 
   static async getMetadata(namespace: string): Promise<any> {
     const metadataResponse: any = await RequestHandler.makeGetRequest(
-      'api/metadata/' + namespace,
+      'elyra/metadata/' + namespace,
       false
     );
 

--- a/packages/pipeline-editor/src/PipelineService.tsx
+++ b/packages/pipeline-editor/src/PipelineService.tsx
@@ -65,16 +65,16 @@ export class PipelineService {
     const dialogBody = (
       <p>
         Check the status of your pipeline at{' '}
-        <a href={response['run-url']} target="_blank" rel="noopener noreferrer">
+        <a href={response['run_url']} target="_blank" rel="noopener noreferrer">
           Run Details.
         </a>
         <br />
         The results and outputs are in the {
-          response['object-storage-path']
+          response['object_storage_path']
         }{' '}
         working directory in{' '}
         <a
-          href={response['object-storage-url']}
+          href={response['object_storage_url']}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/packages/pipeline-editor/src/PipelineService.tsx
+++ b/packages/pipeline-editor/src/PipelineService.tsx
@@ -56,7 +56,7 @@ export class PipelineService {
     console.log(pipeline);
 
     const response = await RequestHandler.makePostRequest(
-      'api/pipeline/schedule',
+      'elyra/pipeline/schedule',
       JSON.stringify(pipeline),
       true
     );
@@ -113,7 +113,7 @@ export class PipelineService {
     };
 
     await RequestHandler.makePostRequest(
-      'api/pipeline/export',
+      'elyra/pipeline/export',
       JSON.stringify(body),
       true
     );


### PR DESCRIPTION
Fixes #513 
by changing all endpoints from `/api` to `/elyra`

Fixes #434 
by adding `/elyra/pipeline/schedule` and `/elyra/pipeline/export` into the swagger documentation

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

