### PR TITLE
Add command to palette to open Runtime Images UI

### DIFF
--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -145,6 +145,7 @@ const extension: JupyterFrontEndPlugin<void> = {
 
     const openMetadataCommand: string = commandIDs.openMetadata;
     app.commands.addCommand(openMetadataCommand, {
+      label: (args: any) => args['label'],
       execute: (args: any) => {
         // Rank has been chosen somewhat arbitrarily to give priority
         // to the running sessions widget in the sidebar.

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -64,10 +64,13 @@ import { PIPELINE_CURRENT_VERSION } from './constants';
 import * as i18nData from './en.json';
 import * as palette from './palette.json';
 import { PipelineExportDialog } from './PipelineExportDialog';
-import { PipelineService } from './PipelineService';
+import {
+  PipelineService,
+  KFP_SCHEMA,
+  RUNTIMES_NAMESPACE
+} from './PipelineService';
 import { PipelineSubmissionDialog } from './PipelineSubmissionDialog';
 import * as properties from './properties.json';
-import { KFP_SCHEMA, RUNTIMES_NAMESPACE } from './RuntimesWidget';
 import Utils from './utils';
 
 const PIPELINE_CLASS = 'elyra-PipelineEditor';
@@ -107,6 +110,7 @@ interface IValidationError {
 
 export const commandIDs = {
   openPipelineEditor: 'pipeline-editor:open',
+  openMetadata: 'elyra-metadata:open',
   openDocManager: 'docmanager:open',
   newDocManager: 'docmanager:new-untitled',
   submitNotebook: 'notebook:submit'

--- a/packages/pipeline-editor/src/PipelineService.tsx
+++ b/packages/pipeline-editor/src/PipelineService.tsx
@@ -25,6 +25,11 @@ import * as React from 'react';
 
 import Utils from './utils';
 
+export const RUNTIMES_NAMESPACE = 'runtimes';
+export const KFP_SCHEMA = 'kfp';
+export const RUNTIME_IMAGES_NAMESPACE = 'runtime-images';
+export const RUNTIME_IMAGE_SCHEMA = 'runtime-image';
+
 export class PipelineService {
   /**
    * Returns a list of external runtime configurations available as

--- a/packages/pipeline-editor/src/RuntimesWidget.tsx
+++ b/packages/pipeline-editor/src/RuntimesWidget.tsx
@@ -24,10 +24,11 @@ import {
 } from '@elyra/metadata-common';
 import React from 'react';
 
-import { PipelineService } from './PipelineService';
-
-export const RUNTIMES_NAMESPACE = 'runtimes';
-export const KFP_SCHEMA = 'kfp';
+import {
+  PipelineService,
+  KFP_SCHEMA,
+  RUNTIMES_NAMESPACE
+} from './PipelineService';
 
 /**
  * A React Component for displaying the runtimes list.

--- a/packages/pipeline-editor/src/index.ts
+++ b/packages/pipeline-editor/src/index.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { pipelineIcon, runtimesIcon } from '@elyra/ui-components';
+import {
+  containerIcon,
+  pipelineIcon,
+  runtimesIcon
+} from '@elyra/ui-components';
 
 import {
   JupyterFrontEnd,
@@ -29,10 +33,13 @@ import { IMainMenu } from '@jupyterlab/mainmenu';
 
 import { PipelineEditorFactory, commandIDs } from './PipelineEditorWidget';
 import {
-  RuntimesWidget,
+  RUNTIME_IMAGE_SCHEMA,
+  RUNTIME_IMAGES_NAMESPACE,
   KFP_SCHEMA,
   RUNTIMES_NAMESPACE
-} from './RuntimesWidget';
+} from './PipelineService';
+import { RuntimesWidget } from './RuntimesWidget';
+
 import { SubmitNotebookButtonExtension } from './SubmitNotebook';
 
 import '../style/index.css';
@@ -130,7 +137,18 @@ const extension: JupyterFrontEndPlugin<void> = {
     palette.addItem({
       command: openPipelineEditorCommand,
       args: { isPalette: true },
-      category: 'Extensions'
+      category: 'Elyra'
+    });
+    palette.addItem({
+      command: commandIDs.openMetadata,
+      args: {
+        label: 'Show Runtime Images',
+        display_name: 'Runtime Images',
+        namespace: RUNTIME_IMAGES_NAMESPACE,
+        schema: RUNTIME_IMAGE_SCHEMA,
+        icon: containerIcon.name
+      },
+      category: 'Elyra'
     });
     // Add the command to the launcher
     if (launcher) {

--- a/packages/python-editor/src/index.ts
+++ b/packages/python-editor/src/index.ts
@@ -230,7 +230,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     palette.addItem({
       command: commandIDs.createNewPython,
       args: { isPalette: true },
-      category: 'Python Editor'
+      category: 'Elyra'
     });
   }
 };

--- a/packages/ui-components/src/icons.tsx
+++ b/packages/ui-components/src/icons.tsx
@@ -19,6 +19,7 @@ import { LabIcon } from '@jupyterlab/ui-components';
 import clearPipelineSvg from '../style/icons/clear-pipeline.svg';
 import elyraSvg from '../style/icons/codait-piebrainlogo-jupyter-color.svg';
 import codeSnippetSvg from '../style/icons/code-snippet.svg';
+import containerSvg from '../style/icons/container.svg';
 import dragDropSvg from '../style/icons/dragdrop.svg';
 import errorIconSvg from '../style/icons/error.svg';
 import exportPipelineSvg from '../style/icons/export-pipeline.svg';
@@ -65,6 +66,10 @@ export const savePipelineIcon = new LabIcon({
 export const runtimesIcon = new LabIcon({
   name: 'elyra:runtimes',
   svgstr: runtimesSvg
+});
+export const containerIcon = new LabIcon({
+  name: 'elyra:container',
+  svgstr: containerSvg
 });
 export const trashIcon = new LabIcon({
   name: 'elyra:trashIcon',

--- a/packages/ui-components/style/icons/container.svg
+++ b/packages/ui-components/style/icons/container.svg
@@ -1,0 +1,5 @@
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+    <path class="jp-icon3" fill="#231F20"  d="M28,12H20V4h8Zm-6-2h4V6H22Z"/>
+    <path class="jp-icon3" fill="#231F20"  d="M17,15V9H9V23H23V15Zm-6-4h4v4H11Zm4,10H11V17h4Zm6,0H17V17h4Z"/>
+    <path class="jp-icon3" fill="#231F20"  d="M26,28H6a2.0023,2.0023,0,0,1-2-2V6A2.0023,2.0023,0,0,1,6,4H16V6H6V26H26V16h2V26A2.0023,2.0023,0,0,1,26,28Z"/>
+</svg>


### PR DESCRIPTION
As part of the previous work on Metadata Widget we added a generic
command to open a UI for any metadata namespace/schema

This PR adds a command call to open the ui for runtime images to
the palette.

Fixes #829

<img width="1792" alt="Screen Shot 2020-08-06 at 4 46 26 PM" src="https://user-images.githubusercontent.com/13952758/89594733-82db4400-d807-11ea-8f52-f6a7097b628f.png">
<img width="1792" alt="Screen Shot 2020-08-06 at 4 46 13 PM" src="https://user-images.githubusercontent.com/13952758/89594737-866ecb00-d807-11ea-9637-89b02855367c.png">


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

