### PR TITLE
Add title to schemas to convey the display_name/label for each property

### DIFF
--- a/elyra/metadata/schemas/code-snippet.json
+++ b/elyra/metadata/schemas/code-snippet.json
@@ -6,11 +6,14 @@
   "namespace": "code-snippets",
   "properties": {
     "schema_name": {
+      "title": "Schema Name",
+      "description": "The schema associated with this instance",
       "type": "string",
       "pattern": "^[a-z][a-z0-9-_]*[a-z0-9]$",
       "minLength": 1
     },
     "display_name": {
+      "title": "Display Name",
       "description": "The display name of the Code Snippet",
       "type": "string",
       "minLength": 1
@@ -20,6 +23,7 @@
       "type": "object",
       "properties": {
         "description": {
+          "title": "Description",
           "description": "Code snippet description",
           "type": "string",
           "uihints": {
@@ -27,6 +31,7 @@
           }
         },
         "language": {
+          "title": "Language",
           "description": "Code snippet implementation language",
           "type": "string",
           "uihints": {
@@ -37,6 +42,7 @@
           "minLength": 1
         },
         "code": {
+          "title": "Code",
           "description": "Code snippet code lines",
           "type": "array",
           "uihints": {

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -6,11 +6,14 @@
   "namespace": "runtimes",
   "properties": {
     "schema_name": {
+      "title": "Schema Name",
+      "description": "The schema associated with this instance",
       "type": "string",
       "pattern": "^[a-z][a-z0-9-_]*[a-z0-9]$",
       "minLength": 1
     },
     "display_name": {
+      "title": "Display Name",
       "description": "The display name of this KFP instance",
       "type": "string",
       "minLength": 1
@@ -20,29 +23,35 @@
       "type": "object",
       "properties": {
         "description": {
+          "title": "Description",
           "description": "The description of this KFP runtime instance",
           "type": "string"
         },
         "api_endpoint": {
+          "title": "API Endpoint",
           "description": "The API endpoint",
           "type": "string",
           "format": "uri"
         },
         "cos_endpoint": {
+          "title": "Cloud Object Storage Endpoint",
           "description": "The Cloud Object Storage endpoint",
           "type": "string",
           "format": "uri"
         },
         "cos_username": {
+          "title": "Cloud Object Storage Username",
           "description": "The Cloud Object Storage username",
           "type": "string"
         },
         "cos_password": {
+          "title": "Cloud Object Storage Password",
           "description": "The Cloud Object Storage password",
           "type": "string",
           "minLength": 8
         },
         "cos_bucket": {
+          "title": "Cloud Object Storage Bucket Name",
           "description": "The Cloud Object Storage bucket name",
           "type": "string",
           "pattern": "^[a-z][a-z0-9-.]*[a-z0-9]$",

--- a/elyra/metadata/schemas/metadata-test.json
+++ b/elyra/metadata/schemas/metadata-test.json
@@ -7,11 +7,14 @@
   "metadata_class_name": "elyra.metadata.tests.MockMetadataTest",
   "properties": {
     "schema_name": {
+      "title": "Schema Name",
+      "description": "The schema associated with this instance",
       "type": "string",
       "pattern": "^[a-z][a-z0-9-_]*[a-z0-9]$",
       "minLength": 1
     },
     "display_name": {
+      "title": "Display Name",
       "description": "The display name of the metadata",
       "type": "string",
       "minLength": 1
@@ -21,49 +24,58 @@
       "type": "object",
       "properties": {
         "required_test": {
+          "title": "Required Test",
           "description": "Property used to test required enforcement",
           "type": "string",
           "minLength": 1
         },
         "uri_test": {
+          "title": "URI Test",
           "description": "Property used to test uri formatting",
           "type": "string",
           "format": "uri"
         },
         "integer_exclusivity_test": {
+          "title": "Integer Exclusivity Test",
           "description": "Property used to test integers with exclusivity restrictions",
           "type": "integer",
           "exclusiveMinimum": 3,
           "exclusiveMaximum": 10
         },
         "integer_multiple_test": {
+          "title": "Integer Multiple Test",
           "description": "Property used to test integers with multipleOf restrictions",
           "type": "integer",
           "multipleOf": 7
         },
         "number_range_test": {
+          "title": "Number Range Test",
           "description": "Property used to test numbers with range",
           "type": "number",
           "minimum": 3,
           "maximum": 10
         },
         "number_default_test": {
+          "title": "Number Default Test",
           "description": "Property used to test numbers with defaults",
           "type": "number",
           "default": 42
         },
         "const_test": {
+          "title": "Const Test",
           "description": "Property used to test properties with const",
           "type": "number",
           "const": 3.14
         },
         "string_length_test": {
+          "title": "String Length Test",
           "description": "Property used to test strings with length restrictions",
           "type": "string",
           "minLength": 3,
           "maxLength": 10
         },
         "enum_test": {
+          "title": "Enum Test",
           "description": "Property used to test properties with enums",
           "type": "string",
           "enum": ["elyra", "rocks"],
@@ -73,6 +85,7 @@
           }
         },
         "array_test": {
+          "title": "Array Test",
           "description": "Property used to test array with item restrictions",
           "type": "array",
           "minItems": 3,
@@ -83,16 +96,19 @@
           }
         },
         "object_test": {
+          "title": "Object Test",
           "description": "Property used to test object elements with properties restrictions",
           "type": "object",
           "minProperties": 3,
           "maxProperties": 10
         },
         "boolean_test": {
+          "title": "Boolean Test",
           "description": "Property used to test boolean values",
           "type": "boolean"
         },
         "null_test": {
+          "title": "Null Test",
           "description": "Property used to test null types",
           "type": "null"
         }

--- a/elyra/metadata/schemas/runtime-image.json
+++ b/elyra/metadata/schemas/runtime-image.json
@@ -6,11 +6,14 @@
   "namespace": "runtime-images",
   "properties": {
     "schema_name": {
+      "title": "Schema Name",
+      "description": "The schema associated with this instance",
       "type": "string",
       "pattern": "^[a-z][a-z0-9-_]*[a-z0-9]$",
       "minLength": 1
     },
     "display_name": {
+      "title": "Display Name",
       "description": "The display name of the Runtime Image",
       "type": "string",
       "minLength": 1
@@ -20,6 +23,7 @@
       "type": "object",
       "properties": {
         "image_name": {
+          "title": "Image Name",
           "description": "Runtime Image description",
           "type": "string",
           "minLength": 1

--- a/elyra/metadata/tests/test_metadata_app.py
+++ b/elyra/metadata/tests/test_metadata_app.py
@@ -433,7 +433,7 @@ def test_number_default(script_runner, mock_data_dir):
 def test_uri(script_runner, mock_data_dir):
     prop_test = PropertyTester("uri")
     prop_test.negative_value = "//invalid-uri"
-    prop_test.negative_stdout = "Property used to test uri formatting; format: uri"
+    prop_test.negative_stdout = "Property used to test uri formatting; title: URI Test, format: uri"
     prop_test.negative_stderr = "'//invalid-uri' is not a 'uri'"
     prop_test.positive_value = "http://localhost:31823/v1/models?version=2017-02-13"
     prop_test.run(script_runner, mock_data_dir)
@@ -443,7 +443,7 @@ def test_integer_exclusivity(script_runner, mock_data_dir):
     prop_test = PropertyTester("integer_exclusivity")
     prop_test.negative_value = 3
     prop_test.negative_stdout = "Property used to test integers with exclusivity restrictions; " \
-                                "exclusiveMinimum: 3, exclusiveMaximum: 10"
+                                "title: Integer Exclusivity Test, exclusiveMinimum: 3, exclusiveMaximum: 10"
     prop_test.negative_stderr = "3 is less than or equal to the minimum of 3"
     prop_test.positive_value = 7
     prop_test.run(script_runner, mock_data_dir)
@@ -452,7 +452,8 @@ def test_integer_exclusivity(script_runner, mock_data_dir):
 def test_integer_multiple(script_runner, mock_data_dir):
     prop_test = PropertyTester("integer_multiple")
     prop_test.negative_value = 32
-    prop_test.negative_stdout = "Property used to test integers with multipleOf restrictions; multipleOf: 7"
+    prop_test.negative_stdout = "Property used to test integers with multipleOf restrictions; " \
+                                "title: Integer Multiple Test, multipleOf: 7"
     prop_test.negative_stderr = "32 is not a multiple of 7"
     prop_test.positive_value = 42
     prop_test.run(script_runner, mock_data_dir)
@@ -461,7 +462,8 @@ def test_integer_multiple(script_runner, mock_data_dir):
 def test_number_range(script_runner, mock_data_dir):
     prop_test = PropertyTester("number_range")
     prop_test.negative_value = 2.7
-    prop_test.negative_stdout = "Property used to test numbers with range; minimum: 3, maximum: 10"
+    prop_test.negative_stdout = "Property used to test numbers with range; " \
+                                "title: Number Range Test, minimum: 3, maximum: 10"
     prop_test.negative_stderr = "2.7 is less than the minimum of 3"
     prop_test.positive_value = 7.2
     prop_test.run(script_runner, mock_data_dir)
@@ -470,7 +472,7 @@ def test_number_range(script_runner, mock_data_dir):
 def test_const(script_runner, mock_data_dir):
     prop_test = PropertyTester("const")
     prop_test.negative_value = 2.718
-    prop_test.negative_stdout = "Property used to test properties with const; const: 3.14"
+    prop_test.negative_stdout = "Property used to test properties with const; title: Const Test, const: 3.14"
     prop_test.negative_stderr = "3.14 was expected"
     prop_test.positive_value = 3.14
     prop_test.run(script_runner, mock_data_dir)
@@ -479,7 +481,8 @@ def test_const(script_runner, mock_data_dir):
 def test_string_length(script_runner, mock_data_dir):
     prop_test = PropertyTester("string_length")
     prop_test.negative_value = "12345678901"
-    prop_test.negative_stdout = "Property used to test strings with length restrictions; minLength: 3, maxLength: 10"
+    prop_test.negative_stdout = "Property used to test strings with length restrictions; " \
+                                "title: String Length Test, minLength: 3, maxLength: 10"
     prop_test.negative_stderr = "'12345678901' is too long"
     prop_test.positive_value = "123456"
     prop_test.run(script_runner, mock_data_dir)
@@ -488,7 +491,8 @@ def test_string_length(script_runner, mock_data_dir):
 def test_enum(script_runner, mock_data_dir):
     prop_test = PropertyTester("enum")
     prop_test.negative_value = "jupyter"
-    prop_test.negative_stdout = "Property used to test properties with enums; enum: ['elyra', 'rocks']"
+    prop_test.negative_stdout = "Property used to test properties with enums; " \
+                                "title: Enum Test, enum: ['elyra', 'rocks']"
     prop_test.negative_stderr = "'jupyter' is not one of ['elyra', 'rocks']"
     prop_test.positive_value = "rocks"
     prop_test.run(script_runner, mock_data_dir)
@@ -498,7 +502,7 @@ def test_array(script_runner, mock_data_dir):
     prop_test = PropertyTester("array")
     prop_test.negative_value = [1, 2, 2]
     prop_test.negative_stdout = "Property used to test array with item restrictions; " \
-                                "minItems: 3, maxItems: 10, uniqueItems: True"
+                                "title: Array Test, minItems: 3, maxItems: 10, uniqueItems: True"
     prop_test.negative_stderr = "[1, 2, 2] has non-unique elements"
     prop_test.positive_value = [1, 2, 3, 4, 5]
     prop_test.run(script_runner, mock_data_dir)
@@ -508,7 +512,7 @@ def test_object(script_runner, mock_data_dir):
     prop_test = PropertyTester("object")
     prop_test.negative_value = {'prop1': 2, 'prop2': 3}
     prop_test.negative_stdout = "Property used to test object elements with properties restrictions; " \
-                                "minProperties: 3, maxProperties: 10"
+                                "title: Object Test, minProperties: 3, maxProperties: 10"
     prop_test.negative_stderr = "{'prop1': 2, 'prop2': 3} does not have enough properties"
     prop_test.positive_value = {'prop1': 2, 'prop2': 3, 'prop3': 4, 'prop4': 5}
     prop_test.run(script_runner, mock_data_dir)
@@ -517,7 +521,7 @@ def test_object(script_runner, mock_data_dir):
 def test_boolean(script_runner, mock_data_dir):
     prop_test = PropertyTester("boolean")
     prop_test.negative_value = "bogus_boolean"
-    prop_test.negative_stdout = "Property used to test boolean values"
+    prop_test.negative_stdout = "Property used to test boolean values; title: Boolean Test"
     prop_test.negative_stderr = "'bogus_boolean' is not of type 'boolean'"
     prop_test.positive_value = True
     prop_test.run(script_runner, mock_data_dir)
@@ -526,7 +530,7 @@ def test_boolean(script_runner, mock_data_dir):
 def test_null(script_runner, mock_data_dir):
     prop_test = PropertyTester("null")
     prop_test.negative_value = "bogus_null"
-    prop_test.negative_stdout = "Property used to test null types"
+    prop_test.negative_stdout = "Property used to test null types; title: Null Test"
     prop_test.negative_stderr = "'bogus_null' is not of type 'null'"
     prop_test.positive_value = None
     prop_test.run(script_runner, mock_data_dir)


### PR DESCRIPTION
This adds the title meta-property to each schema property which can be used to convery the display name or label in applications.

**Note:** I intentionally left the `uihints` stanzas in place in `code-snippet.json` so as to not disrupt the front-end behavior.  Assuming this PR gets merged, I'll make another pass to remove `label` from the `uihints` stanzas and the entire stanza if that's its only property.

Resolves #780



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

