### PR TITLE
Allow for single-character names, set minLength=1 on required strings

### DIFF
--- a/elyra/metadata/metadata.py
+++ b/elyra/metadata/metadata.py
@@ -290,7 +290,7 @@ class FileMetadataStore(MetadataStore):
         if not name:  # At this point, name must be set
             raise ValueError('Name of metadata was not provided.')
 
-        match = re.search("^[a-z][a-z0-9-_]*[a-z,0-9]$", name)
+        match = re.search("^[a-z]([a-z0-9-_]*[a-z,0-9])?$", name)
         if match is None:
             raise ValueError("Name of metadata must be lowercase alphanumeric, beginning with alpha and can include "
                              "embedded hyphens ('-') and underscores ('_').")

--- a/elyra/metadata/schemas/code-snippet.json
+++ b/elyra/metadata/schemas/code-snippet.json
@@ -11,7 +11,8 @@
     },
     "display_name": {
       "description": "The display name of the Code Snippet",
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "metadata": {
       "description": "Additional data specific to this Code Snippet",
@@ -23,7 +24,8 @@
         },
         "language": {
           "description": "Code snippet implementation language",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "code": {
           "description": "Code snippet code lines",

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -11,7 +11,8 @@
     },
     "display_name": {
       "description": "The display name of this KFP instance",
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "metadata": {
       "description": "Additional data specific to this metadata",

--- a/elyra/metadata/schemas/metadata-test.json
+++ b/elyra/metadata/schemas/metadata-test.json
@@ -11,7 +11,8 @@
     },
     "display_name": {
       "description": "The display name of the metadata",
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "metadata": {
       "description": "Additional data specific to this metadata",
@@ -19,7 +20,8 @@
       "properties": {
         "required_test": {
           "description": "Property used to test required enforcement",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "uri_test": {
           "description": "Property used to test uri formatting",

--- a/elyra/metadata/schemas/runtime-image.json
+++ b/elyra/metadata/schemas/runtime-image.json
@@ -11,7 +11,8 @@
     },
     "display_name": {
       "description": "The display name of the Runtime Image",
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "metadata": {
       "description": "Additional data specific to this Runtime Image",
@@ -19,7 +20,8 @@
       "properties": {
         "image_name": {
           "description": "Runtime Image description",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         }
       },
       "required": ["image_name"]

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -99,6 +99,36 @@ def test_manager_add_no_name(tests_manager, metadata_tests_dir):
     assert not os.path.exists(metadata_file)
 
 
+def test_manager_add_short_name(tests_manager, metadata_tests_dir):
+    # Found that single character names were failing validation
+    name = 'a'
+    metadata = Metadata(**valid_metadata_json)
+    instance = tests_manager.add(name, metadata)
+
+    assert instance is not None
+    assert instance.name == name
+
+    # Ensure file was created
+    metadata_file = os.path.join(metadata_tests_dir, '{}.json'.format(name))
+    assert os.path.exists(metadata_file)
+
+    # And finally, remove it.
+    tests_manager.remove(name)
+    assert not os.path.exists(metadata_file)
+
+
+def test_manager_add_empty_display_name(tests_manager, metadata_tests_dir):
+    # Found that empty display_name values were passing validation, so minLength=1 was added
+    metadata = Metadata(**valid_metadata_json)
+    metadata.display_name = ''
+    with pytest.raises(ValidationError):
+        tests_manager.add('empty_display_name', metadata)
+
+    # Ensure file was not created
+    metadata_file = os.path.join(metadata_tests_dir, '{}.json'.format('empty_display_name'))
+    assert not os.path.exists(metadata_file)
+
+
 def test_manager_add_display_name(tests_manager, metadata_tests_dir):
     metadata_display_name = '1 teste "rápido"'
     metadata_name = 'a_1_teste_rpido'


### PR DESCRIPTION
The regex for validating the name of metadata didn't handle single-character alpha names and has been updated.

Since there isn't a good way to express a `None` value from the UI, the display_name property (and any other required string-valued properties) now specify a `minLength` of at least 1 in all existing schemas.



Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

