### PR TITLE
Update notebook node to allow multiple input links

### DIFF
--- a/packages/pipeline-editor/src/palette.json
+++ b/packages/pipeline-editor/src/palette.json
@@ -18,7 +18,7 @@
                 "ui_data": {
                   "cardinality": {
                     "min": 0,
-                    "max": 1
+                    "max": -1
                   },
                   "label": "Input Port"
                 }


### PR DESCRIPTION
Fixes #750

This addresses the issue of cardinality incorrectly being set to a `max: 0` and thus not allowing multiple input links on the notebook node.

The [second observation](https://github.com/elyra-ai/elyra/issues/750#issuecomment-657894923)(cardinality being deleted after first node) was addressed in canvas (https://github.com/elyra-ai/canvas/issues/162) and should be part of the next canvas release.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

