### PR TITLE
Metadata Editor and Widget Bug Fixes

### DIFF
--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -123,7 +123,8 @@ export class MetadataEditor extends ReactWidget {
     for (const schemaField in this.schema) {
       if (
         this.requiredFields.includes(schemaField) &&
-        (this.metadata[schemaField] === null ||
+        (this.metadata[schemaField] === undefined ||
+          this.metadata[schemaField] === null ||
           this.metadata[schemaField] === '' ||
           this.metadata[schemaField] === [] ||
           this.metadata[schemaField] === '(No selection)')

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -110,13 +110,13 @@ export class MetadataEditor extends ReactWidget {
     this.update();
   }
 
-  private isFieldEmpty(schemaField: any): boolean {
+  private isValueEmpty(schemaValue: any): boolean {
     return (
-      schemaField === undefined ||
-      schemaField === null ||
-      schemaField === '' ||
-      schemaField === [] ||
-      schemaField === '(No selection)'
+      schemaValue === undefined ||
+      schemaValue === null ||
+      schemaValue === '' ||
+      schemaValue === [] ||
+      schemaValue === '(No selection)'
     );
   }
 
@@ -133,7 +133,7 @@ export class MetadataEditor extends ReactWidget {
     for (const schemaField in this.schema) {
       if (
         this.requiredFields.includes(schemaField) &&
-        this.isFieldEmpty(this.metadata[schemaField])
+        this.isValueEmpty(this.metadata[schemaField])
       ) {
         this.invalidForm = true;
         this.schema[schemaField].uihints.intent = Intent.DANGER;

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -55,6 +55,7 @@ export class MetadataEditor extends ReactWidget {
   requiredFields: string[];
   invalidForm: boolean;
   showSecure: IDictionary<boolean>;
+  widgetClass: string;
 
   schema: IDictionary<any> = {};
   allMetadata: IDictionary<any>[] = [];
@@ -67,6 +68,9 @@ export class MetadataEditor extends ReactWidget {
     this.schemaName = props.schema;
     this.onSave = props.onSave;
     this.name = props.name;
+
+    this.widgetClass = `elyra-metadataEditor-${this.name ? this.name : 'new'}`;
+    this.addClass(this.widgetClass);
 
     this.handleTextInputChange = this.handleTextInputChange.bind(this);
     this.handleDropdownChange = this.handleDropdownChange.bind(this);
@@ -340,9 +344,18 @@ export class MetadataEditor extends ReactWidget {
           defaultValue={defaultValue}
           rightElement={toggleShowButton}
           type={showPassword || !secure ? 'text' : 'password'}
+          className={`elyra-metadataEditor-form-${fieldName}`}
         />
       </FormGroup>
     );
+  }
+
+  onAfterShow(msg: Message): void {
+    const input = document.querySelector(
+      `.${this.widgetClass} .elyra-metadataEditor-form-display_name input`
+    ) as HTMLInputElement;
+    input.focus();
+    input.setSelectionRange(input.value.length, input.value.length);
   }
 
   renderField(fieldName: string): React.ReactElement {

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -110,6 +110,16 @@ export class MetadataEditor extends ReactWidget {
     this.update();
   }
 
+  private isFieldEmpty(schemaField: any): boolean {
+    return (
+      schemaField === undefined ||
+      schemaField === null ||
+      schemaField === '' ||
+      schemaField === [] ||
+      schemaField === '(No selection)'
+    );
+  }
+
   /**
    * Checks that all required fields have a value before submitting the form.
    * Returns false if the form is valid. Sets any invalid fields' intent to danger
@@ -123,11 +133,7 @@ export class MetadataEditor extends ReactWidget {
     for (const schemaField in this.schema) {
       if (
         this.requiredFields.includes(schemaField) &&
-        (this.metadata[schemaField] === undefined ||
-          this.metadata[schemaField] === null ||
-          this.metadata[schemaField] === '' ||
-          this.metadata[schemaField] === [] ||
-          this.metadata[schemaField] === '(No selection)')
+        this.isFieldEmpty(this.metadata[schemaField])
       ) {
         this.invalidForm = true;
         this.schema[schemaField].uihints.intent = Intent.DANGER;

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -119,7 +119,7 @@ export class MetadataEditor extends ReactWidget {
       schemaValue === undefined ||
       schemaValue === null ||
       schemaValue === '' ||
-      schemaValue === [] ||
+      (Array.isArray(schemaValue) && schemaValue.length === 0) ||
       schemaValue === '(No selection)'
     );
   }

--- a/packages/metadata-common/src/MetadataWidget.tsx
+++ b/packages/metadata-common/src/MetadataWidget.tsx
@@ -172,6 +172,8 @@ export class MetadataWidget extends ReactWidget {
     this.props = props;
     this.renderSignal = new Signal<this, any>(this);
 
+    this.schemaDisplayName = props.schema;
+
     this.fetchMetadata = this.fetchMetadata.bind(this);
     this.updateMetadata = this.updateMetadata.bind(this);
     this.openMetadataEditor = this.openMetadataEditor.bind(this);
@@ -185,6 +187,7 @@ export class MetadataWidget extends ReactWidget {
     for (const schema of schemas) {
       if (this.props.schema === schema.name) {
         this.schemaDisplayName = schema.title;
+        this.update();
         break;
       }
     }

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -62,7 +62,9 @@ const extension: JupyterFrontEndPlugin<void> = {
       } else {
         widgetLabel = `New ${args.schema}`;
       }
-      const widgetId = `${METADATA_EDITOR_ID}:${args.namespace}:${args.schema}:${args.name}`;
+      const widgetId = `${METADATA_EDITOR_ID}:${args.namespace}:${
+        args.schema
+      }:${args.name ? args.name : 'new'}`;
       const openWidget = find(
         app.shell.widgets('main'),
         (widget: Widget, index: number) => {
@@ -70,7 +72,6 @@ const extension: JupyterFrontEndPlugin<void> = {
         }
       );
       if (openWidget) {
-        console.log(openWidget);
         app.shell.activateById(widgetId);
         return;
       }

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -1027,7 +1027,10 @@ export class PipelineEditor extends React.Component<
 
     PipelineService.submitPipeline(
       pipelineFlow,
-      dialogResult.value.runtime_config
+      PipelineService.getDisplayName(
+        dialogResult.value.runtime_config,
+        runtimes
+      )
     );
   }
 

--- a/packages/pipeline-editor/src/PipelineService.tsx
+++ b/packages/pipeline-editor/src/PipelineService.tsx
@@ -31,10 +31,10 @@ export class PipelineService {
    * `runtimes metadata`. This is used to submit the pipeline to be
    * executed on these runtimes.
    */
-  static async getRuntimes(): Promise<any> {
+  static async getRuntimes(showError = true): Promise<any> {
     const runtimes = await FrontendServices.getMetadata('runtimes');
 
-    if (Object.keys(runtimes).length === 0) {
+    if (showError && Object.keys(runtimes).length === 0) {
       return FrontendServices.noMetadataError('runtimes');
     }
 

--- a/packages/pipeline-editor/src/PipelineService.tsx
+++ b/packages/pipeline-editor/src/PipelineService.tsx
@@ -60,15 +60,19 @@ export class PipelineService {
     return images;
   }
 
+  static getDisplayName(name: string, metadataArr: IDictionary<any>[]): string {
+    return metadataArr.find(r => r['name'] === name)['display_name'];
+  }
+
   /**
    * Submit the pipeline to be executed on an external runtime (e.g. Kbeflow Pipelines)
    *
    * @param pipeline
-   * @param runtime_config
+   * @param runtimeName
    */
   static async submitPipeline(
     pipeline: any,
-    runtime_config: string
+    runtimeName: string
   ): Promise<any> {
     console.log('Pipeline definition:');
     console.log(pipeline);
@@ -79,7 +83,7 @@ export class PipelineService {
       true
     );
 
-    const dialogTitle = 'Job submission to ' + runtime_config + ' succeeded';
+    const dialogTitle = 'Job submission to ' + runtimeName + ' succeeded';
     const dialogBody = (
       <p>
         Check the status of your pipeline at{' '}

--- a/packages/pipeline-editor/src/RuntimesWidget.tsx
+++ b/packages/pipeline-editor/src/RuntimesWidget.tsx
@@ -40,13 +40,13 @@ class RuntimesDisplay extends MetadataDisplay<IMetadataDisplayProps> {
 
     return (
       <div>
-        <h6>Runtime History:</h6>
+        <h6>Kubeflow Pipelines UI</h6>
         <a href={apiEndpoint} target="_blank" rel="noreferrer noopener">
           {apiEndpoint}
         </a>
         <br />
         <br />
-        <h6>Cloud Object Storage:</h6>
+        <h6>Cloud Object Storage</h6>
         <a
           href={metadata.metadata.cos_endpoint}
           target="_blank"
@@ -68,7 +68,7 @@ export class RuntimesWidget extends MetadataWidget {
   }
 
   async fetchMetadata(): Promise<any> {
-    return await PipelineService.getRuntimes();
+    return await PipelineService.getRuntimes(false);
   }
 
   renderDisplay(metadata: IMetadata[]): React.ReactElement {

--- a/packages/pipeline-editor/src/SubmitNotebook.ts
+++ b/packages/pipeline-editor/src/SubmitNotebook.ts
@@ -94,7 +94,10 @@ export class SubmitNotebookButtonExtension
         notebookOptions
       );
 
-      PipelineService.submitPipeline(pipeline, result.value.runtime_config);
+      PipelineService.submitPipeline(
+        pipeline,
+        PipelineService.getDisplayName(result.value.runtime_config, runtimes)
+      );
     });
   };
 


### PR DESCRIPTION
Various Bug Fixes as a followup to #591

- Fixed required validation in MetadataEditor. Update to strict
equality check cause the `undefined` case to no longer be caught
by the `null` check
- Text updates to RuntimesWidget to clarify rutime type and api url
- Fixed support for RuntimeWidget when no runtimes are configured
- Focus on Name field when opening a Metadata Editor tab
- Update pipeline submission success dialog to use `display_name`

Fixes #798
Fixes #802
Fixes #806
Fixes #814 


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

