### PR TITLE
Validate pipeline form dialogs

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -542,7 +542,7 @@ export class PipelineEditor extends React.Component<
       defaultButton: 1,
       focusNodeSelector: '#runtime_config'
     };
-    const dialogResult = await showFormDialog(dialogOptions, '');
+    const dialogResult = await showFormDialog(dialogOptions);
 
     if (dialogResult.value == null) {
       // When Cancel is clicked on the dialog, just return
@@ -657,7 +657,7 @@ export class PipelineEditor extends React.Component<
       defaultButton: 1,
       focusNodeSelector: '#pipeline_name'
     };
-    const dialogResult = await showFormDialog(dialogOptions, '');
+    const dialogResult = await showFormDialog(dialogOptions);
 
     if (dialogResult.value == null) {
       // When Cancel is clicked on the dialog, just return

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -535,16 +535,15 @@ export class PipelineEditor extends React.Component<
 
   async handleExportPipeline(): Promise<void> {
     const runtimes = await PipelineService.getRuntimes();
-    const dialogBody = new PipelineExportDialog({ runtimes });
     const dialogOptions: Partial<Dialog.IOptions<any>> = {
       title: 'Export pipeline',
-      body: dialogBody,
+      body: new PipelineExportDialog({ runtimes }),
       buttons: [Dialog.cancelButton(), Dialog.okButton()],
       defaultButton: 1,
       focusNodeSelector: '#runtime_config'
     };
-
     const dialogResult = await showFormDialog(dialogOptions, '');
+
     if (dialogResult.value == null) {
       // When Cancel is clicked on the dialog, just return
       return;
@@ -651,31 +650,35 @@ export class PipelineEditor extends React.Component<
 
   async handleRunPipeline(): Promise<void> {
     const runtimes = await PipelineService.getRuntimes();
-
-    showDialog({
+    const dialogOptions: Partial<Dialog.IOptions<any>> = {
       title: 'Run pipeline',
       body: new PipelineSubmissionDialog({ runtimes }),
       buttons: [Dialog.cancelButton(), Dialog.okButton()],
+      defaultButton: 1,
       focusNodeSelector: '#pipeline_name'
-    }).then(result => {
-      if (result.value == null) {
-        // When Cancel is clicked on the dialog, just return
-        return;
-      }
+    };
+    const dialogResult = await showFormDialog(dialogOptions, '');
 
-      // prepare pipeline submission details
-      const pipelineFlow = this.canvasController.getPipelineFlow();
+    if (dialogResult.value == null) {
+      // When Cancel is clicked on the dialog, just return
+      return;
+    }
 
-      pipelineFlow.pipelines[0]['app_data']['name'] =
-        result.value.pipeline_name;
+    // prepare pipeline submission details
+    const pipelineFlow = this.canvasController.getPipelineFlow();
 
-      // TODO: Be more flexible and remove hardcoded runtime type
-      pipelineFlow.pipelines[0]['app_data']['runtime'] = 'kfp';
-      pipelineFlow.pipelines[0]['app_data']['runtime-config'] =
-        result.value.runtime_config;
+    pipelineFlow.pipelines[0]['app_data']['name'] =
+      dialogResult.value.pipeline_name;
 
-      PipelineService.submitPipeline(pipelineFlow, result.value.runtime_config);
-    });
+    // TODO: Be more flexible and remove hardcoded runtime type
+    pipelineFlow.pipelines[0]['app_data']['runtime'] = 'kfp';
+    pipelineFlow.pipelines[0]['app_data']['runtime-config'] =
+      dialogResult.value.runtime_config;
+
+    PipelineService.submitPipeline(
+      pipelineFlow,
+      dialogResult.value.runtime_config
+    );
   }
 
   handleSavePipeline(): void {

--- a/packages/pipeline-editor/src/PipelineExportDialog.tsx
+++ b/packages/pipeline-editor/src/PipelineExportDialog.tsx
@@ -72,12 +72,12 @@ export class PipelineExportDialog extends Widget
     const content =
       '<label for="runtime_config">Runtime Config:</label>' +
       br +
-      '<select id="runtime_config" name="runtime_config" class="elyra-form-runtime-config">' +
+      '<select id="runtime_config" name="runtime_config" class="elyra-form-runtime-config" data-required="required">' +
       runtime_options +
       '</select>' +
       '<label for="pipeline_filetype">Export Pipeline as:</label>' +
       br +
-      '<select id="pipeline_filetype" name="pipeline_filetype" class="elyra-form-export-filetype">' +
+      '<select id="pipeline_filetype" name="pipeline_filetype" class="elyra-form-export-filetype" data-required="required">' +
       filetype_options +
       '</select>' +
       '<input type="checkbox" id="overwrite"/>' +

--- a/packages/pipeline-editor/src/PipelineExportDialog.tsx
+++ b/packages/pipeline-editor/src/PipelineExportDialog.tsx
@@ -72,12 +72,12 @@ export class PipelineExportDialog extends Widget
     const content =
       '<label for="runtime_config">Runtime Config:</label>' +
       br +
-      '<select id="runtime_config" name="runtime_config" class="elyra-form-runtime-config" data-required="required">' +
+      '<select id="runtime_config" name="runtime_config" class="elyra-form-runtime-config" data-form-required>' +
       runtime_options +
       '</select>' +
       '<label for="pipeline_filetype">Export Pipeline as:</label>' +
       br +
-      '<select id="pipeline_filetype" name="pipeline_filetype" class="elyra-form-export-filetype" data-required="required">' +
+      '<select id="pipeline_filetype" name="pipeline_filetype" class="elyra-form-export-filetype" data-form-required>' +
       filetype_options +
       '</select>' +
       '<input type="checkbox" id="overwrite"/>' +

--- a/packages/pipeline-editor/src/PipelineSubmissionDialog.tsx
+++ b/packages/pipeline-editor/src/PipelineSubmissionDialog.tsx
@@ -62,12 +62,12 @@ export class PipelineSubmissionDialog extends Widget
       '' +
       '<label for="pipeline_name">Pipeline Name:</label>' +
       br +
-      '<input type="text" id="pipeline_name" name="pipeline_name" placeholder="Pipeline Name" data-required="required"/>' +
+      '<input type="text" id="pipeline_name" name="pipeline_name" placeholder="Pipeline Name" data-form-required/>' +
       br +
       br +
       '<label for="runtime_config">Runtime Config:</label>' +
       br +
-      '<select id="runtime_config" name="runtime_config" class="elyra-form-runtime-config" data-required="required">' +
+      '<select id="runtime_config" name="runtime_config" class="elyra-form-runtime-config" data-form-required>' +
       runtime_options +
       '</select>';
 

--- a/packages/pipeline-editor/src/PipelineSubmissionDialog.tsx
+++ b/packages/pipeline-editor/src/PipelineSubmissionDialog.tsx
@@ -62,12 +62,12 @@ export class PipelineSubmissionDialog extends Widget
       '' +
       '<label for="pipeline_name">Pipeline Name:</label>' +
       br +
-      '<input type="text" id="pipeline_name" name="pipeline_name" placeholder="Pipeline Name"/>' +
+      '<input type="text" id="pipeline_name" name="pipeline_name" placeholder="Pipeline Name" data-required="required"/>' +
       br +
       br +
       '<label for="runtime_config">Runtime Config:</label>' +
       br +
-      '<select id="runtime_config" name="runtime_config" class="elyra-form-runtime-config">' +
+      '<select id="runtime_config" name="runtime_config" class="elyra-form-runtime-config" data-required="required">' +
       runtime_options +
       '</select>';
 

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -115,3 +115,11 @@ td {
   padding-left: 10px;
   padding-right: 10px;
 }
+
+.elyra-PipelineOkButton.jp-mod-styled:hover:disabled,
+.elyra-PipelineOkButton.jp-mod-styled:active:disabled,
+.elyra-PipelineOkButton.jp-mod-styled:focus:disabled,
+.elyra-PipelineOkButton.jp-mod-styled:disabled {
+  background-color: lightgray;
+  pointer-events: none;
+}

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -115,11 +115,3 @@ td {
   padding-left: 10px;
   padding-right: 10px;
 }
-
-.elyra-PipelineOkButton.jp-mod-styled:hover:disabled,
-.elyra-PipelineOkButton.jp-mod-styled:active:disabled,
-.elyra-PipelineOkButton.jp-mod-styled:focus:disabled,
-.elyra-PipelineOkButton.jp-mod-styled:disabled {
-  background-color: lightgray;
-  pointer-events: none;
-}

--- a/packages/ui-components/src/FormDialog.tsx
+++ b/packages/ui-components/src/FormDialog.tsx
@@ -29,7 +29,7 @@ const DEFAULT_BUTTON_CLASS = 'elyra-DialogDefaultButton';
  * @params
  *
  * options - The dialog setup options
- * formValidationFunction - Optional validation function
+ * formValidationFunction - Optional custom validation function
  *
  * returns a call to dialog display
  */
@@ -62,32 +62,32 @@ export const showFormDialog = async (
 
         requiredFields.forEach((element: any) => {
           // First deal with the case the field has already been pre-populated
-          element.value
-            ? fieldsValidated.add(element)
-            : fieldsValidated.delete(element);
+          handleSingleFieldValidation(element, fieldsValidated);
+          handleAllFieldsValidation(
+            fieldsValidated,
+            requiredFields,
+            defaultButton
+          );
 
           const fieldType = element.tagName.toLowerCase();
 
           if (fieldType === 'select') {
             element.addEventListener('change', (event: any) => {
-              // Update fieldsValidated set accordingly
-              event.target.value
-                ? fieldsValidated.add(element)
-                : fieldsValidated.delete(element);
-
-              // Only enable defaultButton if all required fields are validated
-              fieldsValidated.size === requiredFields.length
-                ? enableDialogButton(defaultButton)
-                : disableDialogButton(defaultButton);
+              handleSingleFieldValidation(event.target, fieldsValidated);
+              handleAllFieldsValidation(
+                fieldsValidated,
+                requiredFields,
+                defaultButton
+              );
             });
           } else if (fieldType === 'input' || fieldType === 'textarea') {
             element.addEventListener('keyup', (event: any) => {
-              event.target.value.trim()
-                ? fieldsValidated.add(element)
-                : fieldsValidated.delete(element);
-              fieldsValidated.size === requiredFields.length
-                ? enableDialogButton(defaultButton)
-                : disableDialogButton(defaultButton);
+              handleSingleFieldValidation(event.target, fieldsValidated);
+              handleAllFieldsValidation(
+                fieldsValidated,
+                requiredFields,
+                defaultButton
+              );
             });
           }
         });
@@ -104,4 +104,25 @@ export const disableDialogButton = (button: HTMLButtonElement): void => {
 
 export const enableDialogButton = (button: HTMLButtonElement): void => {
   button.removeAttribute('disabled');
+};
+
+// Update set of validated fields according to element value
+const handleSingleFieldValidation = (
+  element: any,
+  fieldsValidated: Set<any>
+): void => {
+  element.value.trim()
+    ? fieldsValidated.add(element)
+    : fieldsValidated.delete(element);
+};
+
+// Only enable dialog button if all required fields are validated
+const handleAllFieldsValidation = (
+  fieldsValidated: Set<any>,
+  requiredFields: NodeListOf<any>,
+  button: HTMLButtonElement
+): void => {
+  fieldsValidated.size === requiredFields.length
+    ? enableDialogButton(button)
+    : disableDialogButton(button);
 };

--- a/packages/ui-components/src/FormDialog.tsx
+++ b/packages/ui-components/src/FormDialog.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018-2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../style/index.css';
+
+import { Dialog } from '@jupyterlab/apputils';
+import { Widget } from '@lumino/widgets';
+
+const DEFAULT_BUTTON_CLASS = 'elyra-DialogDefaultButton';
+/*
+ * Validate required dialog fields upon display
+ * - Provides a generic validation by checking if required form fields are populated
+ * - Expect required fields in dialog body to contain attribute: data-required
+ *
+ * @params
+ *
+ * options - The dialog setup options
+ * formValidationFunction - Optional validation function
+ *
+ * returns a call to dialog display
+ */
+export const showFormDialog = async (
+  options: Partial<Dialog.IOptions<any>>,
+  formValidationFunction: any
+): Promise<Dialog.IResult<any>> => {
+  const dialogBody = options.body;
+  const dialog = new Dialog(options);
+
+  if (formValidationFunction && typeof formValidationFunction === 'function') {
+    formValidationFunction(dialog);
+  } else {
+    if (typeof dialogBody !== 'string') {
+      const requiredFields = (dialogBody as Widget).node.querySelectorAll(
+        '[data-required]'
+      );
+
+      if (requiredFields && requiredFields.length > 0) {
+        // TODO: deal with the case a defaultButton is not passed on dialog options, and the last button added to buttons array is a cancelButton
+        const defaultButtonIndex =
+          options.defaultButton || options.buttons.length - 1;
+        const defaultButton = dialog.node
+          .querySelector('.jp-Dialog-footer')
+          .getElementsByTagName('button')[defaultButtonIndex];
+
+        disableDialogButton(defaultButton);
+
+        // Keep track of all validated elements tagged as required
+        let validatedFields = new Set();
+
+        requiredFields.forEach((element: any) => {
+          const fieldType = element.tagName;
+
+          // For now elyra dialogs only have select field types as required. Update this code with extra fieldType handlers as needed.
+          if (fieldType == 'SELECT') {
+            // First deal with the case the field has already been pre-selected
+            validateField(element, validatedFields);
+
+            // Add appropriate change event listener to each required field
+            element.addEventListener('change', (event: any) => {
+              validateField(event.target, validatedFields);
+
+              // Only enable default button if all required fields are validated
+              if (requiredFields.length === validatedFields.size) {
+                enableDialogButton(defaultButton);
+              }
+            });
+          }
+        });
+      }
+    }
+  }
+  return dialog.launch();
+};
+
+export const disableDialogButton = (button: HTMLButtonElement) => {
+  button.setAttribute('disabled', 'disabled');
+  button.className += ' ' + DEFAULT_BUTTON_CLASS;
+};
+
+export const enableDialogButton = (button: HTMLButtonElement) => {
+  button.removeAttribute('disabled');
+};
+
+// Update validatedFields according to element value
+const validateField = (element: any, validatedFields: Set<any>) => {
+  if (element.value) {
+    validatedFields.add(element);
+  } else {
+    validatedFields.delete(element);
+  }
+};

--- a/packages/ui-components/src/FormDialog.tsx
+++ b/packages/ui-components/src/FormDialog.tsx
@@ -24,7 +24,6 @@ const DEFAULT_BUTTON_CLASS = 'elyra-DialogDefaultButton';
  * Validate required dialog fields upon display
  * - Provides a generic validation by checking if required form fields are populated
  * - Expect required fields in dialog body to contain attribute: data-form-required
- * - NOTE: The Dialog widget will skip any validation upon pressing 'enter' key and resolve the dialog as is
  *
  * @params
  *

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -15,4 +15,5 @@
  */
 export * from './ExpandableErrorDialog';
 export * from './ExpandableComponent';
+export * from './FormDialog';
 export * from './icons';

--- a/packages/ui-components/style/index.css
+++ b/packages/ui-components/style/index.css
@@ -143,3 +143,11 @@ button.elyra-errorDialog-errDisplayButton {
 .jp-Dialog-content {
   resize: both;
 }
+
+.elyra-DialogDefaultButton.jp-mod-styled:hover:disabled,
+.elyra-DialogDefaultButton.jp-mod-styled:active:disabled,
+.elyra-DialogDefaultButton.jp-mod-styled:focus:disabled,
+.elyra-DialogDefaultButton.jp-mod-styled:disabled {
+  background-color: lightgray;
+  pointer-events: none;
+}


### PR DESCRIPTION
Fixes #658 

Exporting or submitting a pipeline now requires the user to populate all required form fields.
Required fields in dialog body should contain attribute `data-form-required`.
While no selection is made or required inputs are empty, the OK button remains disabled.
![image](https://user-images.githubusercontent.com/25207344/85628282-e2a5d300-b63d-11ea-86b7-86db5af184f8.png)

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

