### PR TITLE
Use get_event_loop instead of get_running_loop

### DIFF
--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -67,7 +67,7 @@ class PipelineProcessorManager(SingletonConfigurable):
             raise RuntimeError('Could not find pipeline processor for [{}]'.format(pipeline.runtime))
 
         processor.root_dir = self.root_dir
-        res = await asyncio.get_running_loop().run_in_executor(None, processor.process, pipeline)
+        res = await asyncio.get_event_loop().run_in_executor(None, processor.process, pipeline)
         return res
 
     async def export(self, pipeline, pipeline_export_format, pipeline_export_path, overwrite):
@@ -80,7 +80,7 @@ class PipelineProcessorManager(SingletonConfigurable):
             raise RuntimeError('Could not find pipeline processor for [{}]'.format(pipeline.runtime))
 
         processor.root_dir = self.root_dir
-        res = await asyncio.get_running_loop().run_in_executor(
+        res = await asyncio.get_event_loop().run_in_executor(
             None, processor.export, pipeline, pipeline_export_format, pipeline_export_path, overwrite)
         return res
 


### PR DESCRIPTION
Although the docs recommend using `get_running_loop()`, it only exists in Python 3.7.  This changes that to use the `get_event_loop()` method which is essentially the same although the latter will create an event loop if one does not exist.  Since we're running in a tornado server, we're (virtually) guaranteed to have an event loop.

Fixes #791

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

