### PR TITLE
Replace invalid character in kfp pipeline template

### DIFF
--- a/elyra/templates/kfp_template.jinja2
+++ b/elyra/templates/kfp_template.jinja2
@@ -10,7 +10,8 @@ from kfp_notebook.pipeline import NotebookOp
 def create_pipeline():
     {% for key, operation in operations_list.items() %}
         {% set op_name = operation.notebook_name.split('.') %}
-            notebook_op_{{ op_name[0] }} = NotebookOp(name='{{ op_name[0] }}',
+        {% set operation_id = op_name[0] | replace ("/","_") %}
+            notebook_op_{{ operation_id }} = NotebookOp(name='{{ operation_id }}',
                                                           notebook='{{ operation.notebook_name }}',
                                                           cos_endpoint='{{ operation.cos_endpoint }}',
                                                           cos_bucket='{{ operation.cos_bucket }}',
@@ -20,9 +21,9 @@ def create_pipeline():
                                                           pipeline_outputs='{{ operation.pipeline_outputs }}',
                                                           image='{{ operation.image }}')
 
-            notebook_op_{{ op_name[0] }}.name = '{{ operation.name }}'
-            notebook_op_{{ op_name[0] }}.env_variables = {{ operation.env_variables }}
-            notebook_op_{{ op_name[0] }}.dependent_names = {{ operation.dependent_names }}
+            notebook_op_{{ operation_id }}.name = '{{ operation.name }}'
+            notebook_op_{{ operation_id }}.env_variables = {{ operation.env_variables }}
+            notebook_op_{{ operation_id }}.dependent_names = {{ operation.dependent_names }}
 
     {% endfor %}
 


### PR DESCRIPTION
The kfp template uses the operation name as part of a variable
name which could contain forward slashes if the notebook resides
in a subdirectory.

Fixes #668


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

