### PR TITLE
Use absolute form of export path when exporting pipelines

### DIFF
--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -146,3 +146,12 @@ class PipelineProcessor(LoggingConfigurable):  # ABC
     @abstractmethod
     def export(self, pipeline, pipeline_export_format, pipeline_export_path, overwrite):
         raise NotImplementedError()
+
+    def get_absolute_path(self, path):
+        """Checks if path is absolute or not.  If not absolute, `path` is appended to `root_dir`. """
+
+        absolute_path = path
+        if not os.path.isabs(path):
+            absolute_path = os.path.join(self.root_dir, path)
+
+        return absolute_path

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -93,22 +93,22 @@ class KfpPipelineProcessor(PipelineProcessor):
 
         # Since pipeline_export_path may be relative to the notebook directory, ensure
         # we're using its absolute form.
-        export_path = self.get_absolute_path(pipeline_export_path)
+        absolute_pipeline_export_path = self.get_absolute_path(pipeline_export_path)
 
         runtime_configuration = self._get_runtime_configuration(pipeline.runtime_config)
         api_endpoint = runtime_configuration.metadata['api_endpoint']
 
-        if os.path.exists(export_path) and not overwrite:
-            raise ValueError("File " + export_path + " already exists.")
+        if os.path.exists(absolute_pipeline_export_path) and not overwrite:
+            raise ValueError("File " + absolute_pipeline_export_path + " already exists.")
 
         self.log.info('Creating pipeline definition as a .' + pipeline_export_format + ' file')
         if pipeline_export_format != "py":
             try:
                 pipeline_function = lambda: self._cc_pipeline(pipeline, pipeline_name)  # nopep8
-                kfp.compiler.Compiler().compile(pipeline_function, export_path)
+                kfp.compiler.Compiler().compile(pipeline_function, absolute_pipeline_export_path)
             except Exception as ex:
                 raise RuntimeError('Error compiling pipeline {} for export at {}'.
-                                   format(pipeline_name, export_path), str(ex)) from ex
+                                   format(pipeline_name, absolute_pipeline_export_path), str(ex)) from ex
         else:
             # Load template from installed elyra package
             loader = PackageLoader('elyra', 'templates')
@@ -133,7 +133,7 @@ class KfpPipelineProcessor(PipelineProcessor):
                                             pipeline_description="Elyra Pipeline")
 
             # Write to python file and fix formatting
-            with open(export_path, "w") as fh:
+            with open(absolute_pipeline_export_path, "w") as fh:
                 fh.write(autopep8.fix_code(python_output))
 
         return pipeline_export_path  # Return the input value, not its absolute form

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -57,7 +57,7 @@ class KfpPipelineProcessor(PipelineProcessor):
                 kfp.compiler.Compiler().compile(pipeline_function, pipeline_path)
             except Exception as ex:
                 raise RuntimeError('Error compiling pipeline {} at {}'.
-                                   format(pipeline_name, pipeline_path), str(ex))
+                                   format(pipeline_name, pipeline_path), str(ex)) from ex
 
             self.log.info("Kubeflow Pipeline successfully compiled.")
             self.log.debug("Kubeflow Pipeline was created in %s", pipeline_path)
@@ -66,8 +66,8 @@ class KfpPipelineProcessor(PipelineProcessor):
             client = kfp.Client(host=api_endpoint)
             try:
                 kfp_pipeline = client.upload_pipeline(pipeline_path, pipeline_name)
-            except MaxRetryError:
-                raise RuntimeError('Error connecting to pipeline server {}'.format(api_endpoint))
+            except MaxRetryError as ex:
+                raise RuntimeError('Error connecting to pipeline server {}'.format(api_endpoint)) from ex
 
             self.log.info("Kubeflow Pipeline successfully uploaded to : %s", api_endpoint)
 
@@ -91,20 +91,24 @@ class KfpPipelineProcessor(PipelineProcessor):
 
         pipeline_name = pipeline.name
 
+        # Since pipeline_export_path may be relative to the notebook directory, ensure
+        # we're using its absolute form.
+        export_path = self.get_absolute_path(pipeline_export_path)
+
         runtime_configuration = self._get_runtime_configuration(pipeline.runtime_config)
         api_endpoint = runtime_configuration.metadata['api_endpoint']
 
-        if os.path.exists(pipeline_export_path) and not overwrite:
-            raise ValueError("File " + pipeline_export_path + " already exists.")
+        if os.path.exists(export_path) and not overwrite:
+            raise ValueError("File " + export_path + " already exists.")
 
         self.log.info('Creating pipeline definition as a .' + pipeline_export_format + ' file')
         if pipeline_export_format != "py":
             try:
                 pipeline_function = lambda: self._cc_pipeline(pipeline, pipeline_name)  # nopep8
-                kfp.compiler.Compiler().compile(pipeline_function, pipeline_export_path)
+                kfp.compiler.Compiler().compile(pipeline_function, export_path)
             except Exception as ex:
                 raise RuntimeError('Error compiling pipeline {} for export at {}'.
-                                   format(pipeline_name, pipeline_export_path), str(ex))
+                                   format(pipeline_name, export_path), str(ex)) from ex
         else:
             # Load template from installed elyra package
             loader = PackageLoader('elyra', 'templates')
@@ -129,10 +133,10 @@ class KfpPipelineProcessor(PipelineProcessor):
                                             pipeline_description="Elyra Pipeline")
 
             # Write to python file and fix formatting
-            with open(pipeline_export_path, "w") as fh:
+            with open(export_path, "w") as fh:
                 fh.write(autopep8.fix_code(python_output))
 
-        return pipeline_export_path
+        return pipeline_export_path  # Return the input value, not its absolute form
 
     def _cc_pipeline(self, pipeline, pipeline_name):
 
@@ -279,4 +283,4 @@ class KfpPipelineProcessor(PipelineProcessor):
             return runtime_configuration
         except BaseException as err:
             self.log.error('Error retrieving runtime configuration for {}'.format(name), exc_info=True)
-            raise RuntimeError('Error retrieving runtime configuration for {}', err)
+            raise RuntimeError('Error retrieving runtime configuration for {}', err) from err


### PR DESCRIPTION
Because the notebook server's current working directory doesn't always match the notebook directory, paths relative to the notebook directory are not valid relative to the current working directory causing things like pipeline export to break.  This change leverages the change made in #673 to compute an absolute path for the export's output.

Fixes #689
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

