### PR TITLE
Fix tests broken by notebook 6.1.0 release

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,3 +3,4 @@ pytest-tornasync
 pytest-console-scripts
 flake8
 hacking
+requests-unixsocket


### PR DESCRIPTION
notebook 6.1.0 added a test dependacny on requests-unixsocket in a
file we import in our tests, casuing our tests to fail due to the
missing dependency



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

