### PR TITLE
Update JupyterLab shell background color

### DIFF
--- a/packages/theme/style/index.css
+++ b/packages/theme/style/index.css
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-.lm-DockPanel {
-  background: var(--jp-layout-color0);
+.jp-LabShell {
+  background: var(--jp-layout-color3);
 }


### PR DESCRIPTION
Change the background color for the main panel area to intended JupyterLab color

From black (`--jp-layout-color0`) to gray (`--jp-layout-color3`)

Fixes #715 


**Before**:

<img width="862" alt="image" src="https://user-images.githubusercontent.com/13156555/86839391-5baa1f00-c06f-11ea-85b9-197946016230.png">

<img width="860" alt="image" src="https://user-images.githubusercontent.com/13156555/86839462-754b6680-c06f-11ea-83a1-1e8e4857ff13.png">


**After**:

<img width="865" alt="image" src="https://user-images.githubusercontent.com/13156555/86839300-403f1400-c06f-11ea-94e1-804b0cc734ea.png">

<img width="861" alt="image" src="https://user-images.githubusercontent.com/13156555/86839220-269dcc80-c06f-11ea-8019-2f43c5f40dc7.png">

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

