### PR TITLE
Show user friendly names in tooltip

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -303,7 +303,7 @@ export class PipelineEditor extends React.Component<
         'runtime_image.' + runtimeImage + '.label'
       ] = runtimeImages[runtimeImage];
     }
-    properties.parameters[0].enum = imageEnum;
+    properties.parameters[1].enum = imageEnum;
 
     this.propertiesInfo = {
       parameterDef: properties,
@@ -319,6 +319,7 @@ export class PipelineEditor extends React.Component<
     const node_props = this.propertiesInfo;
     node_props.appData.id = node_id;
 
+    node_props.parameterDef.current_parameters.filename = app_data.filename;
     node_props.parameterDef.current_parameters.runtime_image =
       app_data.runtime_image;
     node_props.parameterDef.current_parameters.outputs = app_data.outputs;

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -422,24 +422,20 @@ export class PipelineEditor extends React.Component<
   tipHandler(tipType: string, data: any): any {
     if (tipType === TIP_TYPE_NODE) {
       const appData = this.canvasController.getNode(data.node.id).app_data;
-      const nodeProps = Object.assign({}, appData);
       const propsInfo = this.propertiesInfo.parameterDef.uihints.parameter_info;
+      const tooltipProps: any = {};
 
       propsInfo.forEach(
-        (info: {
-          parameter_ref: string | number;
-          label: { default: string | number };
-        }) => {
+        (info: { parameter_ref: string; label: { default: string } }) => {
           if (
-            Object.prototype.hasOwnProperty.call(nodeProps, info.parameter_ref)
+            Object.prototype.hasOwnProperty.call(appData, info.parameter_ref)
           ) {
-            nodeProps[info.label.default] = nodeProps[info.parameter_ref];
-            delete nodeProps[info.parameter_ref];
+            tooltipProps[info.label.default] = appData[info.parameter_ref];
           }
         }
       );
 
-      return <NodeProperties {...nodeProps} />;
+      return <NodeProperties {...tooltipProps} />;
     }
   }
 

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -421,8 +421,25 @@ export class PipelineEditor extends React.Component<
    */
   tipHandler(tipType: string, data: any): any {
     if (tipType === TIP_TYPE_NODE) {
-      const properties = this.canvasController.getNode(data.node.id).app_data;
-      return <NodeProperties {...properties} />;
+      const appData = this.canvasController.getNode(data.node.id).app_data;
+      const nodeProps = Object.assign({}, appData);
+      const propsInfo = this.propertiesInfo.parameterDef.uihints.parameter_info;
+
+      propsInfo.forEach(
+        (info: {
+          parameter_ref: string | number;
+          label: { default: string | number };
+        }) => {
+          if (
+            Object.prototype.hasOwnProperty.call(nodeProps, info.parameter_ref)
+          ) {
+            nodeProps[info.label.default] = nodeProps[info.parameter_ref];
+            delete nodeProps[info.parameter_ref];
+          }
+        }
+      );
+
+      return <NodeProperties {...nodeProps} />;
     }
   }
 

--- a/packages/pipeline-editor/src/properties.json
+++ b/packages/pipeline-editor/src/properties.json
@@ -35,7 +35,7 @@
         "parameter_ref": "runtime_image",
         "control": "oneofselect",
         "label": {
-          "default": "Runtime Image (docker image used as execution environment)."
+          "default": "Runtime Image (docker image used as execution environment)"
         }
       },
       {
@@ -50,7 +50,7 @@
       {
         "parameter_ref": "include_subdirectories",
         "label": {
-          "default": "Include subdirectories in dependencies (may increase submission time)."
+          "default": "Include Subdirectories in Dependencies (may increase submission time)"
         }
       },
       {

--- a/packages/pipeline-editor/src/properties.json
+++ b/packages/pipeline-editor/src/properties.json
@@ -1,5 +1,6 @@
 {
   "current_parameters": {
+    "filename": "",
     "runtime_image": "",
     "outputs": [],
     "env_vars": [],
@@ -7,6 +8,10 @@
     "include_subdirectories": false
   },
   "parameters": [
+    {
+      "id": "filename",
+      "type": "string"
+    },
     {
       "id": "runtime_image",
       "enum": []
@@ -31,6 +36,13 @@
   "uihints": {
     "id": "nodeProperties",
     "parameter_info": [
+      {
+        "parameter_ref": "filename",
+        "control": "readonly",
+        "label": {
+          "default": "Filename"
+        }
+      },
       {
         "parameter_ref": "runtime_image",
         "control": "oneofselect",


### PR DESCRIPTION
Display friendly name for property fields shown in pipeline node hover tooltip

Fixes #657 

FYI, using the default label from the properties info displays the full label (same as it appears in the properties dialog):

![image](https://user-images.githubusercontent.com/13156555/85073592-13db5a80-b189-11ea-9d82-dc07e1d48c71.png)


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

