### PR TITLE
Change response from elyra/pipeline/export endpoint

### DIFF
--- a/elyra/api/elyra.yaml
+++ b/elyra/api/elyra.yaml
@@ -304,20 +304,22 @@ paths:
             schema:
               $ref: '#/components/schemas/PipelineExportBodyPost'
       responses:
-        200:
+        201:
           description: The pipeline export response
+          headers:
+            Location:
+              description: Resource endpoint
+              schema:
+                type: string
+                format: url
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  status:
+                  export_path:
                     type: string
-                    description: Pipeline export status
-                  message:
-                    type: string
-                    description: Pipeline export message
-
+                    description: Pipeline export path
 
 components:
   schemas:


### PR DESCRIPTION
Update the response to endpoint `elyra/pipeline/export` to return `export_path` and includes the resource URL in the **Location** header

Fixes #609



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

