### PR TITLE
Add Try Elyra section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,11 @@ includes more details on these features.
 
 ## Try Elyra
 
- You can try out some Elyra features in the following sandbox environments without having to install anything. 
-  - [Binder](https://mybinder.org/v2/gh/elyra-ai/elyra/master?urlpath=lab/tree/binder-demo) ([Learn more...](https://mybinder.readthedocs.io/en/latest/))
+ You can try out some of Elyra features using the [My Binder](https://mybinder.readthedocs.io/en/latest/) service.
+
+ Click on the link below to try Elyra, on a sandbox environment, without having to install anything.
+
+ [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/elyra-ai/elyra/master?urlpath=lab/tree/binder-demo)
 
 ## Installation
 Elyra can be installed via PyPi:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Elyra currently includes:
 The [Elyra Getting Started Guide](https://elyra.readthedocs.io/en/latest/getting_started/overview.html)
 includes more details on these features.
 
+## Try Elyra
+
+ You can try out some Elyra features in the following sandbox environments without having to install anything. 
+  - [Binder](https://mybinder.org/v2/gh/elyra-ai/elyra/master?urlpath=lab/tree/binder-demo) ([Learn more...](https://mybinder.readthedocs.io/en/latest/))
+
 ## Installation
 Elyra can be installed via PyPi:
 


### PR DESCRIPTION
Motivation:
Currently the readme includes a "launch binder" button on the top, which is great for users who know what Binder is. However, users who are not familiar with it might not realize that it provides access to a no-install-required sandbox environment that can be used to try out JupyterLab and extensions (among other things).

Proposal (implemented by this PR):
Add a "Try Elyra" section to the README. Initially this section includes a link to the Elyra Binder deployment and Binder documentation. Later on additional links to other sandbox environments can be added, such as the [Skills Network Labs](https://labs.cognitiveclass.ai/login?next=https%3A%2F%2Flabs.cognitiveclass.ai%2F).


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

