### PR TITLE
Honor notebook directory when locating dependencies

### DIFF
--- a/elyra/__init__.py
+++ b/elyra/__init__.py
@@ -20,7 +20,7 @@ from notebook.utils import url_path_join
 from .api.handlers import YamlSpecHandler
 from .metadata.handlers import MetadataHandler, MetadataResourceHandler, SchemaHandler, SchemaResourceHandler, \
     NamespaceHandler
-from .pipeline import PipelineExportHandler, PipelineSchedulerHandler
+from .pipeline import PipelineExportHandler, PipelineSchedulerHandler, PipelineProcessorManager
 
 namespace_regex = r"(?P<namespace>[\w\.\-]+)"
 resource_regex = r"(?P<resource>[\w\.\-]+)"
@@ -47,4 +47,6 @@ def load_jupyter_server_extension(nb_server_app):
         (url_path_join(web_app.settings['base_url'], r'/elyra/pipeline/schedule'), PipelineSchedulerHandler),
         (url_path_join(web_app.settings['base_url'], r'/elyra/pipeline/export'), PipelineExportHandler),
     ])
+    # Create PipelineProcessorManager instance passing root directory
+    PipelineProcessorManager.instance(root_dir=web_app.settings['server_root_dir'])
 

--- a/elyra/pipeline/handlers.py
+++ b/elyra/pipeline/handlers.py
@@ -49,7 +49,7 @@ class PipelineExportHandler(HttpErrorMixin, APIHandler):
 
         pipeline = PipelineParser.parse(pipeline_definition)
 
-        pipeline_exported_path = PipelineProcessorManager.export(
+        pipeline_exported_path = PipelineProcessorManager.instance().export(
             pipeline,
             pipeline_export_format,
             pipeline_export_path,
@@ -90,7 +90,7 @@ class PipelineSchedulerHandler(HttpErrorMixin, APIHandler):
 
         pipeline = PipelineParser.parse(pipeline_definition)
 
-        response = PipelineProcessorManager.process(pipeline)
+        response = PipelineProcessorManager.instance().process(pipeline)
         json_msg = json.dumps(response.to_json())
 
         self.set_status(200)

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -252,7 +252,7 @@ class KfpPipelineProcessor(PipelineProcessor):
         return name + '-' + operation.id + ".tar.gz"
 
     def _get_dependency_source_dir(self, operation):
-        return os.path.join(os.getcwd(), os.path.dirname(operation.filename))
+        return os.path.join(self.root_dir, os.path.dirname(operation.filename))
 
     def _generate_dependency_archive(self, operation):
         archive_artifact_name = self._get_dependency_archive_name(operation)


### PR DESCRIPTION
Rather than use the current working directory to establish the parent
directory for dependency locations, use the root-dir (notebook-dir)
instead. This enables the user to start the notebook server from
wherever they like while pointing at their notebook directory.

Fixes #670



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

