### PR TITLE
Improve dependency management and archive generation

### DIFF
--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -136,6 +136,25 @@ class Operation(object):
                 self.inputs == other.inputs and \
                 self.parent_operations == other.parent_operations
 
+    def __str__(self) -> str:
+        return "componentID : {id} \n " \
+               "name : {name} \n " \
+               "parent_operations : {parent_op} \n " \
+               "dependencies : {depends} \n " \
+               "dependencies include subdirectories : {inc_subdirs} \n " \
+               "filename : {filename} \n " \
+               "inputs : {inputs} \n " \
+               "outputs : {outputs} \n " \
+               "runtime image : {image} \n ".format(id=self.id,
+                                                    name=self.name,
+                                                    parent_op=self.parent_operations,
+                                                    depends=self.dependencies,
+                                                    inc_subdirs=self.include_subdirectories,
+                                                    filename=self.filename,
+                                                    inputs=self.inputs,
+                                                    outputs=self.outputs,
+                                                    image=self.runtime_image)
+
     @staticmethod
     def __initialize_empty_array_if_none(value):
         if value:

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -269,10 +269,12 @@ class KfpPipelineProcessor(PipelineProcessor):
         archive_artifact_name = self._get_dependency_archive_name(operation)
         archive_source_dir = self._get_dependency_source_dir(operation)
 
+        dependencies = [os.path.basename(operation.filename)]
+        dependencies.extend(operation.dependencies)
+
         archive_artifact = create_temp_archive(archive_name=archive_artifact_name,
                                                source_dir=archive_source_dir,
-                                               primary_file=os.path.basename(operation.filename),
-                                               dependencies=operation.dependencies,
+                                               filenames=dependencies,
                                                recursive=operation.include_subdirectories)
 
         return archive_artifact

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -269,13 +269,10 @@ class KfpPipelineProcessor(PipelineProcessor):
         archive_artifact_name = self._get_dependency_archive_name(operation)
         archive_source_dir = self._get_dependency_source_dir(operation)
 
-        files = [os.path.basename(operation.filename)]  # Always include the notebook for this op
-        files.extend(operation.dependencies)            # and any dependencies
-
         archive_artifact = create_temp_archive(archive_name=archive_artifact_name,
                                                source_dir=archive_source_dir,
-                                               files=files,
-                                               has_dependencies=len(operation.dependencies) > 0,
+                                               primary_file=os.path.basename(operation.filename),
+                                               dependencies=operation.dependencies,
                                                recursive=operation.include_subdirectories)
 
         return archive_artifact

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -13,10 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import autopep8
 import kfp
 import os
 import tempfile
-import autopep8
+import time
 
 from datetime import datetime
 
@@ -54,7 +55,11 @@ class KfpPipelineProcessor(PipelineProcessor):
             # Compile the new pipeline
             try:
                 pipeline_function = lambda: self._cc_pipeline(pipeline, pipeline_name)  # nopep8 E731
+                t0 = time.time()
                 kfp.compiler.Compiler().compile(pipeline_function, pipeline_path)
+                t1 = time.time()
+                self.log.debug("process: Compilation of pipeline '{name}' took {duration:.3f} secs.".
+                               format(name=pipeline_name, duration=(t1 - t0)))
             except Exception as ex:
                 raise RuntimeError('Error compiling pipeline {} at {}'.
                                    format(pipeline_name, pipeline_path), str(ex)) from ex
@@ -65,7 +70,11 @@ class KfpPipelineProcessor(PipelineProcessor):
             # Upload the compiled pipeline and create an experiment and run
             client = kfp.Client(host=api_endpoint)
             try:
+                t0 = time.time()
                 kfp_pipeline = client.upload_pipeline(pipeline_path, pipeline_name)
+                t1 = time.time()
+                self.log.debug("process: Upload of pipeline '{name}' took {duration:.3f} secs.".
+                               format(name=pipeline_name, duration=(t1 - t0)))
             except MaxRetryError as ex:
                 raise RuntimeError('Error connecting to pipeline server {}'.format(api_endpoint)) from ex
 
@@ -105,7 +114,11 @@ class KfpPipelineProcessor(PipelineProcessor):
         if pipeline_export_format != "py":
             try:
                 pipeline_function = lambda: self._cc_pipeline(pipeline, pipeline_name)  # nopep8
+                t0 = time.time()
                 kfp.compiler.Compiler().compile(pipeline_function, absolute_pipeline_export_path)
+                t1 = time.time()
+                self.log.debug("export: Compilation of pipeline '{name}' took {duration:.3f} secs.".
+                               format(name=pipeline_name, duration=(t1 - t0)))
             except Exception as ex:
                 raise RuntimeError('Error compiling pipeline {} for export at {}'.
                                    format(pipeline_name, absolute_pipeline_export_path), str(ex)) from ex
@@ -155,42 +168,23 @@ class KfpPipelineProcessor(PipelineProcessor):
         # In order to process this recursively, the current operation's inputs should be combined
         # from its parent's inputs (which, themselves are derived from the outputs of their parent)
         # and its parent's outputs.
-        for pipeline_operation in pipeline.operations.values():
-            parent_inputs_and_outputs = []
-            for parent_operation_id in pipeline_operation.parent_operations:
+        for operation in pipeline.operations.values():
+            parent_io = []  # gathers inputs & outputs relative to parent
+            for parent_operation_id in operation.parent_operations:
                 parent_operation = pipeline.operations[parent_operation_id]
                 if parent_operation.inputs:
-                    parent_inputs_and_outputs.extend(parent_operation.inputs)
+                    parent_io.extend(parent_operation.inputs)
                 if parent_operation.outputs:
-                    parent_inputs_and_outputs.extend(parent_operation.outputs)
+                    parent_io.extend(parent_operation.outputs)
 
-                if parent_inputs_and_outputs:
-                    pipeline_operation.inputs = parent_inputs_and_outputs
+                if parent_io:
+                    operation.inputs = parent_io
 
         for operation in pipeline.operations.values():
             operation_artifact_archive = self._get_dependency_archive_name(operation)
 
-            self.log.debug("Creating pipeline component :\n "
-                           "componentID : %s \n "
-                           "name : %s \n "
-                           "parent_operations : %s \n "
-                           "dependencies : %s \n "
-                           "dependencies include subdirectories : %s \n "
-                           "filename : %s \n "
-                           "archive : %s \n "
-                           "inputs : %s \n "
-                           "outputs : %s \n "
-                           "runtime image : %s \n ",
-                           operation.id,
-                           operation.name,
-                           operation.parent_operations,
-                           operation.dependencies,
-                           operation.include_subdirectories,
-                           operation.filename,
-                           operation_artifact_archive,
-                           operation.inputs,
-                           operation.outputs,
-                           operation.runtime_image)
+            self.log.debug("Creating pipeline component :\n {op} archive : {archive}".format(
+                           op=operation, archive=operation_artifact_archive))
 
             # create pipeline operation
             notebook_op = NotebookOp(name=operation.name,
@@ -225,11 +219,23 @@ class KfpPipelineProcessor(PipelineProcessor):
 
             # upload operation dependencies to object storage
             try:
+                t0 = time.time()
                 dependency_archive_path = self._generate_dependency_archive(operation)
+                t1 = time.time()
+                self.log.debug("_cc_pipeline: Generation of dependency archive for operation '{name}' "
+                               "took {duration:.3f} secs.".
+                               format(name=operation.name, duration=(t1 - t0)))
+
                 cos_client = CosClient(config=runtime_configuration)
+                t0 = time.time()
                 cos_client.upload_file_to_dir(dir=cos_directory,
                                               file_name=operation_artifact_archive,
                                               file_path=dependency_archive_path)
+                t1 = time.time()
+                self.log.debug("_cc_pipeline: Upload of dependency archive for operation '{name}' "
+                               "took {duration:.3f} secs.".
+                               format(name=operation.name, duration=(t1 - t0)))
+
             except BaseException as ex:
                 self.log.error("Error uploading artifacts to object storage.", exc_info=True)
                 raise ex from ex
@@ -237,9 +243,9 @@ class KfpPipelineProcessor(PipelineProcessor):
             self.log.info("Pipeline dependencies have been uploaded to object storage")
 
         # Process dependencies after all the operations have been created
-        for pipeline_operation in pipeline.operations.values():
-            op = notebook_ops[pipeline_operation.id]
-            for parent_operation_id in pipeline_operation.parent_operations:
+        for operation in pipeline.operations.values():
+            op = notebook_ops[operation.id]
+            for parent_operation_id in operation.parent_operations:
                 parent_op = notebook_ops[parent_operation_id]  # Parent Operation
                 op.after(parent_op)
 

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -269,12 +269,13 @@ class KfpPipelineProcessor(PipelineProcessor):
         archive_artifact_name = self._get_dependency_archive_name(operation)
         archive_source_dir = self._get_dependency_source_dir(operation)
 
-        files = [os.path.basename(operation.filename)]
-        files.extend(operation.dependencies)
+        files = [os.path.basename(operation.filename)]  # Always include the notebook for this op
+        files.extend(operation.dependencies)            # and any dependencies
 
         archive_artifact = create_temp_archive(archive_name=archive_artifact_name,
                                                source_dir=archive_source_dir,
                                                files=files,
+                                               has_dependencies=len(operation.dependencies) > 0,
                                                recursive=operation.include_subdirectories)
 
         return archive_artifact

--- a/elyra/util/archive.py
+++ b/elyra/util/archive.py
@@ -104,7 +104,7 @@ def create_temp_archive(archive_name, source_dir, filenames=None, recursive=Fals
             return None
 
     # If there's a '*' - less things to check.
-    include_all =  filenames and len(set([WILDCARDS[0]]) & set(filenames)) > 0
+    include_all = filenames and len(set([WILDCARDS[0]]) & set(filenames)) > 0
 
     processed_filenames = []
     temp_dir = create_project_temp_dir()

--- a/elyra/util/archive.py
+++ b/elyra/util/archive.py
@@ -93,7 +93,7 @@ def create_temp_archive(archive_name, source_dir, filenames=None, recursive=Fals
                 # if this is a direct match, record that its been processed
                 if not has_wildcards(filename) and not recursive:
                     processed_filenames.append(filename)
-                matched_filenames.append(filename)
+                matched_set.add(filename)
                 return tarinfo
 
             # If the filename is a "flat" wildcarded value (i.e., isn't prefixed with a directory name)
@@ -101,7 +101,7 @@ def create_temp_archive(archive_name, source_dir, filenames=None, recursive=Fals
             # occurs for dependencies like *.py when include-subdirectories is enabled.
             if not directory_prefixed(filename) and has_wildcards(filename):
                 if fnmatch.fnmatch(os.path.basename(tarinfo.name), filename):
-                    matched_filenames.append(filename)
+                    matched_set.add(filename)
                     return tarinfo
         return None
 
@@ -111,7 +111,7 @@ def create_temp_archive(archive_name, source_dir, filenames=None, recursive=Fals
     # If there's a '*' - less things to check.
     include_all = len(set([WILDCARDS[0]]) & filenames_set) > 0
     processed_filenames = []
-    matched_filenames = []
+    matched_set = set()
     temp_dir = create_project_temp_dir()
     archive = os.path.join(temp_dir, archive_name)
 
@@ -119,8 +119,7 @@ def create_temp_archive(archive_name, source_dir, filenames=None, recursive=Fals
         tar.add(source_dir, arcname="", filter=tar_filter)
 
     if require_complete and not include_all:
-        # convert matched_filenames to a set and compare against filenames_set to ensure they're the same.
-        matched_set = set(matched_filenames)
+        # compare matched_set against filenames_set to ensure they're the same.
         if len(filenames_set) > len(matched_set):
             raise FileNotFoundError(filenames_set - matched_set)  # Only include the missing filenames
 

--- a/elyra/util/archive.py
+++ b/elyra/util/archive.py
@@ -73,7 +73,7 @@ def create_temp_archive(archive_name, source_dir, filenames=None, recursive=Fals
             # allow if found - except if a single '*' is listed (i.e., include_all) in
             # which case we don't want to add this directory since recursive is False.
             # This occurs with filenames like `data/util.py` or `data/*.py`.
-            elif directory_in_list(tarinfo.name, filenames) and not include_all:
+            elif not include_all and directory_in_list(tarinfo.name, filenames):
                 return tarinfo
             return None
 

--- a/elyra/util/tests/test_archive.py
+++ b/elyra/util/tests/test_archive.py
@@ -33,7 +33,8 @@ class ArchiveTestCase(unittest.TestCase):
         'a.py',
         'b.py',
         'c.json',
-        'd.txt'
+        'd.txt',
+        'e.ipynb'
     ]
 
     def setUp(self):
@@ -51,22 +52,42 @@ class ArchiveTestCase(unittest.TestCase):
 
     def test_archive_all(self):
         test_archive_name = 'all-' + self.test_timestamp + '.tar.gz'
-        archive_path = create_temp_archive(test_archive_name, self.test_dir)
+        archive_path = create_temp_archive(test_archive_name, self.test_dir, filenames=['*'])
         self.assertArchivedContent(archive_path, self.test_files)
+
+    def test_archive_empty_filter(self):
+        test_archive_name = 'all-' + self.test_timestamp + '.tar.gz'
+        archive_path = create_temp_archive(test_archive_name, self.test_dir, filenames=[])
+        self.assertArchivedFileCount(archive_path, 0)
+
+    def test_archive_no_filter(self):
+        test_archive_name = 'all-' + self.test_timestamp + '.tar.gz'
+        archive_path = create_temp_archive(test_archive_name, self.test_dir)
+        self.assertArchivedFileCount(archive_path, 0)
 
     def test_archive_by_filter(self):
         test_archive_name = 'python-' + self.test_timestamp + '.tar.gz'
-        archive_path = create_temp_archive(test_archive_name, self.test_dir, ['*.py'])
+        archive_path = create_temp_archive(test_archive_name, self.test_dir, filenames=['*.py'])
         self.assertArchivedContent(archive_path, ['a.py', 'b.py'])
+
+    def test_archive_by_sequence_wildcard(self):
+        test_archive_name = 'python-' + self.test_timestamp + '.tar.gz'
+        archive_path = create_temp_archive(test_archive_name, self.test_dir, filenames=['[ab].*'])
+        self.assertArchivedContent(archive_path, ['a.py', 'b.py'])
+
+    def test_archive_by_excluded_sequence(self):
+        test_archive_name = 'python-' + self.test_timestamp + '.tar.gz'
+        archive_path = create_temp_archive(test_archive_name, self.test_dir, filenames=['*[!b].py'])
+        self.assertArchivedContent(archive_path, ['a.py'])
 
     def test_archive_multiple_filters(self):
         test_archive_name = 'multiple-' + self.test_timestamp + '.tar.gz'
-        archive_path = create_temp_archive(test_archive_name, self.test_dir, ['*.json', '*.txt'])
+        archive_path = create_temp_archive(test_archive_name, self.test_dir, filenames=['*.json', '*.txt'])
         self.assertArchivedContent(archive_path, ['c.json', 'd.txt'])
 
-    def test_archive_unexistent_filter(self):
+    def test_archive_nonexistent_filter(self):
         test_archive_name = 'empty-' + self.test_timestamp + '.tar.gz'
-        archive_path = create_temp_archive(test_archive_name, self.test_dir, ['*.yml'])
+        archive_path = create_temp_archive(test_archive_name, self.test_dir, filenames=['*.yml'])
         self.assertArchivedContent(archive_path, [])
 
     def test_archive_with_subdirectories(self):
@@ -77,9 +98,22 @@ class ArchiveTestCase(unittest.TestCase):
         test_archive_name = 'subdir-' + self.test_timestamp + '.tar.gz'
         archive_path = create_temp_archive(archive_name=test_archive_name,
                                            source_dir=self.test_dir,
+                                           filenames=['*'],
                                            recursive=True)
 
-        self.assertArchivedFileCount(archive_path, 8)
+        self.assertArchivedFileCount(archive_path, 10)
+
+    def test_archive_with_subdirectories_no_filter(self):
+        subdir_name = os.path.join(self.test_dir, 'subdir')
+        os.makedirs(subdir_name)
+        self._create_test_files(subdir_name)
+
+        test_archive_name = 'subdir-' + self.test_timestamp + '.tar.gz'
+        archive_path = create_temp_archive(archive_name=test_archive_name,
+                                           source_dir=self.test_dir,
+                                           recursive=True)
+
+        self.assertArchivedFileCount(archive_path, 0)
 
     def test_archive_with_subdirectories_and_filters(self):
         subdir_name = os.path.join(self.test_dir, 'subdir')
@@ -89,10 +123,11 @@ class ArchiveTestCase(unittest.TestCase):
         test_archive_name = 'subdir-' + self.test_timestamp + '.tar.gz'
         archive_path = create_temp_archive(archive_name=test_archive_name,
                                            source_dir=self.test_dir,
-                                           files=['*.py'],
+                                           filenames=['subdir/*.py'],
                                            recursive=True)
 
-        self.assertArchivedFileCount(archive_path, 4)
+        self.assertArchivedFileCount(archive_path, 2)
+        self.assertArchivedContent(archive_path, ['subdir/a.py', 'subdir/b.py'])
 
     def test_archive_with_second_level_subdirectories(self):
         subdir_name = os.path.join(self.test_dir, 'subdir')
@@ -106,11 +141,12 @@ class ArchiveTestCase(unittest.TestCase):
         test_archive_name = 'subdir-' + self.test_timestamp + '.tar.gz'
         archive_path = create_temp_archive(archive_name=test_archive_name,
                                            source_dir=self.test_dir,
+                                           filenames=['*'],
                                            recursive=True)
 
-        self.assertArchivedFileCount(archive_path, 12)
+        self.assertArchivedFileCount(archive_path, 15)
 
-    def test_archive_with_second_level_subdirectories_and_unexistent_filter(self):
+    def test_archive_with_second_level_subdirectories_and_nonexistent_filter(self):
         subdir_name = os.path.join(self.test_dir, 'subdir')
         os.makedirs(subdir_name)
         self._create_test_files(subdir_name)
@@ -122,7 +158,7 @@ class ArchiveTestCase(unittest.TestCase):
         test_archive_name = 'subdir-' + self.test_timestamp + '.tar.gz'
         archive_path = create_temp_archive(archive_name=test_archive_name,
                                            source_dir=self.test_dir,
-                                           files=['*.yml'],
+                                           filenames=['*.yml'],
                                            recursive=True)
 
         self.assertArchivedFileCount(archive_path, 0)

--- a/elyra/util/tests/test_archive.py
+++ b/elyra/util/tests/test_archive.py
@@ -100,7 +100,7 @@ class ArchiveTestCase(unittest.TestCase):
             create_temp_archive(test_archive_name, self.test_dir,
                                 filenames=['*.json', '*.txt', 'a.py', 'c.py'],
                                 require_complete=True)
-        assert 'c.py' in str(ex)
+        assert "{'c.py'}" in str(ex)  # ensure c.py is the only item not matched
 
     def test_archive_nonexistent_filter(self):
         test_archive_name = 'empty-' + self.test_timestamp + '.tar.gz'

--- a/elyra/util/tests/test_archive.py
+++ b/elyra/util/tests/test_archive.py
@@ -14,10 +14,11 @@
 # limitations under the License.
 #
 import os
-import unittest
+import pytest
 import shutil
 import tarfile
 import tempfile
+import unittest
 
 from datetime import datetime
 
@@ -84,6 +85,22 @@ class ArchiveTestCase(unittest.TestCase):
         test_archive_name = 'multiple-' + self.test_timestamp + '.tar.gz'
         archive_path = create_temp_archive(test_archive_name, self.test_dir, filenames=['*.json', '*.txt'])
         self.assertArchivedContent(archive_path, ['c.json', 'd.txt'])
+
+    def test_archive_require_complete(self):
+        test_archive_name = 'multiple-' + self.test_timestamp + '.tar.gz'
+        archive_path = create_temp_archive(test_archive_name, self.test_dir,
+                                           filenames=['*.json', '*.txt', 'a.py'],
+                                           require_complete=True)
+        self.assertArchivedContent(archive_path, ['c.json', 'd.txt', 'a.py'])
+
+    def test_archive_require_complete_fail(self):
+        test_archive_name = 'multiple-' + self.test_timestamp + '.tar.gz'
+        # c.py does not exist and exception is expected
+        with pytest.raises(FileNotFoundError) as ex:
+            create_temp_archive(test_archive_name, self.test_dir,
+                                filenames=['*.json', '*.txt', 'a.py', 'c.py'],
+                                require_complete=True)
+        assert 'c.py' in str(ex)
 
     def test_archive_nonexistent_filter(self):
         test_archive_name = 'empty-' + self.test_timestamp + '.tar.gz'


### PR DESCRIPTION
These changes improve how dependencies are handled, generally eliminating the need to include subdirectories when adding dependencies from subdirectories.

- Allow for `'*'`, `'?'`, and `'[a-z]'` / `'[!a-z]'` (sequence) wildcards.
- Allow for embedded wildcards, including directory names (e.g., `inputs/ACS*` - to include all directories beginning with ACS in subdirectory `inputs`)
- Enforce that all dependencies must be matched (i.e., present in resulting archive)
- Updated tests to include additional wildcard testing
- Added timing metrics around pipeline compilation, archive creation, and upload - logged as DEBUG statements
- Minor refactoring to help with readability
- Once nodes are updated to not include subdirectories but only include what they need, we see ~70% improvement in the submission time of the COVID pipeline - 80 secs to 25 secs.  With no changes to the pipeline, the submission goes from 80 secs to 50 secs.

## Behavioral Changes

1. With these changes, it is no longer the case that **selecting 'include subdirectories' with NO files listed as dependencies results in all files being included!** Instead, no files will be included in that case.  One must add a dependency of '*' to have all files included.  If include-subdirectories is also selected, then all files in the folder hierarchy will be added.  This treats empty dependency lists the same (and expected) way.
1. As noted above, unmatched dependencies will now fail a pipeline's submission for run and export.

Fixes #204 
Fixes #572 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

