### PR TITLE
Remove miniconda runtime-image

### DIFF
--- a/etc/config/metadata/runtime-images/miniconda.json
+++ b/etc/config/metadata/runtime-images/miniconda.json
@@ -1,7 +1,0 @@
-{
-  "display_name": "Miniconda Python 3.x",
-  "metadata": {
-    "image_name": "continuumio/miniconda3:latest"
-  },
-  "schema_name": "runtime-image"
-}


### PR DESCRIPTION
The latest miniconda docker image was missing
the curl package required by Elyra. As we already
have anaconda image that works well, we will use
that.

Fixes #621


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

