### PR TITLE
Make pipeline process and export asynchronous

### DIFF
--- a/elyra/metadata/handlers.py
+++ b/elyra/metadata/handlers.py
@@ -15,9 +15,9 @@
 #
 
 from jsonschema import ValidationError
-from tornado import web, gen
+from tornado import web
 from notebook.base.handlers import APIHandler
-from notebook.utils import maybe_future, url_unescape, url_path_join
+from notebook.utils import url_unescape, url_path_join
 from .metadata import MetadataManager, SchemaManager, Metadata
 from ..util.http import HttpErrorMixin
 
@@ -26,13 +26,12 @@ class MetadataHandler(HttpErrorMixin, APIHandler):
     """Handler for metadata configurations collection. """
 
     @web.authenticated
-    @gen.coroutine
-    def get(self, namespace):
+    async def get(self, namespace):
         namespace = url_unescape(namespace)
         try:
             metadata_manager = MetadataManager(namespace=namespace)
             self.log.debug("MetadataHandler: Fetching all metadata resources from namespace '{}'...".format(namespace))
-            metadata = yield maybe_future(metadata_manager.get_all())
+            metadata = metadata_manager.get_all()
         except (ValidationError, ValueError) as err:
             raise web.HTTPError(400, str(err))
         except FileNotFoundError as err:
@@ -46,8 +45,7 @@ class MetadataHandler(HttpErrorMixin, APIHandler):
         self.finish(metadata_model)
 
     @web.authenticated
-    @gen.coroutine
-    def post(self, namespace):
+    async def post(self, namespace):
 
         namespace = url_unescape(namespace)
         try:
@@ -98,8 +96,7 @@ class MetadataResourceHandler(HttpErrorMixin, APIHandler):
     """Handler for metadata configuration specific resource (e.g. a runtime element). """
 
     @web.authenticated
-    @gen.coroutine
-    def get(self, namespace, resource):
+    async def get(self, namespace, resource):
         namespace = url_unescape(namespace)
         resource = url_unescape(resource)
 
@@ -107,7 +104,7 @@ class MetadataResourceHandler(HttpErrorMixin, APIHandler):
             metadata_manager = MetadataManager(namespace=namespace)
             self.log.debug("MetadataResourceHandler: Fetching metadata resource '{}' from namespace '{}'...".
                            format(resource, namespace))
-            metadata = yield maybe_future(metadata_manager.get(resource))
+            metadata = metadata_manager.get(resource)
         except (ValidationError, ValueError, NotImplementedError) as err:
             raise web.HTTPError(400, str(err))
         except FileNotFoundError as err:
@@ -119,8 +116,7 @@ class MetadataResourceHandler(HttpErrorMixin, APIHandler):
         self.finish(metadata.to_dict(trim=True))
 
     @web.authenticated
-    @gen.coroutine
-    def put(self, namespace, resource):
+    async def put(self, namespace, resource):
         namespace = url_unescape(namespace)
         resource = url_unescape(resource)
 
@@ -149,8 +145,7 @@ class MetadataResourceHandler(HttpErrorMixin, APIHandler):
         self.finish(metadata.to_dict(trim=True))
 
     @web.authenticated
-    @gen.coroutine
-    def delete(self, namespace, resource):
+    async def delete(self, namespace, resource):
         namespace = url_unescape(namespace)
         resource = url_unescape(resource)
 
@@ -176,13 +171,12 @@ class SchemaHandler(HttpErrorMixin, APIHandler):
     """Handler for namespace schemas. """
 
     @web.authenticated
-    @gen.coroutine
-    def get(self, namespace):
+    async def get(self, namespace):
         namespace = url_unescape(namespace)
         schema_manager = SchemaManager()
         try:
             self.log.debug("SchemaHandler: Fetching all schemas for namespace '{}'...".format(namespace))
-            schemas = yield maybe_future(schema_manager.get_namespace_schemas(namespace))
+            schemas = schema_manager.get_namespace_schemas(namespace)
         except (ValidationError, ValueError, FileNotFoundError) as err:
             raise web.HTTPError(404, str(err))
         except Exception as ex:
@@ -198,15 +192,14 @@ class SchemaResourceHandler(HttpErrorMixin, APIHandler):
     """Handler for a specific schema (resource) for a given namespace. """
 
     @web.authenticated
-    @gen.coroutine
-    def get(self, namespace, resource):
+    async def get(self, namespace, resource):
         namespace = url_unescape(namespace)
         resource = url_unescape(resource)
         schema_manager = SchemaManager()
         try:
             self.log.debug("SchemaResourceHandler: Fetching schema '{}' for namespace '{}'...".
                            format(resource, namespace))
-            schema = yield maybe_future(schema_manager.get_schema(namespace, resource))
+            schema = schema_manager.get_schema(namespace, resource)
         except (ValidationError, ValueError, FileNotFoundError) as err:
             raise web.HTTPError(404, str(err))
         except Exception as ex:
@@ -220,8 +213,7 @@ class NamespaceHandler(HttpErrorMixin, APIHandler):
     """Handler for retrieving namespaces """
 
     @web.authenticated
-    @gen.coroutine
-    def get(self):
+    async def get(self):
         schema_manager = SchemaManager()
         try:
             self.log.debug("NamespaceHandler: Fetching namespaces...")

--- a/elyra/pipeline/handlers.py
+++ b/elyra/pipeline/handlers.py
@@ -19,7 +19,7 @@ from notebook.base.handlers import APIHandler
 from notebook.utils import url_path_join
 from .parser import PipelineParser
 from .processor import PipelineProcessorManager
-from tornado import web, gen
+from tornado import web
 from ..util.http import HttpErrorMixin
 
 
@@ -27,15 +27,13 @@ class PipelineExportHandler(HttpErrorMixin, APIHandler):
     """Handler to expose REST API to export pipelines"""
 
     @web.authenticated
-    @gen.coroutine
-    def get(self):
+    async def get(self):
         msg_json = dict(title="Operation not supported.")
         self.write(msg_json)
         self.flush()
 
     @web.authenticated
-    @gen.coroutine
-    def post(self, *args, **kwargs):
+    async def post(self, *args, **kwargs):
         self.log.debug("Pipeline Export handler now executing post request")
 
         payload = self.get_json_body()
@@ -49,7 +47,7 @@ class PipelineExportHandler(HttpErrorMixin, APIHandler):
 
         pipeline = PipelineParser.parse(pipeline_definition)
 
-        pipeline_exported_path = PipelineProcessorManager.instance().export(
+        pipeline_exported_path = await PipelineProcessorManager.instance().export(
             pipeline,
             pipeline_export_format,
             pipeline_export_path,
@@ -74,15 +72,13 @@ class PipelineSchedulerHandler(HttpErrorMixin, APIHandler):
     """Handler to expose method calls to execute pipelines as batch jobs"""
 
     @web.authenticated
-    @gen.coroutine
-    def get(self):
+    async def get(self):
         msg_json = dict(title="Operation not supported.")
         self.write(msg_json)
         self.flush()
 
     @web.authenticated
-    @gen.coroutine
-    def post(self, *args, **kwargs):
+    async def post(self, *args, **kwargs):
         self.log.debug("Pipeline SchedulerHandler now executing post request")
 
         pipeline_definition = self.get_json_body()
@@ -90,7 +86,7 @@ class PipelineSchedulerHandler(HttpErrorMixin, APIHandler):
 
         pipeline = PipelineParser.parse(pipeline_definition)
 
-        response = PipelineProcessorManager.instance().process(pipeline)
+        response = await PipelineProcessorManager.instance().process(pipeline)
         json_msg = json.dumps(response.to_json())
 
         self.set_status(200)

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import entrypoints
 import os
 
@@ -24,6 +25,7 @@ class PipelineProcessorRegistry(SingletonConfigurable):
     __processors = {}
 
     def __init__(self):
+        super(PipelineProcessorRegistry, self).__init__()
 
         # Register all known processors based on entrypoint configuration
         for processor in entrypoints.get_group_all('elyra.pipeline.processors'):
@@ -55,7 +57,7 @@ class PipelineProcessorManager(SingletonConfigurable):
         # Since root_dir may contain '~' for user home, use expanduser()
         self.root_dir = os.path.expanduser(kwargs.get('root_dir', os.getcwd()))
 
-    def process(self, pipeline):
+    async def process(self, pipeline):
         registry = PipelineProcessorRegistry()
 
         processor_type = pipeline.runtime
@@ -65,9 +67,10 @@ class PipelineProcessorManager(SingletonConfigurable):
             raise RuntimeError('Could not find pipeline processor for [{}]'.format(pipeline.runtime))
 
         processor.root_dir = self.root_dir
-        return processor.process(pipeline)
+        res = await asyncio.get_running_loop().run_in_executor(None, processor.process, pipeline)
+        return res
 
-    def export(self, pipeline, pipeline_export_format, pipeline_export_path, overwrite):
+    async def export(self, pipeline, pipeline_export_format, pipeline_export_path, overwrite):
         registry = PipelineProcessorRegistry()
 
         processor_type = pipeline.runtime
@@ -77,7 +80,9 @@ class PipelineProcessorManager(SingletonConfigurable):
             raise RuntimeError('Could not find pipeline processor for [{}]'.format(pipeline.runtime))
 
         processor.root_dir = self.root_dir
-        return processor.export(pipeline, pipeline_export_format, pipeline_export_path, overwrite)
+        res = await asyncio.get_running_loop().run_in_executor(
+            None, processor.export, pipeline, pipeline_export_format, pipeline_export_path, overwrite)
+        return res
 
 
 class PipelineProcessorResponse(object):


### PR DESCRIPTION
- PipelineManager now invokes the process and export methods via a loop executor allowing asynchronous behavior via the REST API.
- Converted all REST methods from `@gen.coroutine/yield` to `async def/await`.

Resolves #576

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

