### PR TITLE
Fix bad JSON file handling

### DIFF
--- a/elyra/metadata/tests/conftest.py
+++ b/elyra/metadata/tests/conftest.py
@@ -24,7 +24,7 @@ from tornado.escape import url_escape
 from elyra.metadata import MetadataManager, SchemaManager, METADATA_TEST_NAMESPACE, FileMetadataStore  # noqa: F401
 
 from .test_utils import valid_metadata_json, invalid_metadata_json, another_metadata_json, byo_metadata_json, \
-    create_json_file
+    invalid_json, create_json_file, create_file
 
 
 # BEGIN - Remove once transition to jupyter_server occurs
@@ -115,6 +115,7 @@ def setup_namespace(environ, namespace_location):
     create_json_file(namespace_location, 'valid.json', valid_metadata_json)
     create_json_file(namespace_location, 'another.json', another_metadata_json)
     create_json_file(namespace_location, 'invalid.json', invalid_metadata_json)
+    create_file(namespace_location, 'bad.json', invalid_json)
 
 
 @pytest.fixture

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -170,14 +170,20 @@ def test_manager_add_display_name(tests_manager, namespace_location):
         tests_manager.metadata_store.fetch_instances(metadata_name)
 
 
-def test_manager_list_summary(tests_manager):
-    metadata_summary_list = tests_manager.get_all(include_invalid=False)
-    assert len(metadata_summary_list) == 2
-    metadata_summary_list = tests_manager.get_all(include_invalid=True)
-    assert len(metadata_summary_list) == 3
+def test_manager_get_include_invalid(tests_manager):
+    metadata_list = tests_manager.get_all(include_invalid=False)
+    assert len(metadata_list) == 2
+    metadata_list = tests_manager.get_all(include_invalid=True)
+    assert len(metadata_list) == 4
 
 
-def test_manager_list_all(tests_manager):
+def test_manager_get_bad_json(tests_manager):
+    with pytest.raises(ValueError) as ve:
+        tests_manager.get("bad")
+    assert "JSON failed to load for metadata 'bad'" in str(ve.value)
+
+
+def test_manager_get_all(tests_manager):
     metadata_list = tests_manager.get_all()
     assert len(metadata_list) == 2
     # Ensure name is getting derived from resource and not from contents
@@ -188,18 +194,18 @@ def test_manager_list_all(tests_manager):
             assert metadata.name == "valid"
 
 
-def test_manager_list_summary_none(tests_manager, namespace_location):
+def test_manager_get_none(tests_manager, namespace_location):
     # Delete the namespace contents and attempt listing metadata
     _remove_namespace(tests_manager.metadata_store, namespace_location)
     assert tests_manager.namespace_exists() is False
     _create_namespace(tests_manager.metadata_store, namespace_location)
     assert tests_manager.namespace_exists()
 
-    metadata_summary_list = tests_manager.get_all()
-    assert len(metadata_summary_list) == 0
+    metadata_list = tests_manager.get_all()
+    assert len(metadata_list) == 0
 
 
-def test_manager_list_all_none(tests_manager, namespace_location):
+def test_manager_get_all_none(tests_manager, namespace_location):
     # Delete the namespace contents and attempt listing metadata
     _remove_namespace(tests_manager.metadata_store, namespace_location)
     assert tests_manager.namespace_exists() is False

--- a/elyra/metadata/tests/test_utils.py
+++ b/elyra/metadata/tests/test_utils.py
@@ -43,12 +43,21 @@ another_metadata_json = {
 
 invalid_metadata_json = {
     'schema_name': 'metadata-test',
-    'display_name': 'Invalid Metadata Instance',
+    'display_name': 'Invalid Metadata Instance - bad uri',
     'metadata': {
         'uri_test': '//localhost:8081/',
         'required_test': "required_value"
     }
 }
+
+invalid_json = "{\
+    'schema_name': 'metadata-test',\
+    'display_name': 'Invalid Metadata Instance - missing comma'\
+    'metadata': {\
+        'uri_test': '//localhost:8081/',\
+        'required_test': 'required_value'\
+    }\
+}"
 
 invalid_no_display_name_json = {
     'schema_name': 'metadata-test',
@@ -115,6 +124,10 @@ byo_metadata_json = {
 
 
 def create_json_file(location, file_name, content):
+    create_file(location, file_name, json.dumps(content))
+
+
+def create_file(location, file_name, content):
     try:
         os.makedirs(location)
     except OSError as e:
@@ -123,7 +136,7 @@ def create_json_file(location, file_name, content):
 
     resource = os.path.join(location, file_name)
     with open(resource, 'w', encoding='utf-8') as f:
-        f.write(json.dumps(content))
+        f.write(content)
 
 
 def get_schema(schema_name):


### PR DESCRIPTION
The error handling relative to JSON load issues was side-effected by
the recent refactor.  However, with these changes, we now DO include
JSON load issues in the results when `include-invalid` is requested.

In such cases, name, schema_name, resource and reason are set on the
returned instance, although schema_name is set to '{unknown}' since
we cannot make that determination.

Here's output from `elyra-metadata list runtimes` which includes two schema-invalid instances and one JSON-invalid instance:
```
$ elyra-metadata list runtimes
[E 2020-07-07 10:44:48,132.132] JSON failed to load for metadata 'foo' in namespace 'runtimes' with error: Expecting ',' delimiter: line 10 column 5 (char 318).
[E 2020-07-07 10:44:48,137.137] Schema validation failed for metadata 'foofoo' in namespace 'runtimes' with error: None is not of type 'string'.
[E 2020-07-07 10:44:48,138.138] Schema validation failed for metadata 'barbar' in namespace 'runtimes' with error: 'xxx' is too short.
Available metadata instances for runtimes (includes invalid):

Schema      Instance  Resource                                                     
------      --------  --------                                                     
kfp         barbar    /Users/kbates/Library/Jupyter/metadata/runtimes/barbar.json  **INVALID** (ValidationError)
kfp         baz       /Users/kbates/Library/Jupyter/metadata/runtimes/baz.json     
kfp         foodoo    /Users/kbates/Library/Jupyter/metadata/runtimes/foodoo.json  
kfp         foofoo    /Users/kbates/Library/Jupyter/metadata/runtimes/foofoo.json  **INVALID** (ValidationError)
kfp         kf_1      /Users/kbates/Library/Jupyter/metadata/runtimes/kf_1.json    
{unknown}   foo       /Users/kbates/Library/Jupyter/metadata/runtimes/foo.json     **INVALID** (ValueError)
```

Fixes #712

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

