### PR TITLE
Move ability to add env variable to kfp-notebook

### DIFF
--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -24,7 +24,6 @@ from elyra.metadata import MetadataManager
 from elyra.pipeline import PipelineProcessor, PipelineProcessorResponse
 from elyra.util.archive import create_temp_archive
 from elyra.util.cos import CosClient
-from kubernetes.client.models import V1EnvVar
 from kfp_notebook.pipeline import NotebookOp
 from urllib3.exceptions import MaxRetryError
 from jinja2 import Environment, PackageLoader
@@ -203,8 +202,8 @@ class KfpPipelineProcessor(PipelineProcessor):
             if operation.outputs:
                 notebook_op.add_pipeline_outputs(self._artifact_list_to_str(operation.outputs))
 
-            notebook_op.container.add_env_variable(V1EnvVar(name='AWS_ACCESS_KEY_ID', value=cos_username))
-            notebook_op.container.add_env_variable(V1EnvVar(name='AWS_SECRET_ACCESS_KEY', value=cos_password))
+            notebook_op.add_environment_variable('AWS_ACCESS_KEY_ID', cos_username)
+            notebook_op.add_environment_variable('AWS_SECRET_ACCESS_KEY', cos_password)
 
             # Set ENV variables
             if operation.env_vars:
@@ -214,7 +213,7 @@ class KfpPipelineProcessor(PipelineProcessor):
                     result = [x.strip(' \'\"') for x in env_var.split('=', 1)]
                     # Should be non empty key with a value
                     if len(result) == 2 and result[0] != '':
-                        notebook_op.container.add_env_variable(V1EnvVar(name=result[0], value=result[1]))
+                        notebook_op.add_environment_variable(result[0], result[1])
 
             notebook_ops[operation.id] = notebook_op
 


### PR DESCRIPTION
The kfp processor should pass environmental variables
that need to be set in the container to notebook_op instead
of digging into the notebook_op parent class and setting
them there. 

This should be merged in conjunction with https://github.com/elyra-ai/kfp-notebook/pull/33
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

