### PR TITLE
Validate that runtime images meet minimum criteria

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -64,3 +64,12 @@ jobs:
     - name: Collect logs
       if: failure()
       run: cat /tmp/jupyterlab-debug-*.log
+  image_validation:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        clean: true
+    - name: Validate runtime images
+      run: make REMOVE_RUNTIME_IMAGE=1 validate-runtime-images

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@
 #
 
 .PHONY: help purge uninstall clean test-dependencies lint-server lint-ui lint yarn-install build-ui build-server install-server
-.PHONY: install-external-extensions install watch test-server test-ui test-ui-debug test docs-dependencies docs dist-ui release docker-image
+.PHONY: install-external-extensions install watch test-server test-ui test-ui-debug test docs-dependencies docs dist-ui release
+.PHONY: docker-image, validate-runtime-images
 
 SHELL:=/bin/bash
 
@@ -24,6 +25,10 @@ TOC_VERSION:=4.0.0
 
 TAG:=dev
 IMAGE=elyra/elyra:$(TAG)
+
+# Contains the set of commands required to be used by elyra
+REQUIRED_RUNTIME_IMAGE_COMMANDS?="curl python3" 
+REMOVE_RUNTIME_IMAGE?=0  # Invoke `make REMOVE_RUNTIME_IMAGE=1 validate-runtime-images` to have images removed after validation
 
 help:
 # http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
@@ -136,6 +141,33 @@ docker-image: ## Build docker image
 	cp etc/docker/elyra/Dockerfile build/docker/Dockerfile
 	cp etc/docker/elyra/start-elyra.sh build/docker/start-elyra.sh
 	DOCKER_BUILDKIT=1 docker build -t $(IMAGE) build/docker/ --progress plain
+
+validate-runtime-images: ## Validates delivered runtime-images meet minimum criteria
+	@required_commands=$(REQUIRED_RUNTIME_IMAGE_COMMANDS) ; \
+	for file in `find etc/config/metadata/runtime-images -name "*.json"` ; do \
+		image=`grep image_name $$file | awk '{print $$2}' | sed s/\"//g` ; \
+		fail=0; \
+		for cmd in $$required_commands ; do \
+			echo Checking $$image in $$file for $$cmd... ; \
+			docker inspect $$image > /dev/null 2>&1 ; \
+			if [ $$? -ne 0 ]; then \
+				echo Image $$image is not present, pulling... ; \
+			fi; \
+			docker run --rm $$image which $$cmd > /dev/null 2>&1 ; \
+			if [ $$? -ne 0 ]; then \
+				echo ERROR: Image $$image did not meet criteria for command: $$cmd ; \
+				fail=1; \
+			fi; \
+		done; \
+		if [ $(REMOVE_RUNTIME_IMAGE) -eq 1 ]; then \
+			echo Removing image $$image... ; \
+			docker rmi $$image > /dev/null ; \
+		fi; \
+		if [ $$fail -eq 1 ]; then \
+			exit 1; \
+		fi; \
+	done
+
 
 define UNLINK_LAB_EXTENSION
 	- jupyter labextension unlink --no-build $1


### PR DESCRIPTION
Currently validates that each image contains `curl` and `python3`, but that list of commands can be extended in the Makefile (or via a variable).

Because validation can take 10-15 minutes when no images are present, I've created a separate GitHub job to run in parallel with the other platform-specific jobs.  The image-validation job does not use a matrix approach - so the build time should not be much longer than it is now.

By default, the images remain.  This way quicker dev/testing can occur.  The GitHub action, on the other hand, goes ahead and removes each image in case space considerations are an issue.  Developers can quickly remote these images by running validation just like GH Actions:
```
make REMOVE_RUNTIME_IMAGE=1 validate-runtime-images
```

Resolves #631

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

