### PR TITLE
Prevent display of meta-properties, update runtime-images schema

### DIFF
--- a/elyra/metadata/metadata_app_utils.py
+++ b/elyra/metadata/metadata_app_utils.py
@@ -106,6 +106,8 @@ class SchemaProperty(CliOption):
     skipped_meta_properties = ['description', 'type', 'items', 'additionalItems', 'properties'
                                'propertyNames', 'dependencies', 'examples', 'contains',
                                'additionalProperties', 'patternProperties']
+    # Turn off the inclusion of meta-property information in the printed help messages  (Issue #837)
+    print_meta_properties = False
 
     def __init__(self, name, schema_property):
         self.schema_property = schema_property
@@ -120,10 +122,11 @@ class SchemaProperty(CliOption):
     def print_description(self):
 
         additional_clause = ""
-        for meta_prop, value in self.schema_property.items():
-            if meta_prop in self.skipped_meta_properties:
-                continue
-            additional_clause = self._build_clause(additional_clause, meta_prop, value)
+        if self.print_meta_properties:  # Only if enabled
+            for meta_prop, value in self.schema_property.items():
+                if meta_prop in self.skipped_meta_properties:
+                    continue
+                additional_clause = self._build_clause(additional_clause, meta_prop, value)
 
         print("\t{}{}".format(self.description, additional_clause))
 

--- a/elyra/metadata/schemas/runtime-image.json
+++ b/elyra/metadata/schemas/runtime-image.json
@@ -22,9 +22,14 @@
       "description": "Additional data specific to this Runtime Image",
       "type": "object",
       "properties": {
+        "description": {
+          "title": "Description",
+          "description": "The description of this Runtime Image instance",
+          "type": "string"
+        },
         "image_name": {
           "title": "Image Name",
-          "description": "Runtime Image description",
+          "description": "The image name (including optional tag)",
           "type": "string",
           "minLength": 1
         }

--- a/elyra/metadata/tests/test_metadata_app.py
+++ b/elyra/metadata/tests/test_metadata_app.py
@@ -442,7 +442,9 @@ def test_number_default(script_runner, mock_data_dir):
 def test_uri(script_runner, mock_data_dir):
     prop_test = PropertyTester("uri")
     prop_test.negative_value = "//invalid-uri"
-    prop_test.negative_stdout = "Property used to test uri formatting; title: URI Test, format: uri"
+    prop_test.negative_stdout = "Property used to test uri formatting"
+    #  this can be joined with previous if adding meta-properties
+    #  "; title: URI Test, format: uri"
     prop_test.negative_stderr = "'//invalid-uri' is not a 'uri'"
     prop_test.positive_value = "http://localhost:31823/v1/models?version=2017-02-13"
     prop_test.run(script_runner, mock_data_dir)
@@ -451,8 +453,9 @@ def test_uri(script_runner, mock_data_dir):
 def test_integer_exclusivity(script_runner, mock_data_dir):
     prop_test = PropertyTester("integer_exclusivity")
     prop_test.negative_value = 3
-    prop_test.negative_stdout = "Property used to test integers with exclusivity restrictions; " \
-                                "title: Integer Exclusivity Test, exclusiveMinimum: 3, exclusiveMaximum: 10"
+    prop_test.negative_stdout = "Property used to test integers with exclusivity restrictions"
+    #  this can be joined with previous if adding meta-properties
+    #  "; title: Integer Exclusivity Test, exclusiveMinimum: 3, exclusiveMaximum: 10"
     prop_test.negative_stderr = "3 is less than or equal to the minimum of 3"
     prop_test.positive_value = 7
     prop_test.run(script_runner, mock_data_dir)
@@ -461,8 +464,9 @@ def test_integer_exclusivity(script_runner, mock_data_dir):
 def test_integer_multiple(script_runner, mock_data_dir):
     prop_test = PropertyTester("integer_multiple")
     prop_test.negative_value = 32
-    prop_test.negative_stdout = "Property used to test integers with multipleOf restrictions; " \
-                                "title: Integer Multiple Test, multipleOf: 7"
+    prop_test.negative_stdout = "Property used to test integers with multipleOf restrictions"
+    #  this can be joined with previous if adding meta-properties
+    #  "; title: Integer Multiple Test, multipleOf: 7"
     prop_test.negative_stderr = "32 is not a multiple of 7"
     prop_test.positive_value = 42
     prop_test.run(script_runner, mock_data_dir)
@@ -471,8 +475,9 @@ def test_integer_multiple(script_runner, mock_data_dir):
 def test_number_range(script_runner, mock_data_dir):
     prop_test = PropertyTester("number_range")
     prop_test.negative_value = 2.7
-    prop_test.negative_stdout = "Property used to test numbers with range; " \
-                                "title: Number Range Test, minimum: 3, maximum: 10"
+    prop_test.negative_stdout = "Property used to test numbers with range"
+    #  this can be joined with previous if adding meta-properties
+    #  "; title: Number Range Test, minimum: 3, maximum: 10"
     prop_test.negative_stderr = "2.7 is less than the minimum of 3"
     prop_test.positive_value = 7.2
     prop_test.run(script_runner, mock_data_dir)
@@ -481,7 +486,9 @@ def test_number_range(script_runner, mock_data_dir):
 def test_const(script_runner, mock_data_dir):
     prop_test = PropertyTester("const")
     prop_test.negative_value = 2.718
-    prop_test.negative_stdout = "Property used to test properties with const; title: Const Test, const: 3.14"
+    prop_test.negative_stdout = "Property used to test properties with const"
+    #  this can be joined with previous if adding meta-properties
+    #  " ; title: Const Test, const: 3.14"
     prop_test.negative_stderr = "3.14 was expected"
     prop_test.positive_value = 3.14
     prop_test.run(script_runner, mock_data_dir)
@@ -490,8 +497,9 @@ def test_const(script_runner, mock_data_dir):
 def test_string_length(script_runner, mock_data_dir):
     prop_test = PropertyTester("string_length")
     prop_test.negative_value = "12345678901"
-    prop_test.negative_stdout = "Property used to test strings with length restrictions; " \
-                                "title: String Length Test, minLength: 3, maxLength: 10"
+    prop_test.negative_stdout = "Property used to test strings with length restrictions"
+    #  this can be joined with previous if adding meta-properties
+    #  "; title: String Length Test, minLength: 3, maxLength: 10"
     prop_test.negative_stderr = "'12345678901' is too long"
     prop_test.positive_value = "123456"
     prop_test.run(script_runner, mock_data_dir)
@@ -500,8 +508,9 @@ def test_string_length(script_runner, mock_data_dir):
 def test_string_pattern(script_runner, mock_data_dir):
     prop_test = PropertyTester("string_pattern")  # Must start/end with alphanumeric, can include '-' and '.'
     prop_test.negative_value = "-foo1"
-    prop_test.negative_stdout = "Property used to test strings with pattern restrictions; " \
-                                "title: String Pattern Test, pattern: ^[a-z0-9][a-z0-9-.]*[a-z0-9]$"
+    prop_test.negative_stdout = "Property used to test strings with pattern restrictions"
+    #  this can be joined with previous if adding meta-properties
+    #  "; title: String Pattern Test, pattern: ^[a-z0-9][a-z0-9-.]*[a-z0-9]$"
     prop_test.negative_stderr = "'-foo1' does not match '^[a-z0-9][a-z0-9-.]*[a-z0-9]$'"
     prop_test.positive_value = "0foo-bar.com-01"
     prop_test.run(script_runner, mock_data_dir)
@@ -510,8 +519,9 @@ def test_string_pattern(script_runner, mock_data_dir):
 def test_enum(script_runner, mock_data_dir):
     prop_test = PropertyTester("enum")
     prop_test.negative_value = "jupyter"
-    prop_test.negative_stdout = "Property used to test properties with enums; " \
-                                "title: Enum Test, enum: ['elyra', 'rocks']"
+    prop_test.negative_stdout = "Property used to test properties with enums"
+    #  this can be joined with previous if adding meta-properties
+    #  "; title: Enum Test, enum: ['elyra', 'rocks']"
     prop_test.negative_stderr = "'jupyter' is not one of ['elyra', 'rocks']"
     prop_test.positive_value = "rocks"
     prop_test.run(script_runner, mock_data_dir)
@@ -520,8 +530,9 @@ def test_enum(script_runner, mock_data_dir):
 def test_array(script_runner, mock_data_dir):
     prop_test = PropertyTester("array")
     prop_test.negative_value = [1, 2, 2]
-    prop_test.negative_stdout = "Property used to test array with item restrictions; " \
-                                "title: Array Test, minItems: 3, maxItems: 10, uniqueItems: True"
+    prop_test.negative_stdout = "Property used to test array with item restrictions"
+    #  this can be joined with previous if adding meta-properties
+    #  "; title: Array Test, minItems: 3, maxItems: 10, uniqueItems: True"
     prop_test.negative_stderr = "[1, 2, 2] has non-unique elements"
     prop_test.positive_value = [1, 2, 3, 4, 5]
     prop_test.run(script_runner, mock_data_dir)
@@ -530,8 +541,9 @@ def test_array(script_runner, mock_data_dir):
 def test_object(script_runner, mock_data_dir):
     prop_test = PropertyTester("object")
     prop_test.negative_value = {'prop1': 2, 'prop2': 3}
-    prop_test.negative_stdout = "Property used to test object elements with properties restrictions; " \
-                                "title: Object Test, minProperties: 3, maxProperties: 10"
+    prop_test.negative_stdout = "Property used to test object elements with properties restrictions"
+    #  this can be joined with previous if adding meta-properties
+    #  "; title: Object Test, minProperties: 3, maxProperties: 10"
     prop_test.negative_stderr = "{'prop1': 2, 'prop2': 3} does not have enough properties"
     prop_test.positive_value = {'prop1': 2, 'prop2': 3, 'prop3': 4, 'prop4': 5}
     prop_test.run(script_runner, mock_data_dir)
@@ -540,7 +552,9 @@ def test_object(script_runner, mock_data_dir):
 def test_boolean(script_runner, mock_data_dir):
     prop_test = PropertyTester("boolean")
     prop_test.negative_value = "bogus_boolean"
-    prop_test.negative_stdout = "Property used to test boolean values; title: Boolean Test"
+    prop_test.negative_stdout = "Property used to test boolean values"
+    #  this can be joined with previous if adding meta-properties
+    #  "; title: Boolean Test"
     prop_test.negative_stderr = "'bogus_boolean' is not of type 'boolean'"
     prop_test.positive_value = True
     prop_test.run(script_runner, mock_data_dir)
@@ -549,7 +563,9 @@ def test_boolean(script_runner, mock_data_dir):
 def test_null(script_runner, mock_data_dir):
     prop_test = PropertyTester("null")
     prop_test.negative_value = "bogus_null"
-    prop_test.negative_stdout = "Property used to test null types; title: Null Test"
+    prop_test.negative_stdout = "Property used to test null types"
+    #  this can be joined with previous if adding meta-properties
+    #  "; title: Null Test"
     prop_test.negative_stderr = "'bogus_null' is not of type 'null'"
     prop_test.positive_value = None
     prop_test.run(script_runner, mock_data_dir)


### PR DESCRIPTION
The addiitional meta-properties printed on each help message have been removed and the runtime-image schema's `image_name` property description has also been updated.  I've kept the ability to enable them via a boolean since it was trivial to do and might be useful.

Fixes #837 

```
$ elyra-metadata install runtime-images --schema_name=runtime-image
'--name' is a required parameter.

Install a metadata instance into namespace 'runtime-images'.

Options
-------

--replace
	Replace existing instance
--schema_name=<string>
	The schema_name of the metadata instance to install
--name=<string>
	The name of the metadata instance to install
--display_name=<string>
	The display name of the Runtime Image
--description=<string>
	The description of this Runtime Image instance
--image_name=<string>
	The image name (including optional tag)
```
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

