### PR TITLE
Use config to determine metadata storage class

### DIFF
--- a/elyra/metadata/manager.py
+++ b/elyra/metadata/manager.py
@@ -43,11 +43,11 @@ class MetadataManager(LoggingConfigurable):
 
     def __init__(self, namespace: str, **kwargs):
         """
-        Generic object to read Notebook related metadata
-        :param namespace: the partition where it is stored, this might have
-        a unique meaning for each of the supported metadata storage
-        :param store: the metadata store to be used
-        :param kwargs: additional arguments to be used to instantiate a metadata store
+        Generic object to manage metadata instances.
+        :param namespace (str): the partition where metadata instances are stored
+        :param kwargs: additional arguments to be used to instantiate a metadata manager
+        Keyword Args:
+            metadata_store_class (str): the name of the MetadataStore subclass to use for storing managed instances
         """
         super(MetadataManager, self).__init__(**kwargs)
 

--- a/elyra/metadata/manager.py
+++ b/elyra/metadata/manager.py
@@ -39,7 +39,7 @@ class MetadataManager(LoggingConfigurable):
     metadata_store_class = Type(default_value=FileMetadataStore, config=True,
                                 klass=MetadataStore,
                                 help="""The metadata store class.  This is configurable to allow subclassing of
-                                the MetadataManager for customized behavior.""")
+                                the MetadataStore for customized behavior.""")
 
     def __init__(self, namespace: str, **kwargs):
         """

--- a/elyra/metadata/manager.py
+++ b/elyra/metadata/manager.py
@@ -21,7 +21,7 @@ import re
 from jsonschema import validate, ValidationError, draft7_format_checker
 from traitlets import Type
 from traitlets.config import LoggingConfigurable
-from typing import Optional, List
+from typing import List
 
 from .metadata import Metadata
 from .schema import SchemaManager
@@ -29,17 +29,19 @@ from .storage import MetadataStore, FileMetadataStore
 
 
 class MetadataManager(LoggingConfigurable):
+    """Manages metadata instances"""
 
     # System-owned namespaces
     NAMESPACE_RUNTIMES = "runtimes"
     NAMESPACE_CODE_SNIPPETS = "code-snippets"
     NAMESPACE_RUNTIME_IMAGES = "runtime-images"
 
-    metadata_class = Type(Metadata, config=True,
-                          help="""The metadata class.  This is configurable to allow subclassing of
-                          the MetadataManager for customized behavior.""")
+    metadata_store_class = Type(default_value=FileMetadataStore, config=True,
+                                klass=MetadataStore,
+                                help="""The metadata store class.  This is configurable to allow subclassing of
+                                the MetadataManager for customized behavior.""")
 
-    def __init__(self, namespace: str, store: Optional[MetadataStore] = None, **kwargs):
+    def __init__(self, namespace: str, **kwargs):
         """
         Generic object to read Notebook related metadata
         :param namespace: the partition where it is stored, this might have
@@ -52,10 +54,7 @@ class MetadataManager(LoggingConfigurable):
         self.schema_mgr = SchemaManager.instance()
         self.schema_mgr.validate_namespace(namespace)
         self.namespace = namespace
-        if store:
-            self.metadata_store = store
-        else:
-            self.metadata_store = FileMetadataStore(namespace, **kwargs)
+        self.metadata_store = self.metadata_store_class(namespace, **kwargs)
 
     def namespace_exists(self) -> bool:
         """Returns True if the namespace for this instance exists"""

--- a/elyra/metadata/tests/conftest.py
+++ b/elyra/metadata/tests/conftest.py
@@ -21,10 +21,10 @@ import jupyter_core.paths
 
 from notebook.utils import url_path_join
 from tornado.escape import url_escape
-from elyra.metadata import MetadataManager, SchemaManager, METADATA_TEST_NAMESPACE, FileMetadataStore  # noqa: F401
+from elyra.metadata import MetadataManager, SchemaManager, METADATA_TEST_NAMESPACE  # noqa: F401
 
 from .test_utils import valid_metadata_json, invalid_metadata_json, another_metadata_json, byo_metadata_json, \
-    invalid_json, create_json_file, create_file
+    invalid_json, create_json_file, create_instance
 
 
 # BEGIN - Remove once transition to jupyter_server occurs
@@ -111,14 +111,6 @@ factory_location = pytest.fixture(lambda env_jupyter_path:
 
 
 @pytest.fixture
-def setup_namespace(environ, namespace_location):
-    create_json_file(namespace_location, 'valid.json', valid_metadata_json)
-    create_json_file(namespace_location, 'another.json', another_metadata_json)
-    create_json_file(namespace_location, 'invalid.json', invalid_metadata_json)
-    create_file(namespace_location, 'bad.json', invalid_json)
-
-
-@pytest.fixture
 def setup_hierarchy(environ, factory_location):
     # Only populate factory info
     byo_instance = byo_metadata_json
@@ -128,19 +120,26 @@ def setup_hierarchy(environ, factory_location):
     create_json_file(factory_location, 'byo_3.json', byo_instance)
 
 
-@pytest.fixture(params=["FileMetadataStore"])  # Add types as needed
-def store_manager(request):
-    return globals()[request.param](namespace=METADATA_TEST_NAMESPACE)
+@pytest.fixture
+def store_manager(tests_manager):
+    return tests_manager.metadata_store
+
+
+@pytest.fixture(params=["elyra.metadata.storage.FileMetadataStore",
+                        "elyra.metadata.tests.test_utils.MockMetadataStore"])  # Add types as needed
+def tests_manager(environ, namespace_location, request):
+    metadata_mgr = MetadataManager(namespace=METADATA_TEST_NAMESPACE, metadata_store_class=request.param)
+    store_mgr = metadata_mgr.metadata_store
+    create_instance(store_mgr, namespace_location, 'valid', valid_metadata_json)
+    create_instance(store_mgr, namespace_location, 'another', another_metadata_json)
+    create_instance(store_mgr, namespace_location, 'invalid', invalid_metadata_json)
+    create_instance(store_mgr, namespace_location, 'bad', invalid_json)
+    return metadata_mgr
 
 
 @pytest.fixture
-def tests_manager(setup_namespace, store_manager):
-    return MetadataManager(namespace=METADATA_TEST_NAMESPACE, store=store_manager)
-
-
-@pytest.fixture
-def tests_hierarchy_manager(setup_hierarchy, store_manager):
-    return MetadataManager(namespace=METADATA_TEST_NAMESPACE, store=store_manager)
+def tests_hierarchy_manager(setup_hierarchy):  # Only uses FileMetadataStore for storage right now.
+    return MetadataManager(namespace=METADATA_TEST_NAMESPACE)
 
 
 @pytest.fixture

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -23,7 +23,7 @@ from jsonschema import validate, ValidationError, draft7_format_checker
 from elyra.metadata import Metadata, MetadataManager, MetadataStore, FileMetadataStore, SchemaManager, \
     MetadataNotFoundError, MetadataExistsError, SchemaNotFoundError, METADATA_TEST_NAMESPACE
 from .test_utils import valid_metadata_json, invalid_metadata_json, byo_metadata_json, create_json_file, \
-    get_schema, invalid_no_display_name_json, valid_display_name_json
+    create_instance, get_schema, invalid_no_display_name_json, valid_display_name_json, MockMetadataStore
 
 
 os.environ["METADATA_TESTING"] = "1"  # Enable metadata-tests namespace
@@ -244,7 +244,7 @@ def test_manager_add_remove_valid(tests_manager, namespace_location):
 
 def test_manager_remove_invalid(tests_manager, namespace_location):
     # Ensure invalid metadata file isn't validated and is removed.
-    create_json_file(namespace_location, 'remove_invalid.json', invalid_metadata_json)
+    create_instance(tests_manager.metadata_store, namespace_location, 'remove_invalid', invalid_metadata_json)
     metadata_name = 'remove_invalid'
     tests_manager.remove(metadata_name)
 
@@ -265,7 +265,8 @@ def test_manager_read_valid_by_name(tests_manager, namespace_location):
     some_metadata = tests_manager.get(metadata_name)
     assert some_metadata.name == metadata_name
     assert some_metadata.schema_name == "metadata-test"
-    assert str(namespace_location) in some_metadata.resource
+    metadata_location = _compose_instance_location(tests_manager.metadata_store, namespace_location, metadata_name)
+    assert metadata_location == some_metadata.resource
 
 
 def test_manager_read_invalid_by_name(tests_manager):
@@ -561,7 +562,7 @@ def test_manager_hierarchy_remove(tests_hierarchy_manager, factory_location, sha
 
 
 # ########################## MetadataStore Tests ###########################
-def test_store_manager_namespace(setup_namespace, store_manager, namespace_location):
+def test_store_namespace(store_manager, namespace_location):
     # Delete the metadata dir contents and attempt listing metadata
     _remove_namespace(store_manager, namespace_location)
     assert store_manager.namespace_exists() is False
@@ -571,12 +572,12 @@ def test_store_manager_namespace(setup_namespace, store_manager, namespace_locat
     assert store_manager.namespace_exists()
 
 
-def test_store_manager_fetch_instances(setup_namespace, store_manager):
+def test_store_fetch_instances(store_manager):
     instances_list = store_manager.fetch_instances()
     assert len(instances_list) == 3
 
 
-def test_store_manager_fetch_no_namespace(setup_namespace, store_manager, namespace_location):
+def test_store_fetch_no_namespace(store_manager, namespace_location):
     # Delete the namespace contents and attempt listing metadata
     _remove_namespace(store_manager, namespace_location)
 
@@ -584,19 +585,19 @@ def test_store_manager_fetch_no_namespace(setup_namespace, store_manager, namesp
     assert len(instance_list) == 0
 
 
-def test_store_manager_fetch_by_name(setup_namespace, store_manager):
+def test_store_fetch_by_name(store_manager):
     metadata_name = 'valid'
     instance_list = store_manager.fetch_instances(name=metadata_name)
     assert instance_list[0].get('name') == metadata_name
 
 
-def test_store_manager_fetch_missing(setup_namespace, store_manager):
+def test_store_fetch_missing(store_manager):
     metadata_name = 'missing'
     with pytest.raises(MetadataNotFoundError):
         store_manager.fetch_instances(name=metadata_name)
 
 
-def test_store_manager_store_instance(setup_namespace, store_manager, namespace_location):
+def test_store_store_instance(store_manager, namespace_location):
 
     _remove_namespace(store_manager, namespace_location)  # Remove namespace to test raw creation and confirm perms
 
@@ -636,7 +637,7 @@ def test_store_manager_store_instance(setup_namespace, store_manager, namespace_
     assert instance.get('metadata')['number_range_test'] == 10
 
 
-def test_store_manager_delete_instance(setup_namespace, store_manager, namespace_location):
+def test_store_delete_instance(store_manager, namespace_location):
     metadata_name = 'valid'
 
     store_manager.delete_instance(metadata_name)
@@ -748,21 +749,27 @@ def _ensure_single_instance(tests_hierarchy_manager, namespace_location, name, e
 
 
 def _create_namespace(store_manager: MetadataStore, namespace_location: str):
-    """Creates namespace in a storage-indendepent manner"""
+    """Creates namespace in a storage-independent manner"""
     if isinstance(store_manager, FileMetadataStore):
         os.makedirs(namespace_location)
+    elif isinstance(store_manager, MockMetadataStore):
+        instances = getattr(store_manager, 'instances')
+        if instances is None:
+            setattr(store_manager, 'instances', dict())
 
 
 def _remove_namespace(store_manager: MetadataStore, namespace_location: str):
-    """Removes namespace in a storage-indendepent manner"""
+    """Removes namespace in a storage-independent manner"""
     if isinstance(store_manager, FileMetadataStore):
         shutil.rmtree(namespace_location)
+    elif isinstance(store_manager, MockMetadataStore):
+        setattr(store_manager, 'instances', None)
 
 
 def _compose_instance_location(store_manager: MetadataStore, location: str, name: str) -> str:
     """Compose location of the named instance in a storage-independent manner"""
     if isinstance(store_manager, FileMetadataStore):
         location = os.path.join(location, '{}.json'.format(name))
-    else:  # Using the same approach for now (using separator)
-        location = os.path.join(location, '{}.json'.format(name))
+    elif isinstance(store_manager, MockMetadataStore):
+        location = None
     return location

--- a/elyra/metadata/tests/test_utils.py
+++ b/elyra/metadata/tests/test_utils.py
@@ -19,7 +19,10 @@ import json
 import os
 
 from jsonschema import ValidationError
-from elyra.metadata import METADATA_TEST_NAMESPACE
+from elyra.metadata import METADATA_TEST_NAMESPACE, MetadataStore, FileMetadataStore, \
+    MetadataNotFoundError, MetadataExistsError
+from typing import Optional, List, Any
+
 
 valid_metadata_json = {
     'schema_name': 'metadata-test',
@@ -139,6 +142,22 @@ def create_file(location, file_name, content):
         f.write(content)
 
 
+def create_instance(metadata_store: MetadataStore, location: str, name: str, content: Any):
+    if isinstance(metadata_store, FileMetadataStore):
+        if isinstance(content, dict):
+            create_json_file(location, name + '.json', content)
+        else:
+            create_file(location, name + '.json', content)
+    elif isinstance(metadata_store, MockMetadataStore):
+        instances = getattr(metadata_store, 'instances')
+        if instances is None:
+            setattr(metadata_store, 'instances', dict())
+            instances = getattr(metadata_store, 'instances')
+        if not isinstance(content, dict):
+            content = {'display_name': name, 'reason': "JSON failed to load for metadata '{}'".format(name)}
+        instances[name] = content
+
+
 def get_schema(schema_name):
     schema_file = os.path.join(os.path.dirname(__file__), '..', 'schemas', schema_name + '.json')
     if not os.path.exists(schema_file):
@@ -205,3 +224,60 @@ class PropertyTester(object):
             assert instance_json["schema_name"] == 'metadata-test'
             assert instance_json["display_name"] == self.name
             assert instance_json["metadata"][self.property] == self.positive_value
+
+
+class MockMetadataStore(MetadataStore):
+    def __init__(self, namespace, **kwargs):
+        super().__init__(namespace, **kwargs)
+        self.instances = None
+
+    def namespace_exists(self) -> bool:
+        """Returns True if the namespace for this instance exists"""
+        if self.instances is not None:
+            return True
+        return False
+
+    def fetch_instances(self, name: Optional[str] = None, include_invalid: bool = False) -> List[dict]:
+        """Fetch metadata instances"""
+
+        if name:
+            if self.instances is not None:
+                if name in self.instances:
+                    instance = self.instances.get(name)
+                    if instance.get('reason'):
+                        raise ValueError(instance.get('reason'))
+                    instance['name'] = name
+                    return [instance]
+            raise MetadataNotFoundError(self.namespace, name)
+
+        # all instances are wanted, filter based on include-invalid and reason ...
+        instance_list = []
+        if self.instances is not None:
+            for name, instance in self.instances.items():
+                if include_invalid or not instance.get('reason'):
+                    instance['name'] = name
+                    instance_list.append(instance)
+        return instance_list
+
+    def store_instance(self, name: str, metadata: dict, for_update: bool = False) -> dict:
+        """Stores the named metadata instance."""
+        try:
+            instance = self.fetch_instances(name)
+            if not for_update:  # Create - already exists
+                raise MetadataExistsError(self.namespace, instance[0].get('resource'))
+        except MetadataNotFoundError as mnfe:
+            if for_update:  # Update - doesn't exist
+                raise mnfe from mnfe
+
+        if self.instances is None:
+            self.instances = dict()
+        self.instances[name] = metadata  # persisted, now fetch
+
+        instance = self.fetch_instances(name)  # confirm persistence
+        return instance[0]
+
+    def delete_instance(self, name: str) -> None:
+        """Deletes the metadata instance corresponding to the given name."""
+
+        self.fetch_instances(name)  # confirm it exists
+        self.instances.pop(name)


### PR DESCRIPTION
The class to use for the `MetadataStore` when creating a `MetadataManager` instance is now pulled from the `metadata_store_class` trait, which requires a class of `MetadataStore` and defaults to `FileMetadataStore`.

Differing storage classes can still be associated during `MetadataManager` creation by using parameter `metadata_store_class="class-name"` like so...
```python
    metadata_mgr = MetadataManager(namespace=METADATA_TEST_NAMESPACE, 
                                   metadata_store_class="elyra.metadata.tests.test_utils.MockMetadataStore")
```
This will be useful for building migration or distribution applications.  For example, one `MetadataManager` using `FileMetadataStore` and fetching instances, while another `MetadataManager` uses `MongoDBMetadataStore` that creates the fetched instances in the destination.  (Note that using `FileMetadataStore` on both ends won't work today (unless you were changing namespaces) because the filesystem locations are derived from within the process - not provided as parameters - but we could probably add that capability if necessary (although cp -r would work fairly easily in that case as well).)

Down the road, one could see a `MetadataStore` instance that corresponds to the specific metadata instance based on schema values.  This would allow for applications like Telemetry that consume JSON-validated records if, for example, the Metadata Store was implemented to "store" its instances wherever the telemetry "sink" is located.  We'd need to add concepts of write-only and perhaps read-only instances, but that would be just another [_meta-behavior_](https://github.com/elyra-ai/elyra/issues/518).

A `MockMetadataStore` has been created and the metadata manager and metadata store tests now run against both it and `FileMetadataStore` for testing.  This helps keep file-based items out of the metadata manager logic and can serve as an example of a non-file based store manager.

Resolves #709

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

