### PR TITLE
Reduce debug logging from metadata service

### DIFF
--- a/elyra/metadata/handlers.py
+++ b/elyra/metadata/handlers.py
@@ -34,7 +34,6 @@ class MetadataHandler(HttpErrorMixin, APIHandler):
         namespace = url_unescape(namespace)
         try:
             metadata_manager = MetadataManager(namespace=namespace)
-            self.log.debug("MetadataHandler: Fetching all metadata resources from namespace '{}'...".format(namespace))
             metadata = metadata_manager.get_all()
         except (ValidationError, ValueError) as err:
             raise web.HTTPError(400, str(err)) from err
@@ -106,8 +105,6 @@ class MetadataResourceHandler(HttpErrorMixin, APIHandler):
 
         try:
             metadata_manager = MetadataManager(namespace=namespace)
-            self.log.debug("MetadataResourceHandler: Fetching metadata resource '{}' from namespace '{}'...".
-                           format(resource, namespace))
             metadata = metadata_manager.get(resource)
         except (ValidationError, ValueError, NotImplementedError) as err:
             raise web.HTTPError(400, str(err)) from err
@@ -179,7 +176,6 @@ class SchemaHandler(HttpErrorMixin, APIHandler):
         namespace = url_unescape(namespace)
         schema_manager = SchemaManager()
         try:
-            self.log.debug("SchemaHandler: Fetching all schemas for namespace '{}'...".format(namespace))
             schemas = schema_manager.get_namespace_schemas(namespace)
         except (ValidationError, ValueError, SchemaNotFoundError) as err:
             raise web.HTTPError(404, str(err)) from err
@@ -201,8 +197,6 @@ class SchemaResourceHandler(HttpErrorMixin, APIHandler):
         resource = url_unescape(resource)
         schema_manager = SchemaManager()
         try:
-            self.log.debug("SchemaResourceHandler: Fetching schema '{}' for namespace '{}'...".
-                           format(resource, namespace))
             schema = schema_manager.get_schema(namespace, resource)
         except (ValidationError, ValueError, SchemaNotFoundError) as err:
             raise web.HTTPError(404, str(err)) from err
@@ -220,7 +214,6 @@ class NamespaceHandler(HttpErrorMixin, APIHandler):
     async def get(self):
         schema_manager = SchemaManager()
         try:
-            self.log.debug("NamespaceHandler: Fetching namespaces...")
             namespaces = schema_manager.get_namespaces()
         except (ValidationError, ValueError) as err:
             raise web.HTTPError(404, str(err)) from err

--- a/elyra/metadata/schema.py
+++ b/elyra/metadata/schema.py
@@ -49,13 +49,11 @@ class SchemaManager(SingletonConfigurable):
 
     def get_namespace_schemas(self, namespace: str) -> dict:
         self.validate_namespace(namespace)
-        self.log.debug("SchemaManager: Fetching all schemas from namespace '{}'".format(namespace))
         schemas = self.namespace_schemas.get(namespace)
         return schemas
 
     def get_schema(self, namespace: str, schema_name: str) -> dict:
         self.validate_namespace(namespace)
-        self.log.debug("SchemaManager: Fetching schema '{}' from namespace '{}'".format(schema_name, namespace))
         schemas = self.namespace_schemas.get(namespace)
         if schema_name not in schemas.keys():
             raise SchemaNotFoundError(namespace, schema_name)


### PR DESCRIPTION
I've noticed way too much debug logging coming out of the metadata service and have reduced it.  That said, I think we might be pulling too often from the frontend.  For example, when opening a code-snippet for edit, ALL instances are fetched again.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

