### PR TITLE
Fix random pythoneditor test failures

### DIFF
--- a/tests/integration/pythoneditor.ts
+++ b/tests/integration/pythoneditor.ts
@@ -20,11 +20,11 @@ describe('PythonEditor', () => {
 
   it('opens blank python from launcher', () => {
     cy.get('[title="Create a new python file"][tabindex="100"]').click();
-    // TODO: Check it opened
+    cy.get('.lm-TabBar-tab[data-type="document-title"]');
   });
 
   it('close python editor', () => {
-    cy.get('.lm-TabBar-tabCloseIcon:visible').click({ multiple: true });
+    cy.get('.lm-TabBar-tabCloseIcon:visible').click();
   });
 
   it('opens blank python from new menu', () => {


### PR DESCRIPTION
- Added code to check when the python editor is open using the document-title as could be a random file name used depending on what is in the workspace.
- Use single click to close the editor instead of multi click
 
When running I noticed that the launcher could not be closed or was closed before the python editor was open and we tried to do the close click.

Fixes #675 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

