### PR TITLE
Allow bucket names to start with alphanumeric

### DIFF
--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -57,7 +57,7 @@
           "title": "Cloud Object Storage Bucket Name",
           "description": "The Cloud Object Storage bucket name",
           "type": "string",
-          "pattern": "^[a-z][a-z0-9-.]*[a-z0-9]$",
+          "pattern": "^[a-z0-9][a-z0-9-.]*[a-z0-9]$",
           "minLength": 3,
           "maxLength": 222
         }

--- a/elyra/metadata/schemas/metadata-test.json
+++ b/elyra/metadata/schemas/metadata-test.json
@@ -74,6 +74,12 @@
           "minLength": 3,
           "maxLength": 10
         },
+        "string_pattern_test": {
+          "title": "String Pattern Test",
+          "description": "Property used to test strings with pattern restrictions",
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-.]*[a-z0-9]$"
+        },
         "enum_test": {
           "title": "Enum Test",
           "description": "Property used to test properties with enums",

--- a/elyra/metadata/tests/test_metadata_app.py
+++ b/elyra/metadata/tests/test_metadata_app.py
@@ -488,6 +488,16 @@ def test_string_length(script_runner, mock_data_dir):
     prop_test.run(script_runner, mock_data_dir)
 
 
+def test_string_pattern(script_runner, mock_data_dir):
+    prop_test = PropertyTester("string_pattern")  # Must start/end with alphanumeric, can include '-' and '.'
+    prop_test.negative_value = "-foo1"
+    prop_test.negative_stdout = "Property used to test strings with pattern restrictions; " \
+                                "title: String Pattern Test, pattern: ^[a-z0-9][a-z0-9-.]*[a-z0-9]$"
+    prop_test.negative_stderr = "'-foo1' does not match '^[a-z0-9][a-z0-9-.]*[a-z0-9]$'"
+    prop_test.positive_value = "0foo-bar.com-01"
+    prop_test.run(script_runner, mock_data_dir)
+
+
 def test_enum(script_runner, mock_data_dir):
     prop_test = PropertyTester("enum")
     prop_test.negative_value = "jupyter"


### PR DESCRIPTION
Update the kfp schema to allow for bucket names starting with a number.
Previously, only alpha was allowed as the first character.

Added a pattern-related property to the test schema to allow for pattern
testing.

Fixes #800


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

