### PR TITLE
Show empty properties in node tooltip

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -428,11 +428,7 @@ export class PipelineEditor extends React.Component<
 
       propsInfo.forEach(
         (info: { parameter_ref: string; label: { default: string } }) => {
-          if (
-            Object.prototype.hasOwnProperty.call(appData, info.parameter_ref)
-          ) {
-            tooltipProps[info.label.default] = appData[info.parameter_ref];
-          }
+          tooltipProps[info.label.default] = appData[info.parameter_ref] || '';
         }
       );
 


### PR DESCRIPTION
Update Pipeline node hover tooltip to always include properties with empty values

Fixes #697 

![image](https://user-images.githubusercontent.com/13156555/86137352-3475af80-babb-11ea-842b-06b784664010.png)



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

