### PR TITLE
Fix attribute exception when --name is not given a value

### DIFF
--- a/elyra/metadata/metadata_app_utils.py
+++ b/elyra/metadata/metadata_app_utils.py
@@ -263,10 +263,12 @@ class AppBase(object):
             else:  # this is a regular option, just set value
                 cli_option.set_value(self.argv_mappings.get(option))
                 if cli_option.required and not cli_option.value:
-                    self.log_and_exit("'{}' is a required parameter.".format(cli_option.option), display_help=True)
+                    self.log_and_exit("Parameter '{}' requires a value.".
+                                      format(cli_option.cli_option), display_help=True)
             self._remove_argv_entry(option)
         elif cli_option.required:
-            self.log_and_exit("'{}' is a required parameter.".format(cli_option.cli_option), display_help=True)
+            self.log_and_exit("'{}' is a required parameter.".
+                              format(cli_option.cli_option), display_help=True)
         cli_option.processed = True
 
     def process_cli_options(self, cli_options):

--- a/elyra/metadata/tests/test_metadata_app.py
+++ b/elyra/metadata/tests/test_metadata_app.py
@@ -310,6 +310,15 @@ def test_remove_no_name(script_runner):
     assert ret.stderr == ''
 
 
+def test_remove_malformed_name(script_runner):
+    # Attempt removal but forget the '=' between parameter and value
+
+    ret = script_runner.run('elyra-metadata', 'remove', METADATA_TEST_NAMESPACE, '--name', 'valid')
+    assert ret.success is False
+    assert ret.stderr == ''
+    assert "Parameter '--name' requires a value." in ret.stdout
+
+
 def test_remove_missing(script_runner):
     # Create an instance so that the namespace exists.
     metadata_manager = MetadataManager(namespace=METADATA_TEST_NAMESPACE)


### PR DESCRIPTION
Output produced is as follows:
```bash
$ elyra-metadata remove runtimes --name cloning1
Parameter '--name' requires a value.

Remove a metadata instance from namespace 'runtimes'.

Options
-------

--name=<string>
	The name of the metadata instance to remove
```

Fixes #812
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

