### PR TITLE
Make metadata error messages more user friendly

### DIFF
--- a/elyra/metadata/error.py
+++ b/elyra/metadata/error.py
@@ -14,36 +14,33 @@
 # limitations under the License.
 #
 """This module includes custom error classes pertaining to the metadata service."""
-import errno
 
 
-class MetadataNotFoundError(FileNotFoundError):
+class MetadataNotFoundError(BaseException):
     """Raised when a metadata instance is not found.
 
        Overrides FileNotFoundError to set contextual message text
        and includes the corresponding namespace.
     """
     def __init__(self, namespace: str, name: str):
-        super().__init__(errno.ENOENT, "No such metadata instance found in namespace '{}'".format(namespace), name)
+        super().__init__("No such instance named '{}' was found in the {} namespace.".format(name, namespace))
 
 
-class MetadataExistsError(FileExistsError):
+class MetadataExistsError(BaseException):
     """Raised when a metadata instance unexpectedly exists.
 
        Overrides FileExistsError to set contextual message text
        and includes the corresponding namespace.
     """
-
     def __init__(self, namespace: str, name: str):
-        super().__init__(errno.EEXIST, "Metadata instance already exists in namespace '{}'".format(namespace), name)
+        super().__init__("An instance named '{}' already exists in the {} namespace.".format(name, namespace))
 
 
-class SchemaNotFoundError(FileNotFoundError):
+class SchemaNotFoundError(BaseException):
     """Raised when a schema instance is not found.
 
        Overrides FileNotFoundError to set contextual message text
        and includes the corresponding namespace.
     """
-
     def __init__(self, namespace: str, name: str):
-        super().__init__(errno.ENOENT, "No such schema instance found in namespace '{}'".format(namespace), name)
+        super().__init__("No such schema named '{}' was found in the {} namespace.".format(name, namespace))

--- a/elyra/metadata/schemas/code-snippet.json
+++ b/elyra/metadata/schemas/code-snippet.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Code Snippet metadata",
   "name": "code-snippet",
+  "display_name": "Code Snippet",
   "namespace": "code-snippets",
   "properties": {
     "schema_name": {

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Kubeflow Pipeline runtime metadata",
   "name": "kfp",
+  "display_name": "KFP",
   "namespace": "runtimes",
   "properties": {
     "schema_name": {

--- a/elyra/metadata/schemas/metadata-test.json
+++ b/elyra/metadata/schemas/metadata-test.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Testing metadata",
   "name": "metadata-test",
+  "display_name": "Metadata Test",
   "namespace": "metadata-tests",
   "properties": {
     "schema_name": {

--- a/elyra/metadata/schemas/runtime-image.json
+++ b/elyra/metadata/schemas/runtime-image.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Runtime Image metadata",
   "name": "runtime-image",
+  "display_name": "Runtime Image",
   "namespace": "runtime-images",
   "properties": {
     "schema_name": {

--- a/elyra/metadata/tests/test_handlers.py
+++ b/elyra/metadata/tests/test_handlers.py
@@ -77,17 +77,19 @@ class MetadataHandlerTest(MetadataTestBase):
 
     def test_missing_instance(self):
         # Validate missing is not found
-        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'missing',
+        name = 'missing'
+        r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, name,
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 404
-        assert "No such metadata instance found in namespace '{}': 'missing'".format(METADATA_TEST_NAMESPACE) in r.text
+        assert "No such instance named '{}' was found in the {} namespace.".\
+               format(name, METADATA_TEST_NAMESPACE) in r.text
 
     def test_invalid_instance(self):
         # Validate invalid throws 404 with validation message
         r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, 'invalid',
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 400
-        assert "Schema validation failed for metadata 'invalid'" in r.text
+        assert "Validation failed for instance 'invalid'" in r.text
 
     def test_valid_instance(self):
         # Ensure valid metadata can be found
@@ -227,7 +229,7 @@ class MetadataHandlerHierarchyTest(MetadataTestBase):
         r = fetch(self.request, 'elyra', 'metadata', METADATA_TEST_NAMESPACE, body=body,
                   method='POST', base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 400
-        assert "Schema validation failed for metadata" in r.text
+        assert "Validation failed for instance 'invalid'" in r.text
 
     def test_create_instance_missing_schema(self):
         """Attempt to create an instance using an invalid schema """
@@ -443,7 +445,7 @@ class SchemaHandlerTest(MetadataTestBase):
         r = fetch(self.request, 'elyra', 'schema', 'runtimes', 'missing',
                   base_url=self.base_url(), headers=self.auth_headers())
         assert r.status_code == 404
-        assert "No such schema instance found in namespace 'runtimes': 'missing'" in r.text
+        assert "No such schema named 'missing' was found in the runtimes namespace." in r.text
 
     def test_get_runtimes_schemas(self):
         # Ensure all schema for runtimes can be found

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -180,7 +180,7 @@ def test_manager_get_include_invalid(tests_manager):
 def test_manager_get_bad_json(tests_manager):
     with pytest.raises(ValueError) as ve:
         tests_manager.get("bad")
-    assert "JSON failed to load for metadata 'bad'" in str(ve.value)
+    assert "JSON failed to load for instance 'bad'" in str(ve.value)
 
 
 def test_manager_get_all(tests_manager):
@@ -228,7 +228,7 @@ def test_manager_add_remove_valid(tests_manager, namespace_location):
     assert instance is not None
 
     # Attempt to create again w/o replace, then replace it.
-    with pytest.raises(FileExistsError):
+    with pytest.raises(MetadataExistsError):
         tests_manager.create(metadata_name, metadata)
 
     instance = tests_manager.update(metadata_name, metadata)
@@ -376,7 +376,7 @@ def test_manager_hierarchy_create(tests_hierarchy_manager, namespace_location):
 
     metadata = Metadata(**byo_metadata_json)
     metadata.display_name = 'user'
-    with pytest.raises(FileExistsError):
+    with pytest.raises(MetadataExistsError):
         tests_hierarchy_manager.create('byo_2', metadata)
 
     instance = tests_hierarchy_manager.update('byo_2', metadata)
@@ -425,7 +425,7 @@ def test_manager_hierarchy_update(tests_hierarchy_manager, factory_location, sha
     assert byo_2.resource.startswith(str(factory_location))
 
     byo_2.display_name = 'user'
-    with pytest.raises(FileExistsError):
+    with pytest.raises(MetadataExistsError):
         tests_hierarchy_manager.create('byo_2', byo_2)
 
     # Repeat with replacement enabled
@@ -546,7 +546,7 @@ def test_manager_hierarchy_remove(tests_hierarchy_manager, factory_location, sha
     # Attempt to remove instance from shared area and its protected
     with pytest.raises(PermissionError) as pe:
         tests_hierarchy_manager.remove('byo_2')
-    assert "Removal of metadata instance" in str(pe.value)
+    assert "Removal of instance 'byo_2'" in str(pe.value)
 
     # Ensure the one that exists is the one in the shared area
     byo_2 = tests_hierarchy_manager.get('byo_2')
@@ -555,7 +555,7 @@ def test_manager_hierarchy_remove(tests_hierarchy_manager, factory_location, sha
     # Attempt to remove instance from factory area and its protected as well
     with pytest.raises(PermissionError) as pe:
         tests_hierarchy_manager.remove('byo_1')
-    assert "Removal of metadata instance" in str(pe.value)
+    assert "Removal of instance 'byo_1'" in str(pe.value)
 
     byo_1 = tests_hierarchy_manager.get('byo_1')
     assert byo_1.resource.startswith(str(factory_location))
@@ -628,7 +628,7 @@ def test_store_store_instance(store_manager, namespace_location):
             assert valid_add['schema_name'] == "metadata-test"
 
     # Attempt to create again w/o replace, then replace it.
-    with pytest.raises(FileExistsError):
+    with pytest.raises(MetadataExistsError):
         store_manager.store_instance(metadata_name, metadata.prepare_write())
 
     metadata.metadata['number_range_test'] = 10
@@ -696,11 +696,7 @@ def test_error_metadata_not_found():
     try:
         raise MetadataNotFoundError(namespace, resource)
     except MetadataNotFoundError as mnfe:
-        assert isinstance(mnfe, MetadataNotFoundError)
-        assert mnfe.filename == resource
-        assert mnfe.strerror == "No such metadata instance found in namespace '{}'".format(namespace)
-        assert str(mnfe) == "[Errno 2] No such metadata instance found in namespace '{}': '{}'".\
-            format(namespace, resource)
+        assert str(mnfe) == "No such instance named '{}' was found in the {} namespace.".format(resource, namespace)
 
 
 def test_error_metadata_exists():
@@ -709,11 +705,7 @@ def test_error_metadata_exists():
     try:
         raise MetadataExistsError(namespace, resource)
     except MetadataExistsError as mee:
-        assert isinstance(mee, MetadataExistsError)
-        assert mee.filename == resource
-        assert mee.strerror == "Metadata instance already exists in namespace '{}'".format(namespace)
-        assert str(mee) == "[Errno 17] Metadata instance already exists in namespace '{}': '{}'".\
-            format(namespace, resource)
+        assert str(mee) == "An instance named '{}' already exists in the {} namespace.".format(resource, namespace)
 
 
 def test_error_schema_not_found():
@@ -722,11 +714,7 @@ def test_error_schema_not_found():
     try:
         raise SchemaNotFoundError(namespace, resource)
     except SchemaNotFoundError as snfe:
-        assert isinstance(snfe, SchemaNotFoundError)
-        assert snfe.filename == resource
-        assert snfe.strerror == "No such schema instance found in namespace '{}'".format(namespace)
-        assert str(snfe) == "[Errno 2] No such schema instance found in namespace '{}': '{}'".\
-            format(namespace, resource)
+        assert str(snfe) == "No such schema named '{}' was found in the {} namespace.".format(resource, namespace)
 
 
 def _ensure_single_instance(tests_hierarchy_manager, namespace_location, name, expected_count=1):

--- a/elyra/metadata/tests/test_metadata_app.py
+++ b/elyra/metadata/tests/test_metadata_app.py
@@ -145,8 +145,9 @@ def test_install_and_replace(script_runner, mock_data_dir):
                             '--name=test-metadata_42_valid-name', '--display_name=display_name',
                             '--required_test=required_value')
     assert ret.success is False
-    assert "The following exception occurred saving metadata instance 'test-metadata_42_valid-name'" \
-           " for schema 'metadata-test':" in ret.stdout
+    assert ret.stdout == ''
+    assert "An instance named 'test-metadata_42_valid-name' already exists in the metadata-tests " \
+           "namespace" in ret.stderr
 
     # Re-attempt with replace flag - success expected
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_NAMESPACE, '--schema_name=metadata-test',
@@ -270,10 +271,8 @@ def test_remove_missing(script_runner):
 
     ret = script_runner.run('elyra-metadata', 'remove', METADATA_TEST_NAMESPACE, '--name=missing')
     assert ret.success is False
-    assert ret.stdout.startswith("[Errno 2] No such metadata instance found in namespace '{}': 'missing'".
-                                 format(METADATA_TEST_NAMESPACE))
-
-    assert ret.stderr == ''
+    assert ret.stdout == ''
+    assert "No such instance named 'missing' was found in the metadata-tests namespace." in ret.stderr
 
     # Now cleanup original instance.
     ret = script_runner.run('elyra-metadata', 'remove', METADATA_TEST_NAMESPACE, '--name=valid')

--- a/elyra/metadata/tests/test_utils.py
+++ b/elyra/metadata/tests/test_utils.py
@@ -154,7 +154,7 @@ def create_instance(metadata_store: MetadataStore, location: str, name: str, con
             setattr(metadata_store, 'instances', dict())
             instances = getattr(metadata_store, 'instances')
         if not isinstance(content, dict):
-            content = {'display_name': name, 'reason': "JSON failed to load for metadata '{}'".format(name)}
+            content = {'display_name': name, 'reason': "JSON failed to load for instance '{}'".format(name)}
         instances[name] = content
 
 


### PR DESCRIPTION
This was accomplished by rephrasing messages and removing resource locations.  Some resource locations are still logged in the server log for troubleshooting.

The custom error codes no longer derive from corresponding OSError classes. This was causing `[Errno N]` prefixed messages, which also aren't friendly.

Also added display_name properties to the existing schemas for purposes of friendlier usage on the client-side (see #734).

Fixes #737

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

