### PR TITLE
Allow code editor to be resized

### DIFF
--- a/packages/code-snippet/style/index.css
+++ b/packages/code-snippet/style/index.css
@@ -55,6 +55,11 @@
   fill: var(--jp-ui-font-color1);
 }
 
+.elyra-codeSnippetsHeader + div:first-of-type {
+  overflow-y: auto;
+  height: calc(100vh - 95px);
+}
+
 .elyra-codeSnippet-item {
   border-bottom: var(--jp-border-width) solid var(--jp-border-color2);
   display: flex;
@@ -63,18 +68,18 @@
   padding: 0;
 }
 
-.elyra-codeSnippet-item .CodeMirror-wrap {
+.elyra-codeSnippet-item .elyra-expandableContainer-details-visible {
+  background-color: var(--jp-cell-editor-background);
+  resize: vertical;
+  height: 100px;
+}
+
+.elyra-codeSnippet-item .CodeMirror.cm-s-jupyter {
   background-color: inherit;
   border: none;
   font-family: var(--jp-code-font-family);
   font-size: var(--jp-code-font-size);
   line-height: var(--jp-code-line-height);
-  height: 100%;
-  width: 100%;
-  resize: vertical;
-  white-space: pre;
-  word-wrap: normal;
-  overflow-x: scroll;
 }
 
 .elyra-codeSnippet-saveButton {

--- a/packages/metadata-editor/src/MetadataEditor.tsx
+++ b/packages/metadata-editor/src/MetadataEditor.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FormGroup, Intent } from '@blueprintjs/core';
+import { FormGroup, Intent, ResizeSensor } from '@blueprintjs/core';
 
 import { FrontendServices, IDictionary } from '@elyra/application';
 import { DropDown } from '@elyra/ui-components';
@@ -349,9 +349,13 @@ export class MetadataEditor extends ReactWidget {
           intent={this.schema[fieldName].uihints.intent}
           helperText={helperText}
         >
-          <div>
-            <div id={'code:' + this.id} className="elyra-form-code"></div>
-          </div>
+          <ResizeSensor
+            onResize={(): void => {
+              this.editor.refresh();
+            }}
+          >
+            <div id={'code:' + this.id} className="elyra-form-code va-va"></div>
+          </ResizeSensor>
         </FormGroup>
       );
     } else {

--- a/packages/metadata-editor/src/MetadataEditor.tsx
+++ b/packages/metadata-editor/src/MetadataEditor.tsx
@@ -343,13 +343,15 @@ export class MetadataEditor extends ReactWidget {
       }
       return (
         <FormGroup
-          style={{ width: '100%', display: 'flex' }}
+          className={'elyra-metadataEditor-code'}
           labelInfo={required}
           label={'Code'}
           intent={this.schema[fieldName].uihints.intent}
           helperText={helperText}
         >
-          <div id={'code:' + this.id} className="elyra-form-code"></div>
+          <div>
+            <div id={'code:' + this.id} className="elyra-form-code"></div>
+          </div>
         </FormGroup>
       );
     } else {
@@ -373,7 +375,6 @@ export class MetadataEditor extends ReactWidget {
     return (
       <div className={ELYRA_METADATA_EDITOR_CLASS}>
         <h3> {headerText} </h3>
-        <br />
         {this.renderTextInput(
           'Name',
           '',

--- a/packages/metadata-editor/style/index.css
+++ b/packages/metadata-editor/style/index.css
@@ -47,7 +47,8 @@
   border: var(--jp-border-width) solid var(--jp-input-border-color);
   overflow-y: auto;
   resize: vertical;
-  height: 200px;
+  min-height: 150px;
+  height: 150px;
   padding-bottom: 10px;
   cursor: initial;
 }

--- a/packages/metadata-editor/style/index.css
+++ b/packages/metadata-editor/style/index.css
@@ -49,6 +49,7 @@
   resize: vertical;
   height: 200px;
   padding-bottom: 10px;
+  cursor: initial;
 }
 
 .elyra-metadataEditor .CodeMirror.cm-s-jupyter {

--- a/packages/metadata-editor/style/index.css
+++ b/packages/metadata-editor/style/index.css
@@ -23,13 +23,14 @@
 }
 
 .elyra-metadataEditor {
-  padding: 20px;
+  margin: 20px;
   display: flex;
   flex-wrap: wrap;
   height: 100%;
   align-content: flex-start;
   align-items: flex-start;
   justify-content: flex-start;
+  overflow-y: auto;
 }
 
 .elyra-metadataEditor h3 {
@@ -43,15 +44,17 @@
 }
 
 .elyra-metadataEditor .elyra-form-code.jp-CodeMirrorEditor {
-  height: 100%;
+  background-color: var(--jp-cell-editor-background);
 }
 
 .elyra-metadataEditor .CodeMirror.cm-s-jupyter {
   background-color: inherit;
-  font-family: var(--jp-code-font-family);
-  font-size: var(--jp-code-font-size);
   line-height: var(--jp-code-line-height);
-  height: 100%;
+  font-size: var(--jp-code-font-size);
+  font-family: var(--jp-code-font-family);
+  border: 0;
+  border-radius: 0;
+  height: auto;
 }
 
 .elyra-metadataEditor .bp3-form-group.elyra-metadataEditor-code {
@@ -67,7 +70,7 @@
 .elyra-metadataEditor-code .bp3-form-content > div:first-of-type {
   background-color: var(--jp-cell-editor-background);
   overflow-y: auto;
-  min-height: 150px;
+  min-height: 100px;
   max-height: calc(100vh - 400px);
   resize: vertical;
   border: var(--jp-border-width) solid var(--jp-input-border-color);

--- a/packages/metadata-editor/style/index.css
+++ b/packages/metadata-editor/style/index.css
@@ -23,14 +23,13 @@
 }
 
 .elyra-metadataEditor {
-  margin: 20px;
+  padding: 20px;
   display: flex;
   flex-wrap: wrap;
   height: 100%;
   align-content: flex-start;
   align-items: flex-start;
   justify-content: flex-start;
-  overflow-y: auto;
 }
 
 .elyra-metadataEditor h3 {
@@ -45,16 +44,16 @@
 
 .elyra-metadataEditor .elyra-form-code.jp-CodeMirrorEditor {
   background-color: var(--jp-cell-editor-background);
+  border: var(--jp-border-width) solid var(--jp-input-border-color);
+  overflow-y: auto;
+  resize: vertical;
+  height: 200px;
+  padding-bottom: 10px;
 }
 
 .elyra-metadataEditor .CodeMirror.cm-s-jupyter {
   background-color: inherit;
-  line-height: var(--jp-code-line-height);
-  font-size: var(--jp-code-font-size);
-  font-family: var(--jp-code-font-family);
-  border: 0;
-  border-radius: 0;
-  height: auto;
+  height: 100%;
 }
 
 .elyra-metadataEditor .bp3-form-group.elyra-metadataEditor-code {
@@ -67,18 +66,13 @@
   height: 100%;
 }
 
-.elyra-metadataEditor-code .bp3-form-content > div:first-of-type {
-  background-color: var(--jp-cell-editor-background);
-  overflow-y: auto;
-  min-height: 100px;
-  max-height: calc(100vh - 400px);
-  resize: vertical;
-  border: var(--jp-border-width) solid var(--jp-input-border-color);
-}
-
 .bp3-dark .bp3-input {
   border: var(--jp-border-width) solid var(--jp-input-border-color);
   color: var(--jp-ui-font-color1);
+}
+
+.elyra-metadata-editor {
+  overflow-y: auto;
 }
 
 .elyra-metadata-editor.bp3-dark {

--- a/packages/metadata-editor/style/index.css
+++ b/packages/metadata-editor/style/index.css
@@ -3,10 +3,10 @@
 }
 
 .elyra-metadataEditor .bp3-form-group {
-  width: 40%;
-  float: left;
   margin-bottom: 12px;
   margin-right: 20px;
+  flex-basis: 40%;
+  height: 65px;
 }
 
 .bp3-select-popover {
@@ -23,14 +23,18 @@
 }
 
 .elyra-metadataEditor {
-  margin: 20px;
+  padding: 20px;
   display: flex;
   flex-wrap: wrap;
+  height: 100%;
+  align-content: flex-start;
+  align-items: flex-start;
+  justify-content: flex-start;
 }
 
 .elyra-metadataEditor h3 {
-  width: 100%;
-  margin-bottom: 10px;
+  flex-basis: 100%;
+  margin-bottom: 15px;
   color: var(--jp-ui-font-color1);
 }
 
@@ -38,18 +42,35 @@
   color: var(--jp-ui-font-color1);
 }
 
-.elyra-metadataEditor .CodeMirror-wrap {
+.elyra-metadataEditor .elyra-form-code.jp-CodeMirrorEditor {
+  height: 100%;
+}
+
+.elyra-metadataEditor .CodeMirror.cm-s-jupyter {
   background-color: inherit;
-  box-shadow: inset 0 0 0 var(--jp-border-width) var(--jp-input-border-color);
   font-family: var(--jp-code-font-family);
   font-size: var(--jp-code-font-size);
   line-height: var(--jp-code-line-height);
   height: 100%;
-  width: 100%;
+}
+
+.elyra-metadataEditor .bp3-form-group.elyra-metadataEditor-code {
+  height: auto;
+  flex-basis: 100%;
+  display: flex;
+}
+
+.elyra-metadataEditor-code .bp3-form-content {
+  height: 100%;
+}
+
+.elyra-metadataEditor-code .bp3-form-content > div:first-of-type {
+  background-color: var(--jp-cell-editor-background);
+  overflow-y: auto;
+  min-height: 150px;
+  max-height: calc(100vh - 400px);
   resize: vertical;
-  white-space: pre;
-  word-wrap: normal;
-  overflow: scroll;
+  border: var(--jp-border-width) solid var(--jp-input-border-color);
 }
 
 .bp3-dark .bp3-input {


### PR DESCRIPTION
Updated the code editor component in the code snippet sidebar and the code editor component in the metadata editor form 

- [x] code editor component can be scrolled using the scrollbars
- [x] code editor component opens at an appropriate default size so other components do not immediately get pushed off screen

Fixes #728

**Before**:

![image](https://user-images.githubusercontent.com/13156555/87069766-caa98400-c1e5-11ea-810d-41d9260bf99f.png)

**After**: 

![image](https://user-images.githubusercontent.com/13156555/87069583-71d9eb80-c1e5-11ea-9cab-1e7efde77e56.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

