### PR TITLE
Add getting started assets for binder

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 #
 # Copyright 2018-2020 IBM Corporation
@@ -43,13 +42,13 @@ mkdir -p binder-demo
 set -x
 
 # Add getting started assets to Docker image
-# (1) Clone the examples repository
+# (1) Clone the examples repository.
 git clone https://github.com/elyra-ai/examples.git 
 
 EXAMPLES_BASE_DIR=examples
 
-# (2) Copy all getting started assets to the working directory
-#     which is referenced when binder is invoked, w.g. 
+# (2) Copy all getting started assets to the working directory,
+#     which is referenced when binder is invoked, e.g. 
 #     https://mybinder.org/v2/gh/elyra-ai/elyra/master?urlpath=lab/tree/binder-demo
 cp -r $EXAMPLES_BASE_DIR/binder/getting-started/* binder-demo/
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,3 +1,4 @@
+
 #!/bin/bash
 #
 # Copyright 2018-2020 IBM Corporation
@@ -37,3 +38,30 @@ jupyter labextension link --no-build packages/application/
 jupyter labextension link --no-build packages/ui-components/
 jupyter lab build --dev-build=False --minimize=False
 mkdir -p binder-demo
+
+# Enable debug output
+set -x
+
+# Add getting started assets to Docker image
+# (1) Clone the examples repository
+git clone https://github.com/elyra-ai/examples.git 
+
+EXAMPLES_BASE_DIR=examples
+
+# (2) Copy all getting started assets to the working directory
+#     which is referenced when binder is invoked, w.g. 
+#     https://mybinder.org/v2/gh/elyra-ai/elyra/master?urlpath=lab/tree/binder-demo
+cp -r $EXAMPLES_BASE_DIR/binder/getting-started/* binder-demo/
+
+# (3) Remove the code snippets from the working directory.
+#     They need to reside in a different location to be usable.
+rm -rf binder-demo/code-snippets
+
+# (4) Add code snippet files to the appropriate location
+DATA_DIR=`jupyter --data-dir`
+CODE_SNIPPETS_DIR="$DATA_DIR/metadata/code-snippets/"
+mkdir -p $CODE_SNIPPETS_DIR
+cp $EXAMPLES_BASE_DIR/binder/getting-started/code-snippets/*.json $CODE_SNIPPETS_DIR
+
+# (5) Remove cloned examples directory
+rm -rf $EXAMPLES_BASE_DIR


### PR DESCRIPTION
Motivation:

Users can launch JupyterLab/Elyra in binder to test drive some of the features without having to install or configure anything. This PR adds ready-to-use assets that support the test drive and is meant to be an interactive "extension" of the non-interactive getting started documentation https://elyra.readthedocs.io/en/latest/getting_started/overview.html. The idea is that this interactive version is a bit more verbose.

- Example assets:
  - `getting_started.md` - the entry point (can be used to highlight the table of content feature)
  -  ...

 

![image](https://user-images.githubusercontent.com/13068832/83931265-9e1acc00-a750-11ea-9922-2b7b96a4cdc7.png)


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

