### PR TITLE
Remove escape when inserting markdown snippet to markdown file

### DIFF
--- a/packages/code-snippet/src/CodeSnippetWidget.tsx
+++ b/packages/code-snippet/src/CodeSnippetWidget.tsx
@@ -94,7 +94,10 @@ class CodeSnippetDisplay extends React.Component<ICodeSnippetDisplayProps> {
       const documentWidget = widget as DocumentWidget;
       const fileEditor = (documentWidget.content as FileEditor).editor;
       const markdownRegex = /^\.(md|mkdn?|mdown|markdown)$/;
-      if (PathExt.extname(widget.context.path).match(markdownRegex) !== null) {
+      if (
+        PathExt.extname(widget.context.path).match(markdownRegex) !== null &&
+        snippet.language.toLowerCase() !== 'markdown'
+      ) {
         // Wrap snippet into a code block when inserting it into a markdown file
         fileEditor.replaceSelection(
           '```' + snippet.language + '\n' + snippetStr + '\n```'

--- a/packages/code-snippet/src/CodeSnippetWidget.tsx
+++ b/packages/code-snippet/src/CodeSnippetWidget.tsx
@@ -121,7 +121,10 @@ class CodeSnippetDisplay extends React.Component<ICodeSnippetDisplayProps> {
           kernelLanguage,
           notebookCellEditor
         );
-      } else if (notebookCell instanceof MarkdownCell) {
+      } else if (
+        notebookCell instanceof MarkdownCell &&
+        snippet.language.toLowerCase() !== 'markdown'
+      ) {
         // Wrap snippet into a code block when inserting it into a markdown cell
         notebookCellEditor.replaceSelection(
           '```' + snippet.language + '\n' + snippetStr + '\n```'


### PR DESCRIPTION
Fixes #739. Prevents code snippet insertion from escaping markdown code snippets when inserting code snippets into markdown files. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

