### PR TITLE
Address metadata update issues

### DIFF
--- a/elyra/api/elyra.yaml
+++ b/elyra/api/elyra.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: Elyra API
-  description: The API for the Elyra extensions
+  description: The API for the Elyra extensions.
   contact:
     name: Elyra
     url: https://github.com/elyra-ai/elyra
@@ -13,10 +13,10 @@ paths:
     get:
       tags:
       - api
-      summary: Get API information (yaml)
+      summary: Get API information (yaml).
       responses:
         200:
-          description: Returns a swagger specification in yaml
+          description: Returns a swagger specification in yaml.
           content:
             text/x-yaml:
               schema:
@@ -28,10 +28,10 @@ paths:
     get:
       tags:
       - namespace
-      summary: Get current namespaces
+      summary: Get current namespaces.
       responses:
         200:
-          description: Returns the list of current namespaces
+          description: Returns the list of current namespaces.
           content:
             application/json:
               schema:
@@ -59,7 +59,7 @@ paths:
           type: string
       responses:
         200:
-          description: Returns the schema instances for a given namespace
+          description: Returns the schema instances for a given namespace.
           content:
             application/json:
               schema:
@@ -67,11 +67,11 @@ paths:
                 properties:
                   namespace:
                     type: array
-                    description: The schema instances within the namespace
+                    description: The schema instances within the namespace.
                     items:
                       $ref: '#/components/schemas/SchemaResource'
         404:
-          description: Namespace not found
+          description: Namespace not found.
           content: {}
         500:
           description: Unexpected error.
@@ -80,29 +80,29 @@ paths:
     get:
       tags:
       - schema
-      summary: Get a given schema instance from a given namespace
+      summary: Get a given schema instance from a given namespace.
       parameters:
       - name: namespace
         in: path
-        description: The name of the namespace
+        description: The name of the namespace.
         required: true
         schema:
           type: string
       - name: resource
         in: path
-        description: The name of the resource in a given namespace
+        description: The name of the resource in a given namespace.
         required: true
         schema:
           type: string
       responses:
         200:
-          description: The named schema instance within the namespace
+          description: The named schema instance within the namespace.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SchemaResource'
         404:
-          description: Namespace/Resource not found
+          description: Namespace/Resource not found.
           content: {}
         500:
           description: Unexpected error.
@@ -111,17 +111,17 @@ paths:
     get:
       tags:
       - metadata
-      summary: Get metadata for a given namespace
+      summary: Get metadata for a given namespace.
       parameters:
       - name: namespace
         in: path
-        description: The name of the namespace
+        description: The name of the namespace.
         required: true
         schema:
           type: string
       responses:
         200:
-          description: The metadata instances within the namespace
+          description: The metadata instances within the namespace.
           content:
             application/json:
               schema:
@@ -133,20 +133,20 @@ paths:
                     items:
                       $ref: '#/components/schemas/MetadataResource'
         400:
-          description: An error (validation, syntax) occurred relative to the instance data
+          description: An error (validation, syntax) occurred relative to the instance data.
         404:
-          description: Namespace not found
+          description: Namespace not found.
           content: {}
         500:
           description: Unexpected error.
     post:
       tags:
       - metadata
-      summary: Create a metadata instance in a given namespace
+      summary: Create a metadata instance in a given namespace.
       parameters:
       - name: namespace
         in: path
-        description: The name of the namespace
+        description: The name of the namespace.
         required: true
         schema:
           type: string
@@ -159,7 +159,7 @@ paths:
 
       responses:
         201:
-          description: The newly-created metadata instance
+          description: The newly-created metadata instance.
           content:
             application/json:
               schema:
@@ -171,11 +171,11 @@ paths:
                 type: string
                 format: url
         400:
-          description: An error (validation, syntax) occurred relative to the instance data
+          description: An error (validation, syntax) occurred relative to the instance data.
         404:
-          description: Namespace not found
+          description: Namespace not found.
         409:
-          description: Resource already exists
+          description: Resource already exists.
         500:
           description: Unexpected error.
 
@@ -183,31 +183,31 @@ paths:
     get:
       tags:
       - metadata
-      summary: Get a given metadata instance from a given namespace
+      summary: Get a given metadata instance from a given namespace.
       parameters:
       - name: namespace
         in: path
-        description: The name of the namespace
+        description: The name of the namespace.
         required: true
         schema:
           type: string
       - name: resource
         in: path
-        description: The name of the resource in a given namespace
+        description: The name of the resource in a given namespace.
         required: true
         schema:
           type: string
       responses:
         200:
-          description: The named metadata instance within the namespace
+          description: The named metadata instance within the namespace.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/MetadataResource'
         400:
-          description: An error (validation, syntax) occurred relative to the instance data
+          description: An error (validation, syntax) occurred relative to the instance data.
         404:
-          description: Namespace/Resource not found
+          description: Namespace/Resource not found.
           content: {}
         500:
           description: Unexpected error.
@@ -215,17 +215,17 @@ paths:
     put:
       tags:
         - metadata
-      summary: Update a given metadata resource within a given namespace
+      summary: Update a given metadata resource within a given namespace.
       parameters:
         - name: namespace
           in: path
-          description: The name of the namespace
+          description: The name of the namespace.
           required: true
           schema:
             type: string
         - name: resource
           in: path
-          description: The name of the resource in a given namespace
+          description: The name of the resource in a given namespace.
           required: true
           schema:
             type: string
@@ -238,44 +238,44 @@ paths:
 
       responses:
         200:
-          description: The updated metadata instance
+          description: The updated metadata instance.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/MetadataResource'
         400:
-          description: An error (validation, syntax, not supported) occurred relative to the instance data
+          description: An error (validation, syntax, not supported) occurred relative to the instance data.
         404:
-          description: The resource to update was not found
+          description: The resource to update was not found.
         500:
           description: Unexpected error.
 
     delete:
       tags:
       - metadata
-      summary: Delete a given metadata resource from a given namespace
+      summary: Delete a given metadata resource from a given namespace.
       parameters:
       - name: namespace
         in: path
-        description: The name of the namespace
+        description: The name of the namespace.
         required: true
         schema:
           type: string
       - name: resource
         in: path
-        description: The name of the resource in a given namespace
+        description: The name of the resource in a given namespace.
         required: true
         schema:
           type: string
       responses:
         204:
-          description: The resource was successfully deleted
+          description: The resource was successfully deleted.
         400:
-          description: An error (validation, syntax) occurred relative to the instance data
+          description: An error (validation, syntax) occurred relative to the instance data.
         403:
-          description: Deletion of the resource is not permitted
+          description: Deletion of the resource is not permitted.
         404:
-          description: The resource was not found
+          description: The resource was not found.
         500:
           description: Unexpected error.
 
@@ -283,7 +283,7 @@ paths:
     post:
       tags:
       - pipeline
-      summary: Execute pipelines as batch jobs
+      summary: Execute pipelines as batch jobs.
       requestBody:
         required: true
         content:
@@ -292,7 +292,7 @@ paths:
               $ref: '#/components/schemas/PipelineResource'
       responses:
         200:
-          description: The pipeline processor response
+          description: The pipeline processor response.
           content:
             application/json:
               schema:
@@ -302,7 +302,7 @@ paths:
     post:
       tags:
       - pipeline
-      summary: Export pipeline
+      summary: Export a pipeline.
       requestBody:
         required: true
         content:
@@ -311,10 +311,10 @@ paths:
               $ref: '#/components/schemas/PipelineExportBodyPost'
       responses:
         201:
-          description: The pipeline export response
+          description: The pipeline export response.
           headers:
             Location:
-              description: Resource endpoint
+              description: The resource endpoint.
               schema:
                 type: string
                 format: url
@@ -325,12 +325,12 @@ paths:
                 properties:
                   export_path:
                     type: string
-                    description: Pipeline export path
+                    description: The pipeline export path.
 
 components:
   schemas:
     MetadataResourceBody:
-      description: The set of properties comprising the request body for POST
+      description: The set of properties comprising the request body for POST and PUT requests.
       required:
         - display_name
         - schema_name
@@ -345,7 +345,7 @@ components:
           description: The display name of the resource.
         schema_name:
           type: string
-          description: The schema name used to validate the resource
+          description: The schema name used to validate the resource.
         metadata:
           type: object
           properties: {}
@@ -353,7 +353,7 @@ components:
             about the resource.
 
     MetadataResource:
-      description: The set of properties comprising a metadata resource entity
+      description: The set of properties comprising a metadata resource entity.
       required:
       - display_name
       - name
@@ -362,13 +362,13 @@ components:
       properties:
         name:
           type: string
-          description: The canonical name of the metadata resource
+          description: The canonical name of the metadata resource.
         display_name:
           type: string
-          description: The display name of the metadata resource
+          description: The display name of the metadata resource.
         schema_name:
           type: string
-          description: The schema name used to validate the metadata resource
+          description: The schema name used to validate the metadata resource.
         metadata:
           type: object
           properties: {}
@@ -376,7 +376,7 @@ components:
             about the resource.
 
     SchemaResource:
-      description: The set of properties comprising a schema resource entity
+      description: The set of properties comprising a schema resource entity.
       required:
       - name
       - namespace
@@ -384,13 +384,13 @@ components:
       properties:
         namespace:
           type: string
-          description: The namespace of the schema resource
+          description: The namespace of the schema resource.
         name:
           type: string
-          description: The canonical name of the schema resource
+          description: The canonical name of the schema resource.
         title:
           type: string
-          description: The title of the schema resource
+          description: The title of the schema resource.
         properties:
           type: object
           properties: {}
@@ -398,7 +398,7 @@ components:
             about the resource.
 
     PipelineResource:
-      description: The set of properties comprising a pipeline resource entity
+      description: The set of properties comprising a pipeline resource entity.
       required:
         - primary_pipeline
         - pipelines
@@ -406,36 +406,36 @@ components:
       properties:
         primary_pipeline:
           type: string
-          description: The primary pipeline id
+          description: The primary pipeline id.
         pipelines:
           type: array
-          description: A set of pipeline definitions
+          description: A set of pipeline definitions.
           items:
             type: object
             properties:
               id:
                 type: string
-                description: The unique identifier of the pipeline
+                description: The unique identifier of the pipeline.
               name:
                 type: string
-                description: The name of the pipeline
+                description: The name of the pipeline.
               nodes:
                 type: array
-                description: The set of nodes in the pipeline
+                description: The set of nodes in the pipeline.
                 items:
                   type: object
                   properties: {}
-                  description: The node configuration
+                  description: The node configuration.
               runtime:
                 type: string
-                description: The runtime type for the pipeline
+                description: The runtime type for the pipeline.
               runtime-config:
                 type: object
                 properties: {}
-                description: Runtime configuration that should be used to submit the pipeline
+                description: The runtime configuration that should be used to submit the pipeline.
 
     PipelineScheduleResponse:
-      description: The set of properties comprising a pipeline processor response entity
+      description: The set of properties comprising a pipeline processor response entity.
       required:
       - run_url
       - object_storage_url
@@ -444,18 +444,18 @@ components:
       properties:
         run_url:
           type: string
-          description: The runtime URL to access the pipeline experiment
+          description: The runtime URL to access the pipeline experiment.
         object_storage_url:
           type: string
           description: The object storage URL to access the pipeline outputs
-            and processed notebooks
+            and processed notebooks.
         object_storage_path:
           type: string
           description: The object storage working directory path where the pipeline outputs
-            and processed notebooks are located
+            and processed notebooks are located.
 
     PipelineExportBodyPost:
-      description: The set of properties comprising the request body for POST
+      description: The set of properties comprising the request body for POST request.
       required:
         - pipeline
         - export_format
@@ -467,26 +467,26 @@ components:
           $ref: '#/components/schemas/PipelineResource'
         export_format:
           type: string
-          description: Pipeline export format
+          description: The pipeline export format.
         export_path:
           type: string
-          description: Pipeline export path
+          description: The pipeline export path.
         overwrite:
           type: boolean
-          description: True if existing export should be overwritten
+          description: Determines if the existing export should be overwritten.
 
   parameters:
     namespace:
       name: namespace
       in: path
-      description: The name of the namespace
+      description: The name of the namespace.
       required: true
       schema:
         type: string
     resource:
       name: resource
       in: path
-      description: The name of the resource in a given namespace
+      description: The name of the resource in a given namespace.
       required: true
       schema:
         type: string

--- a/elyra/api/elyra.yaml
+++ b/elyra/api/elyra.yaml
@@ -132,6 +132,8 @@ paths:
                     description: The name of the namespace.
                     items:
                       $ref: '#/components/schemas/MetadataResource'
+        400:
+          description: An error (validation, syntax) occurred relative to the instance data
         404:
           description: Namespace not found
           content: {}
@@ -153,7 +155,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MetadataResourceBodyPost'
+              $ref: '#/components/schemas/MetadataResourceBody'
 
       responses:
         201:
@@ -202,6 +204,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MetadataResource'
+        400:
+          description: An error (validation, syntax) occurred relative to the instance data
         404:
           description: Namespace/Resource not found
           content: {}
@@ -230,7 +234,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/MetadataResourceBodyPut'
+              $ref: '#/components/schemas/MetadataResourceBody'
 
       responses:
         200:
@@ -240,7 +244,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/MetadataResource'
         400:
-          description: The operation is not supported
+          description: An error (validation, syntax, not supported) occurred relative to the instance data
         404:
           description: The resource to update was not found
         500:
@@ -266,6 +270,8 @@ paths:
       responses:
         204:
           description: The resource was successfully deleted
+        400:
+          description: An error (validation, syntax) occurred relative to the instance data
         403:
           description: Deletion of the resource is not permitted
         404:
@@ -323,40 +329,20 @@ paths:
 
 components:
   schemas:
-    MetadataResourceBodyPost:
+    MetadataResourceBody:
       description: The set of properties comprising the request body for POST
       required:
         - display_name
-        - name
         - schema_name
         - metadata
       type: object
       properties:
         name:
           type: string
-          description: The canonical name of the resource
+          description: The canonical name of the resource.  Will be derived from display_name if not provided on POST.
         display_name:
           type: string
-          description: The display name of the resource
-        schema_name:
-          type: string
-          description: The schema name used to validate the resource
-        metadata:
-          type: object
-          properties: {}
-          description: A free-form dictionary consisting of additional information
-            about the resource.
-
-    MetadataResourceBodyPut:
-      description: The set of properties comprising the request body for PUT; no field is required
-      type: object
-      properties:
-        name:
-          type: string
-          description: The canonical name of the resource
-        display_name:
-          type: string
-          description: The display name of the resource
+          description: The display name of the resource.
         schema_name:
           type: string
           description: The schema name used to validate the resource

--- a/elyra/metadata/metadata.py
+++ b/elyra/metadata/metadata.py
@@ -285,12 +285,13 @@ class FileMetadataStore(MetadataStore):
         if not isinstance(metadata, Metadata):
             raise TypeError("'metadata' is not an instance of class 'Metadata'.")
 
-        if not name:
+        if not name and not replace:  # name is derived from display_name only on creates
             if metadata.display_name:
                 name = self._get_normalized_name(metadata.display_name)
                 metadata.name = name
-            else:
-                raise ValueError('Name of metadata was not provided.')
+
+        if not name:  # At this point, name must be set
+            raise ValueError('Name of metadata was not provided.')
 
         match = re.search("^[a-z][a-z0-9-_]*[a-z,0-9]$", name)
         if match is None:
@@ -358,6 +359,9 @@ class FileMetadataStore(MetadataStore):
                 if renamed_resource:  # Restore the renamed file
                     os.rename(renamed_resource, resource)
             raise ve
+
+        if renamed_resource:  # Remove the renamed file
+            os.remove(renamed_resource)
 
         return metadata
 

--- a/elyra/metadata/metadata.py
+++ b/elyra/metadata/metadata.py
@@ -171,8 +171,8 @@ class MetadataStore(ABC):
     def __init__(self, namespace, **kwargs):
         self.schema_mgr = SchemaManager.instance()
         if not self.schema_mgr.is_valid_namespace(namespace):
-            raise FileNotFoundError("Namespace '{}' is not in the list of valid namespaces: {}".
-                                    format(namespace, self.schema_mgr.get_namespaces()))
+            raise ValueError("Namespace '{}' is not in the list of valid namespaces: {}".
+                             format(namespace, self.schema_mgr.get_namespaces()))
 
         self.namespace = namespace
         self.log = log.get_logger()

--- a/elyra/metadata/tests/test_handlers.py
+++ b/elyra/metadata/tests/test_handlers.py
@@ -71,7 +71,7 @@ class MetadataHandlerTest(MetadataTestBase):
         # Remove self.request (and other 'self.' prefixes) once transition to jupyter_server occurs
         r = fetch(self.request, 'elyra', 'metadata', 'bogus', 'missing',
                   base_url=self.base_url(), headers=self.auth_headers())
-        assert r.status_code == 404
+        assert r.status_code == 400
         assert "Namespace 'bogus' is not in the list of valid namespaces:" in r.text
         assert not os.path.exists(self.metadata_bogus_dir)
 

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -66,7 +66,7 @@ def test_validate_factory_schemas():
 # ########################## MetadataManager Tests ###########################
 def test_manager_add_invalid(tests_manager, data_dir):
 
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(ValueError):
         MetadataManager(namespace='invalid')
 
     # Attempt with non Metadata instance

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -403,6 +403,24 @@ def test_manager_hierarchy_update(tests_hierarchy_manager, factory_dir, shared_d
     assert byo_2.resource.startswith(str(shared_dir))
 
 
+def _ensure_single_file(metadata_tests_dir, filename, expected_count=1):
+    """Because updates can trigger the copy of the original, this methods ensures that
+       only the name file (`filename`) exists after the operation.  The expected_count
+       can be altered so that it can also be used to ensure clean removals.
+    """
+    # Ensure only the actual metadata file exists.  The renamed file will start with 'filename' but have
+    # a timestamp appended to it.
+    count = 0
+    actual = 0
+    for f in os.listdir(str(metadata_tests_dir)):
+        if filename in f:
+            count = count + 1
+        if filename == f:
+            actual = actual + 1
+    assert count == expected_count, "Temporarily renamed file was not removed"
+    assert actual == expected_count
+
+
 def test_manager_update(tests_hierarchy_manager, metadata_tests_dir):
 
     # Create some metadata, then attempt to update it with a known schema violation
@@ -422,17 +440,7 @@ def test_manager_update(tests_hierarchy_manager, metadata_tests_dir):
     instance2.metadata['number_range_test'] = 7
     tests_hierarchy_manager.add('update', instance2, replace=True)
 
-    # Ensure only the actual metadata file exists.  The renamed file will start with 'update.json' but have
-    # a timestamp appended to it.
-    count = 0
-    actual = 0
-    for f in os.listdir(str(metadata_tests_dir)):
-        if "update.json" in f:
-            count = count + 1
-        if "update.json" == f:
-            actual = actual + 1
-    assert count == 1, "Renamed file was not removed"
-    assert actual == 1
+    _ensure_single_file(metadata_tests_dir, "update.json")
 
     instance2 = tests_hierarchy_manager.get('update')
     assert instance2.display_name == 'user2'
@@ -460,15 +468,19 @@ def test_manager_bad_update(tests_hierarchy_manager, metadata_tests_dir):
     with pytest.raises(ValidationError):
         tests_hierarchy_manager.add('bad_update', instance2, replace=True)
 
+    _ensure_single_file(metadata_tests_dir, "bad_update.json")
+
     instance2 = tests_hierarchy_manager.get('bad_update')
     assert instance2.display_name == instance.display_name
     assert 'number_range_test' not in instance2.metadata
 
-    # Now try update within providing a name, ValueError expected
+    # Now try update without providing a name, ValueError expected
     instance2 = tests_hierarchy_manager.get('bad_update')
     instance2.display_name = 'user update with no name'
     with pytest.raises(ValueError):
         tests_hierarchy_manager.add(None, instance2, replace=True)
+
+    _ensure_single_file(metadata_tests_dir, "bad_update.json")
 
 
 def test_manager_hierarchy_remove(tests_hierarchy_manager, factory_dir, shared_dir, metadata_tests_dir):
@@ -501,6 +513,7 @@ def test_manager_hierarchy_remove(tests_hierarchy_manager, factory_dir, shared_d
 
     # Now remove instance.  Should be allowed since it resides in user area
     tests_hierarchy_manager.remove('byo_2')
+    _ensure_single_file(metadata_tests_dir, "byo_2.json", expected_count=0)
 
     # Attempt to remove instance from shared area and its protected
     with pytest.raises(PermissionError) as pe:


### PR DESCRIPTION
This pull request contains several changes, most of which were inter-related...
- Prevent data loss on updates
Data loss of failed update attempts is now prevented.  We now validate the metadata against its schema before persistence.  In addition, we rename the original file and if there are issues writing the updated file or schema validation fails after the write, then the renamed original is restored and an exception is raised reflecting the failure.

- Adjust exception to status code mappings
ValidationError and ValueError exceptions now return 400 status codes.  Previously, they were associated with 404.  Now only FileNotFoundErrors will result in 404 codes - this includes things like missing namespace or schema. 

- Require full body on PUT requests
Previously, PUT didn't require required properties since it would just overlay the updates on a newly fetched copy.  However, that approach does not lend itself to _removing_ fields from a schema instance - since there's no way to distinguish a field that wasn't sent from one being removed.  As a result, PUT behaves just like POST relative to the body requirement.  Neither requires a `name` field since POST will derive `name` from `display_name` and PUT will infer name from the `resource` in the endpoint.  This leads to a more simplified Swagger doc in that there's now a single metadata resource body description.

- Schema is required for metadata
In that same vein, we now require all metadata to be associated with a schema and, since schema_name is required in the schema file, metadata missing a schema designation will be considered invalid.

- Fix test side-effect
I found some issues with tests where one test was side-effecting another because the static test data was shallowed copied.  Once the deep copy was performed the tests side-effects stopped.

Fixes #637


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

