### PR TITLE
Fix CLI output when no instances and json is requested

### DIFF
--- a/elyra/metadata/tests/test_metadata_app.py
+++ b/elyra/metadata/tests/test_metadata_app.py
@@ -255,8 +255,8 @@ def test_list_json_instances(script_runner, mock_data_dir):
     ret = script_runner.run('elyra-metadata', 'list', METADATA_TEST_NAMESPACE, '--json')
     assert ret.success
     lines = ret.stdout.split('\n')
-    assert len(lines) == 2  # always 2 more than the actual runtime count
-    assert lines[0].startswith("No metadata instances found for {}".format(METADATA_TEST_NAMESPACE))
+    assert len(lines) == 2
+    assert lines[0] == "[]"
 
     valid = Metadata(**valid_metadata_json)
     resource = metadata_manager.create('valid', valid)
@@ -318,8 +318,8 @@ def test_remove_missing(script_runner):
 
     ret = script_runner.run('elyra-metadata', 'remove', METADATA_TEST_NAMESPACE, '--name=missing')
     assert ret.success is False
-    assert ret.stdout == ''
-    assert "No such instance named 'missing' was found in the metadata-tests namespace." in ret.stderr
+    assert ret.stderr == ''
+    assert "No such instance named 'missing' was found in the metadata-tests namespace." in ret.stdout
 
     # Now cleanup original instance.
     ret = script_runner.run('elyra-metadata', 'remove', METADATA_TEST_NAMESPACE, '--name=valid')


### PR DESCRIPTION
Don't intercept an empty result set when asking for JSON.

Also found/fixed a couple of minor issues relative to previous changes.

Fixes #762 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

