### PR TITLE
Provide visual feedback when copying code snippet

### DIFF
--- a/packages/code-snippet/src/CodeSnippetWidget.tsx
+++ b/packages/code-snippet/src/CodeSnippetWidget.tsx
@@ -190,6 +190,7 @@ class CodeSnippetDisplay extends React.Component<ICodeSnippetDisplayProps> {
       {
         title: 'Copy',
         icon: copyIcon,
+        feedback: 'Copied!',
         onClick: (): void => {
           Clipboard.copyToSystem(codeSnippet.code.join('\n'));
         }

--- a/packages/ui-components/src/ExpandableComponent.tsx
+++ b/packages/ui-components/src/ExpandableComponent.tsx
@@ -23,6 +23,8 @@ import {
 } from '@jupyterlab/ui-components';
 import * as React from 'react';
 
+import { FeedbackButton } from './FeedbackButton';
+
 /**
  * The CSS class for expandable containers.
  */
@@ -42,6 +44,7 @@ export interface IExpandableActionButton {
   title: string;
   icon: LabIcon;
   onClick: Function;
+  feedback?: string;
 }
 
 export interface IExpandableComponentProps {
@@ -123,9 +126,10 @@ export class ExpandableComponent extends React.Component<
           <div className={ACTION_BUTTONS_WRAPPER_CLASS}>
             {actionButtons.map((btn: IExpandableActionButton) => {
               return (
-                <button
+                <FeedbackButton
                   key={btn.title}
                   title={btn.title}
+                  feedback={btn.feedback || ''}
                   className={buttonClasses + ' ' + ACTION_BUTTON_CLASS}
                   onClick={(): void => {
                     btn.onClick();
@@ -136,7 +140,7 @@ export class ExpandableComponent extends React.Component<
                     elementPosition="center"
                     width="16px"
                   />
-                </button>
+                </FeedbackButton>
               );
             })}
           </div>

--- a/packages/ui-components/src/FeedbackButton.tsx
+++ b/packages/ui-components/src/FeedbackButton.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018-2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import '../style/index.css';
+
+import * as React from 'react';
+
+/**
+ * The CSS class for feedback buttons.
+ */
+const ELYRA_FEEDBACKBUTTON_CLASS = 'elyra-feedbackButton';
+
+export interface IFeedbackButtonProps {
+  feedback?: string;
+  onClick: () => string | void;
+}
+
+export class FeedbackButton extends React.Component<
+  React.HTMLProps<HTMLButtonElement> & IFeedbackButtonProps
+> {
+  node: React.RefObject<HTMLButtonElement>;
+
+  constructor(props: any) {
+    super(props);
+    this.node = React.createRef();
+  }
+
+  handleClick(): void {
+    let feedback = this.props.onClick();
+    if (typeof feedback !== 'string') {
+      feedback = this.props.feedback;
+    }
+    if (feedback) {
+      this.node.current.setAttribute('data-feedback', feedback);
+      setTimeout(() => {
+        this.node.current.removeAttribute('data-feedback');
+      }, 750);
+    }
+  }
+
+  render(): React.ReactElement {
+    const { children, className } = this.props;
+    const classes = `${ELYRA_FEEDBACKBUTTON_CLASS} ${className}`;
+
+    return (
+      <button
+        title={this.props.title}
+        ref={this.node}
+        className={classes}
+        onClick={(): void => {
+          this.handleClick();
+        }}
+      >
+        {children}
+      </button>
+    );
+  }
+}

--- a/packages/ui-components/style/index.css
+++ b/packages/ui-components/style/index.css
@@ -144,3 +144,37 @@
 [data-jp-theme-light='false'] .elyra-pieBrain-icon rect.st2 {
   fill: var(--jp-inverse-layout-color3);
 }
+
+.elyra-feedbackButton {
+  display: inline;
+  position: relative;
+}
+
+.elyra-feedbackButton[data-feedback]:not([data-feedback='']):before {
+  border: solid;
+  border-color: var(--jp-inverse-layout-color2) transparent;
+  border-width: 0 6px 6px 6px;
+  bottom: 0;
+  content: '';
+  left: 5px;
+  position: absolute;
+  z-index: 999;
+}
+
+.elyra-feedbackButton[data-feedback]:not([data-feedback='']):after {
+  background: var(--jp-inverse-layout-color2);
+  border-radius: 2px;
+  bottom: -20px;
+  color: var(--jp-ui-inverse-font-color1);
+  content: attr(data-feedback);
+  font-size: 0.75rem;
+  font-weight: 400;
+  padding: 3px 5px;
+  pointer-events: none;
+  position: absolute;
+  right: -10px;
+  text-align: center;
+  width: max-content;
+  word-wrap: break-word;
+  z-index: 999;
+}


### PR DESCRIPTION
Per issue #531 when users click on the code snippet copy button no feedback is provided indicating the code has been copied. This PR addresses the issue by

- adding a generic `FeedbackButton` in `ui-components` which can provide tooltip message

- updating code snippet copy button to make use of the `FeedbackButton` component

<img width="286" alt="image" src="https://user-images.githubusercontent.com/13156555/88209697-19f9a680-cc21-11ea-8e25-4bf8dbb94797.png">
<img width="286" alt="image" src="https://user-images.githubusercontent.com/13156555/88210428-321df580-cc22-11ea-9ef9-6d6d37c6daab.png">


Fixes #531



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

