### PR TITLE
Fix input and output parsing errors

### DIFF
--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 import kfp
 import os
 import tempfile
@@ -197,9 +196,12 @@ class KfpPipelineProcessor(PipelineProcessor):
                                      cos_bucket=cos_bucket,
                                      cos_directory=cos_directory,
                                      cos_dependencies_archive=operation_artifact_archive,
-                                     pipeline_inputs=self._artifact_list_to_str(operation.inputs),
-                                     pipeline_outputs=self._artifact_list_to_str(operation.outputs),
                                      image=operation.runtime_image)
+
+            if operation.inputs:
+                notebook_op.add_pipeline_inputs(self._artifact_list_to_str(operation.inputs))
+            if operation.outputs:
+                notebook_op.add_pipeline_outputs(self._artifact_list_to_str(operation.outputs))
 
             notebook_op.container.add_env_variable(V1EnvVar(name='AWS_ACCESS_KEY_ID', value=cos_username))
             notebook_op.container.add_env_variable(V1EnvVar(name='AWS_SECRET_ACCESS_KEY', value=cos_password))
@@ -241,10 +243,10 @@ class KfpPipelineProcessor(PipelineProcessor):
         return notebook_ops
 
     def _artifact_list_to_str(self, pipeline_array):
-        if not pipeline_array:
-            return "None"
-        else:
-            return ','.join(pipeline_array)
+        trimmed_artifact_list = []
+        for artifact_name in pipeline_array:
+            trimmed_artifact_list.append(artifact_name.strip())
+        return ','.join(trimmed_artifact_list)
 
     def _get_dependency_archive_name(self, operation):
         archive_name = os.path.basename(operation.filename)


### PR DESCRIPTION
Strip and remove whitespace in file lists to avoid
parsing errors during bootstrapping in the container

I wanted to trim that whitespace out of there as soon as possible before it
got to kfp-notebook so I put it into this PR

To be merged with https://github.com/elyra-ai/kfp-notebook/pull/31
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

