### PR TITLE
Infer value of bool secure parameter from endpoint scheme

### DIFF
--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -85,7 +85,7 @@ Example: `https://kubernetes-service.ibm.com/pipeline`
 ##### cos_endpoint
 This should be the URL address of your S3 Object Storage. If running an Object Storage Service within a kubernetes cluster (Minio), you can use the kubernetes local DNS address.
 
-Example: `minio-service.kubeflow:9000`
+Example: `https://minio-service.kubeflow:9000`
 
 ##### cos_username
 Username used to access the Object Store. SEE NOTE.
@@ -104,5 +104,4 @@ Example: `test-bucket`
 
 NOTE: If using IBM Cloud Object Storage, you must generate a set of [HMAC Credentials](https://cloud.ibm.com/docs/services/cloud-object-storage/hmac?topic=cloud-object-storage-uhc-hmac-credentials-main) 
 and grant that key at least [Writer](https://cloud.ibm.com/docs/services/cloud-object-storage/iam?topic=cloud-object-storage-iam-bucket-permissions) level privileges.
-Your `access_key_id` and `secret_access_key` will be used as your `cos_username` and `cos_password` respectively, and
-you should also add `cos_secure` as `"True"`.
+Your `access_key_id` and `secret_access_key` will be used as your `cos_username` and `cos_password` respectively.

--- a/elyra/util/cos.py
+++ b/elyra/util/cos.py
@@ -23,23 +23,20 @@ from traitlets.config import LoggingConfigurable
 class CosClient(LoggingConfigurable):
     client = None
 
-    def __init__(self, config=None, endpoint=None, access_key=None, secret_key=None, secure=False, bucket=None):
+    def __init__(self, config=None, endpoint=None, access_key=None, secret_key=None, bucket=None):
         super().__init__()
         if config:
             self.endpoint = urlparse(config.metadata['cos_endpoint'])
             self.access_key = config.metadata['cos_username']
             self.secret_key = config.metadata['cos_password']
-            if 'cos_secure' in config.metadata.keys():
-                self.secure = config.metadata['cos_secure']
-            else:
-                self.secure = secure
             self.bucket = config.metadata['cos_bucket']
         else:
             self.endpoint = urlparse(endpoint)
             self.access_key = access_key
             self.secret_key = secret_key
-            self.secure = secure
             self.bucket = bucket
+        # Infer secure from the endpoint's scheme.
+        self.secure = self.endpoint.scheme == 'https'
 
         self.client = self.__initialize_object_store()
 


### PR DESCRIPTION
This change removes the need for maintaining an optional `cos_secure` field in the metadata instance by inferring its boolean value from the scheme of the corresponding `cos_endpoint` value (which is required).

Also updated the docs accordingly.  Since the example, recommended setting the previous `cos_secure` to `True`, the endpoint in the example is now prefixed with a scheme of `https`

Resolves #417
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

