### PR TITLE
Add support for metadata instance classes

### DIFF
--- a/elyra/metadata/handlers.py
+++ b/elyra/metadata/handlers.py
@@ -53,7 +53,7 @@ class MetadataHandler(HttpErrorMixin, APIHandler):
 
         namespace = url_unescape(namespace)
         try:
-            instance = self._validate_body()
+            instance = self._validate_body(namespace)
             self.log.debug("MetadataHandler: Creating metadata instance '{}' in namespace '{}'...".
                            format(instance.name, namespace))
             metadata_manager = MetadataManager(namespace=namespace)
@@ -73,7 +73,7 @@ class MetadataHandler(HttpErrorMixin, APIHandler):
         self.set_header('Location', location)
         self.finish(metadata.to_dict(trim=True))
 
-    def _validate_body(self):
+    def _validate_body(self, namespace: str):
         """Validates the body issued for creates. """
         body = self.get_json_body()
 
@@ -92,7 +92,7 @@ class MetadataHandler(HttpErrorMixin, APIHandler):
                 )
             )
 
-        instance = Metadata(**body)
+        instance = Metadata.from_dict(namespace, {**body})
         return instance
 
 
@@ -133,7 +133,7 @@ class MetadataResourceHandler(HttpErrorMixin, APIHandler):
             if 'name' in payload and payload['name'] != resource:
                 raise NotImplementedError("The attempt to rename instance '{}' to '{}' is not supported.".
                                           format(resource, payload['name']))
-            instance = Metadata(**payload)
+            instance = Metadata.from_dict(namespace, {**payload})
             self.log.debug("MetadataHandler: Updating metadata instance '{}' in namespace '{}'...".
                            format(resource, namespace))
             metadata = metadata_manager.update(resource, instance)

--- a/elyra/metadata/manager.py
+++ b/elyra/metadata/manager.py
@@ -21,7 +21,7 @@ import re
 from jsonschema import validate, ValidationError, draft7_format_checker
 from traitlets import Type
 from traitlets.config import LoggingConfigurable
-from typing import List
+from typing import List, Any
 
 from .error import SchemaNotFoundError
 from .metadata import Metadata
@@ -42,7 +42,7 @@ class MetadataManager(LoggingConfigurable):
                                 help="""The metadata store class.  This is configurable to allow subclassing of
                                 the MetadataStore for customized behavior.""")
 
-    def __init__(self, namespace: str, **kwargs):
+    def __init__(self, namespace: str, **kwargs: Any):
         """
         Generic object to manage metadata instances.
         :param namespace (str): the partition where metadata instances are stored
@@ -68,17 +68,17 @@ class MetadataManager(LoggingConfigurable):
         instance_list = self.metadata_store.fetch_instances(include_invalid=include_invalid)
         for metadata_dict in instance_list:
             # validate the instance prior to return, include invalid instances as appropriate
-            metadata = Metadata.from_dict(metadata_dict)
+            metadata = Metadata.from_dict(self.namespace, metadata_dict)
+            metadata.post_load()  # Allow class instances to handle loads
             try:
                 # if we're including invalid and there was an issue on retrieval, add it to the list
                 if include_invalid and metadata.reason:
                     # If no schema-name is present, set to '{unknown}' since we can't make that determination.
                     if not metadata.schema_name:
                         metadata.schema_name = '{unknown}'
-                    instances.append(metadata)
                 else:  # go ahead and validate against the schema
                     self.validate(metadata.name, metadata)
-                    instances.append(metadata)
+                instances.append(metadata)
             except Exception as ex:  # Ignore ValidationError and others when fetching all instances
                 self.log.debug("Fetch of instance '{}' of namespace '{}' encountered an exception: {}".
                                format(metadata.name, self.namespace, ex))
@@ -91,7 +91,9 @@ class MetadataManager(LoggingConfigurable):
         """Returns the metadata instance corresponding to the given name"""
         instance_list = self.metadata_store.fetch_instances(name=name)
         metadata_dict = instance_list[0]
-        metadata = Metadata.from_dict(metadata_dict)
+        metadata = Metadata.from_dict(self.namespace, metadata_dict)
+        metadata.post_load()  # Allow class instances to handle loads
+
         # validate the instance prior to return...
         self.validate(name, metadata)
         return metadata
@@ -106,8 +108,16 @@ class MetadataManager(LoggingConfigurable):
 
     def remove(self, name: str) -> None:
         """Removes the metadata instance corresponding to the given name"""
+
+        instance_list = self.metadata_store.fetch_instances(name=name)
+        metadata_dict = instance_list[0]
+
         self.log.debug("Removing metadata resource '{}' from namespace '{}'.".format(name, self.namespace))
-        self.metadata_store.delete_instance(name)
+
+        metadata = Metadata.from_dict(self.namespace, metadata_dict)
+        metadata.pre_delete()  # Allow class instances to handle delete
+
+        self.metadata_store.delete_instance(metadata_dict)
 
     def validate(self, name: str, metadata: Metadata) -> None:
         """Validate metadata against its schema.
@@ -115,7 +125,7 @@ class MetadataManager(LoggingConfigurable):
         Ensure metadata is valid based on its schema.  If invalid or schema
         is not found, ValidationError will be raised.
         """
-        metadata_dict = metadata.to_dict(trim=True)
+        metadata_dict = metadata.to_dict()
         schema_name = metadata_dict.get('schema_name')
         if not schema_name:
             raise ValueError("Instance '{}' in the {} namespace is missing a 'schema_name' field!".
@@ -185,5 +195,10 @@ class MetadataManager(LoggingConfigurable):
 
         # Validate the metadata prior to storage then store the instance.
         self.validate(name, metadata)
+
+        # Allow class instances to handle saves
+        metadata.pre_save(for_update=for_update)
+
         metadata_dict = self.metadata_store.store_instance(name, metadata.prepare_write(), for_update=for_update)
-        return Metadata.from_dict(metadata_dict)
+
+        return Metadata.from_dict(self.namespace, metadata_dict)

--- a/elyra/metadata/metadata.py
+++ b/elyra/metadata/metadata.py
@@ -16,7 +16,10 @@
 
 import json
 
-from typing import Type, TypeVar
+from ipython_genutils.importstring import import_item
+from typing import Type, TypeVar, Any
+
+from .schema import SchemaManager
 
 # Setup forward reference for type hint on return from class factory method.  See
 # https://stackoverflow.com/questions/39205527/can-you-annotate-return-type-when-value-is-instance-of-cls/39205612#39205612
@@ -31,7 +34,7 @@ class Metadata(object):
     metadata = {}
     reason = None
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         self.name = kwargs.get('name')
         self.display_name = kwargs.get('display_name')
         self.schema_name = kwargs.get('schema_name')
@@ -39,15 +42,52 @@ class Metadata(object):
         self.resource = kwargs.get('resource')
         self.reason = kwargs.get('reason')
 
+    def post_load(self, **kwargs: Any) -> None:
+        """Called by MetadataManager after fetching the instance.
+
+        :param kwargs: additional arguments
+        """
+        pass
+
+    def pre_save(self, **kwargs: Any) -> None:
+        """Called by MetadataManager prior to saving the instance.
+
+        :param kwargs: additional arguments
+        Keyword Args:
+            for_update (bool): indicates if this save operation if for update (True) or create (False)
+        """
+        pass
+
+    def pre_delete(self, **kwargs: Any) -> None:
+        """Called by MetadataManager prior to deleting the instance.
+
+        :param kwargs: additional arguments
+        """
+        pass
+
     @classmethod
-    def from_dict(cls: Type[M], metadata_dict: dict) -> M:
-        """Creates an instance of Metadata from a dictionary instance """
-        return cls(name=metadata_dict.get('name'),
-                   display_name=metadata_dict.get('display_name'),
-                   schema_name=metadata_dict.get('schema_name'),
-                   metadata=metadata_dict.get('metadata', {}),
-                   resource=metadata_dict.get('resource'),
-                   reason=metadata_dict.get('reason'))
+    def from_dict(cls: Type[M], namespace: str, metadata_dict: dict) -> M:
+        """Creates an appropriate instance of Metadata from a dictionary instance """
+
+        # Get the schema and look for metadata_class entry and use that, else Metadata.
+        metadata_class_name = 'elyra.metadata.Metadata'
+        schema_name = metadata_dict.get('schema_name')
+        if schema_name:
+            try:
+                schema = SchemaManager.instance().get_schema(namespace, schema_name)
+                metadata_class_name = schema.get('metadata_class_name', metadata_class_name)
+            except Exception:  # just use the default
+                pass
+        metadata_class = import_item(metadata_class_name)
+        try:
+            instance = metadata_class(**metadata_dict)
+            if not isinstance(instance, Metadata):
+                raise ValueError("The metadata_class_name ('{}') for schema '{}' must be a subclass of '{}'!".
+                                 format(metadata_class_name, schema_name, cls.__name__))
+        except TypeError as te:
+            raise ValueError("The metadata_class_name ('{}') for schema '{}' must be a subclass of '{}'!".
+                             format(metadata_class_name, schema_name, cls.__name__)) from te
+        return instance
 
     def to_dict(self, trim: bool = False) -> dict:
         # Exclude resource, and reason only if trim is True since we don't want to persist that information.

--- a/elyra/metadata/schemas/metadata-test.json
+++ b/elyra/metadata/schemas/metadata-test.json
@@ -4,6 +4,7 @@
   "name": "metadata-test",
   "display_name": "Metadata Test",
   "namespace": "metadata-tests",
+  "metadata_class_name": "elyra.metadata.tests.MockMetadataTest",
   "properties": {
     "schema_name": {
       "type": "string",

--- a/elyra/metadata/storage.py
+++ b/elyra/metadata/storage.py
@@ -47,7 +47,7 @@ class MetadataStore(ABC):
         pass
 
     @abstractmethod
-    def delete_instance(self, name: str) -> None:
+    def delete_instance(self, metadata: dict) -> None:
         """Deletes the metadata instance corresponding to the given name."""
         pass
 
@@ -155,11 +155,9 @@ class FileMetadataStore(MetadataStore):
 
         return metadata
 
-    def delete_instance(self, name: str) -> None:
+    def delete_instance(self, metadata: dict) -> None:
         """Delete the named instance"""
 
-        instance_list = self.fetch_instances(name=name)  # Let exceptions (FileNotFound) propagate
-        metadata = instance_list[0]
         resource = metadata.get('resource')
         if resource:
             # Since multiple folders are in play, we only allow removal if the resource is in

--- a/elyra/metadata/storage.py
+++ b/elyra/metadata/storage.py
@@ -157,7 +157,7 @@ class FileMetadataStore(MetadataStore):
 
     def delete_instance(self, metadata: dict) -> None:
         """Delete the named instance"""
-
+        name = metadata.get('name')
         resource = metadata.get('resource')
         if resource:
             # Since multiple folders are in play, we only allow removal if the resource is in

--- a/elyra/metadata/tests/__init__.py
+++ b/elyra/metadata/tests/__init__.py
@@ -13,3 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from .test_utils import MockMetadataStore, MockMetadataTest, MockMetadataTestInvalid

--- a/elyra/metadata/tests/conftest.py
+++ b/elyra/metadata/tests/conftest.py
@@ -126,7 +126,7 @@ def store_manager(tests_manager):
 
 
 @pytest.fixture(params=["elyra.metadata.storage.FileMetadataStore",
-                        "elyra.metadata.tests.test_utils.MockMetadataStore"])  # Add types as needed
+                        "elyra.metadata.tests.MockMetadataStore"])  # Add types as needed
 def tests_manager(environ, namespace_location, request):
     metadata_mgr = MetadataManager(namespace=METADATA_TEST_NAMESPACE, metadata_store_class=request.param)
     store_mgr = metadata_mgr.metadata_store

--- a/elyra/metadata/tests/test_handlers.py
+++ b/elyra/metadata/tests/test_handlers.py
@@ -191,6 +191,10 @@ class MetadataHandlerHierarchyTest(MetadataTestBase):
         assert r.status_code == 201
         assert r.headers.get('location') == r.request.path_url + '/valid'
         metadata = r.json()
+        # Add expected "extra" fields to 'valid' so whole-object comparison is satisfied.
+        # These are added during the pre_save() hook on the MockMetadataTest class instance.
+        valid['for_update'] = False
+        valid['special_property'] = valid['metadata']['required_test']
         assert metadata == valid
 
     def test_create_hierarchy_instance(self):


### PR DESCRIPTION
This pull request adds the ability for custom class implementations to be tied to metadata instances of the same schema.

Schemas that contain the system-level property `metadata_class_name` will have instances containing their metadata properties of that class. These instances, which are subclasses of `Metadata` (enforced), can then override methods `post_load()`, `pre_save()` and `pre_delete()` to allow the implementations to adjust their values, perform actions on behalf of the instance, etc.

The pre_save() method is called after validation, while post_load() is called prior to validation of the object against its schema. (Validation is not performed on deletes, so call order relative to validation is not applicable.)

Use of this feature is optional, but the metadata tests show how this can behave.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

