### PR TITLE
Added endpoint to 404 dialog text

### DIFF
--- a/packages/application/src/requests.tsx
+++ b/packages/application/src/requests.tsx
@@ -64,10 +64,14 @@ export class RequestHandler {
    *
    * @returns A promise that resolves with whether the dialog was accepted.
    */
-  private static server404(): Promise<Dialog.IResult<any>> {
+  private static server404(endpoint: string): Promise<Dialog.IResult<any>> {
     return showDialog({
       title: 'Error contacting server',
-      body: <p>Elyra service endpoint not found.</p>,
+      body: (
+        <p>
+          Endpoint <code>{endpoint}</code> not found.
+        </p>
+      ),
       buttons: [Dialog.okButton()]
     });
   }
@@ -193,7 +197,7 @@ export class RequestHandler {
             },
             // handle 404 if the server is not found
             (reason: any) => {
-              return this.server404();
+              return this.server404(requestPath);
             }
           );
         },


### PR DESCRIPTION
Added the api endpoint that returns the 404 to the 404 dialog text

Fixes #639

<img width="463" alt="Screen Shot 2020-06-12 at 5 16 51 PM" src="https://user-images.githubusercontent.com/13952758/84555458-f3675800-acd1-11ea-9c26-5dfab8865ba5.png">

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

