### PR TITLE
Make handling of schema-name more friendly in CLI

### DIFF
--- a/elyra/metadata/metadata_app.py
+++ b/elyra/metadata/metadata_app.py
@@ -147,19 +147,36 @@ class NamespaceInstall(NamespaceBase):
 
     replace_flag = Flag("--replace", name='replace',
                         description='Replace existing instance', default_value=False)
-    schema_name_option = CliOption("--schema_name", name='schema_name',
-                                   description='The schema_name of the metadata instance to install', required=True)
     name_option = CliOption("--name", name='name',
                             description='The name of the metadata instance to install', required=True)
 
     # 'Install' options
-    options = [replace_flag, schema_name_option, name_option]
+    options = [replace_flag]  # defer name_option until after schema_option
 
     def __init__(self, **kwargs):
         super(NamespaceInstall, self).__init__(**kwargs)
         self.metadata_manager = MetadataManager(namespace=self.namespace)
         # First, process the schema_name option so we can then load the appropriate schema
         # file to build the schema-based options.  If help is requested, give it to them.
+
+        # As an added benefit, if the namespace has one schema, got ahead and default that value.
+        # If multiple, add the list so proper messaging can be applied.  As a result, we need to
+        # to build the option here since this is where we have access to the schemas.
+        schema_list = list(self.schemas.keys())
+        if len(schema_list) == 1:
+            self.schema_name_option = CliOption("--schema_name", name='schema_name',
+                                                default_value=schema_list[0],
+                                                description="The schema_name of the metadata instance to "
+                                                            "install (defaults to '{}')".format(schema_list[0]),
+                                                required=True)
+        else:
+            one_of = schema_list
+            self.schema_name_option = CliOption("--schema_name", name='schema_name', one_of=one_of,
+                                                description='The schema_name of the metadata instance to install.  '
+                                                            'Must be one of: {}'.format(one_of),
+                                                required=True)
+
+        self.options.extend([self.schema_name_option, self.name_option])
         self.process_cli_option(self.schema_name_option, check_help=True)
         schema_name = self.schema_name_option.value
 

--- a/elyra/metadata/metadata_app_utils.py
+++ b/elyra/metadata/metadata_app_utils.py
@@ -34,12 +34,14 @@ class Option(object):
     type = None  # Only used by SchemaProperty instances for now
     processed = False
 
-    def __init__(self, cli_option, name=None, description=None, default_value=None, required=False, type="string"):
+    def __init__(self, cli_option, name=None, description=None, default_value=None, one_of=None,
+                 required=False, type="string"):
         self.cli_option = cli_option
         self.name = name
         self.description = description
         self.default_value = default_value
         self.value = default_value
+        self.one_of = one_of
         self.required = required
         self.type = type
 
@@ -262,13 +264,23 @@ class AppBase(object):
                 cli_option.value = not cli_option.default_value
             else:  # this is a regular option, just set value
                 cli_option.set_value(self.argv_mappings.get(option))
-                if cli_option.required and not cli_option.value:
-                    self.log_and_exit("Parameter '{}' requires a value.".
-                                      format(cli_option.cli_option), display_help=True)
+                if cli_option.required:
+                    if not cli_option.value:
+                        self.log_and_exit("Parameter '{}' requires a value.".
+                                          format(cli_option.cli_option), display_help=True)
+                    elif cli_option.one_of:  # ensure value is in set
+                        if cli_option.value not in cli_option.one_of:
+                            self.log_and_exit("Parameter '{}' requires one of the following values: {}".
+                                              format(cli_option.cli_option, cli_option.one_of), display_help=True)
             self._remove_argv_entry(option)
-        elif cli_option.required:
-            self.log_and_exit("'{}' is a required parameter.".
-                              format(cli_option.cli_option), display_help=True)
+        elif cli_option.required and cli_option.value is None:
+            if cli_option.one_of is None:
+                self.log_and_exit("'{}' is a required parameter.".
+                                  format(cli_option.cli_option), display_help=True)
+            else:
+                self.log_and_exit("'{}' is a required parameter and must be one of the following values: {}.".
+                                  format(cli_option.cli_option, cli_option.one_of), display_help=True)
+
         cli_option.processed = True
 
     def process_cli_options(self, cli_options):

--- a/elyra/metadata/schemas/metadata-test2.json
+++ b/elyra/metadata/schemas/metadata-test2.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Metadata Test2",
+  "name": "metadata-test2",
+  "display_name": "Metadata Test2",
+  "namespace": "metadata-tests",
+  "metadata_class_name": "elyra.metadata.tests.MockMetadataTest",
+  "properties": {
+    "schema_name": {
+      "title": "Schema Name",
+      "description": "The schema associated with this instance",
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-_]*[a-z0-9]$",
+      "minLength": 1
+    },
+    "display_name": {
+      "title": "Display Name",
+      "description": "The display name of the metadata",
+      "type": "string",
+      "minLength": 1
+    },
+    "metadata": {
+      "description": "Additional data specific to this metadata",
+      "type": "object",
+      "properties": {
+        "required_test": {
+          "title": "Required Test",
+          "description": "Property used to test required enforcement",
+          "type": "string",
+          "minLength": 1
+        },
+        "uri_test": {
+          "title": "URI Test",
+          "description": "Property used to test uri formatting",
+          "type": "string",
+          "format": "uri"
+        },
+        "integer_exclusivity_test": {
+          "title": "Integer Exclusivity Test",
+          "description": "Property used to test integers with exclusivity restrictions",
+          "type": "integer",
+          "exclusiveMinimum": 3,
+          "exclusiveMaximum": 10
+        },
+        "integer_multiple_test": {
+          "title": "Integer Multiple Test",
+          "description": "Property used to test integers with multipleOf restrictions",
+          "type": "integer",
+          "multipleOf": 7
+        },
+        "number_range_test": {
+          "title": "Number Range Test",
+          "description": "Property used to test numbers with range",
+          "type": "number",
+          "minimum": 3,
+          "maximum": 10
+        },
+        "number_default_test": {
+          "title": "Number Default Test",
+          "description": "Property used to test numbers with defaults",
+          "type": "number",
+          "default": 42
+        },
+        "const_test": {
+          "title": "Const Test",
+          "description": "Property used to test properties with const",
+          "type": "number",
+          "const": 3.14
+        },
+        "string_length_test": {
+          "title": "String Length Test",
+          "description": "Property used to test strings with length restrictions",
+          "type": "string",
+          "minLength": 3,
+          "maxLength": 10
+        },
+        "string_pattern_test": {
+          "title": "String Pattern Test",
+          "description": "Property used to test strings with pattern restrictions",
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-.]*[a-z0-9]$"
+        },
+        "enum_test": {
+          "title": "Enum Test",
+          "description": "Property used to test properties with enums",
+          "type": "string",
+          "enum": ["elyra", "rocks"],
+          "uihints": {
+            "field_type": "dropdown",
+            "default_choices": ["elyra"]
+          }
+        },
+        "array_test": {
+          "title": "Array Test",
+          "description": "Property used to test array with item restrictions",
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 10,
+          "uniqueItems": true,
+          "uihints": {
+            "field_type": "code"
+          }
+        },
+        "object_test": {
+          "title": "Object Test",
+          "description": "Property used to test object elements with properties restrictions",
+          "type": "object",
+          "minProperties": 3,
+          "maxProperties": 10
+        },
+        "boolean_test": {
+          "title": "Boolean Test",
+          "description": "Property used to test boolean values",
+          "type": "boolean"
+        },
+        "null_test": {
+          "title": "Null Test",
+          "description": "Property used to test null types",
+          "type": "null"
+        }
+      },
+      "required": ["required_test"]
+    }
+  },
+  "required": ["schema_name", "display_name", "metadata"]
+}

--- a/elyra/metadata/tests/test_handlers.py
+++ b/elyra/metadata/tests/test_handlers.py
@@ -460,8 +460,8 @@ class SchemaHandlerTest(MetadataTestBase):
         self._get_namespace_schemas('code-snippets', ['code-snippet'])
 
     def test_get_test_schemas(self):
-        # Ensure all schema for code-snippets can be found
-        self._get_namespace_schemas(METADATA_TEST_NAMESPACE, ['metadata-test'])
+        # Ensure all schema for metadata_tests can be found
+        self._get_namespace_schemas(METADATA_TEST_NAMESPACE, ['metadata-test', 'metadata-test2'])
 
     def test_get_runtimes_schema(self):
         # Ensure all schema for runtimes can be found

--- a/elyra/metadata/tests/test_metadata_app.py
+++ b/elyra/metadata/tests/test_metadata_app.py
@@ -78,10 +78,29 @@ def test_install_help(script_runner):
     assert ret.stderr == ''
 
 
-def test_install_no_schema_name(script_runner, mock_data_dir):
+def test_install_no_schema_single(script_runner, mock_data_dir):
+    # Use the runtime-images namespace since that is most likely to always be a single-schema namespace.
+    # Note: this test will break if it ever supports multiple.
+    ret = script_runner.run('elyra-metadata', 'install', "runtime-images")
+    assert ret.success is False
+    assert ret.stdout.startswith("'--name' is a required parameter.")
+    assert ret.stderr == ''
+
+
+def test_install_no_schema_multiple(script_runner, mock_data_dir):
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_NAMESPACE)
     assert ret.success is False
-    assert ret.stdout.startswith("'--schema_name' is a required parameter.")
+    # Since order in dictionaries, where the one-of list is derived, can be random, just check up to the
+    # first known difference in the schema names.
+    assert ret.stdout.startswith("'--schema_name' is a required parameter and must be one of the "
+                                 "following values: ['metadata-test")
+    assert ret.stderr == ''
+
+
+def test_install_bad_schema_multiple(script_runner, mock_data_dir):
+    ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_NAMESPACE, '--schema_name=metadata-foo')
+    assert ret.success is False
+    assert ret.stdout.startswith("Parameter '--schema_name' requires one of the following values: ['metadata-test")
     assert ret.stderr == ''
 
 


### PR DESCRIPTION
For single-schema namespaces, the CLI tool will default the schema name so it doesn't need to be set.  For multi-schema namespaces, the available options will be presented if no schema-name is provided or an invalid schema-name is used.  Note: schema-name only comes into play when installing metadata.  It is not an option for 'list' or 'remove' subcommands.

Fixes #836 

Here are some "screen scrapes"...
```
$ elyra-metadata install runtime-images
'--name' is a required parameter.

Install a metadata instance into namespace 'runtime-images'.

Options
-------

--replace
	Replace existing instance
--schema_name=<string>
	The schema_name of the metadata instance to install (defaults to 'runtime-image')
--name=<string>
	The name of the metadata instance to install
...
```
Since no current namespaces have multiple schemas, I've added another test schema to the `metadata-tests` namespace:
```
$ elyra-metadata install metadata-tests
'--schema_name' is a required parameter and must be one of the following values: ['metadata-test2', 'metadata-test'].

Install a metadata instance into namespace 'metadata-tests'.

Options
-------

--replace
	Replace existing instance
--schema_name=<string>
	The schema_name of the metadata instance to install.  Must be one of: ['metadata-test2', 'metadata-test']
--name=<string>
	The name of the metadata instance to install
```
and with an invalid schema name...
```
$ elyra-metadata install metadata-tests -schema_name=invalid-name
'--schema_name' is a required parameter and must be one of the following values: ['metadata-test2', 'metadata-test'].

Install a metadata instance into namespace 'metadata-tests'.

Options
-------

--replace
	Replace existing instance
--schema_name=<string>
	The schema_name of the metadata instance to install.  Must be one of: ['metadata-test2', 'metadata-test']
--name=<string>
	The name of the metadata instance to install
```
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

