### PR TITLE
Add dialog when reloading metadata editor with unsaved changes

### DIFF
--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -18,7 +18,8 @@ import { MetadataWidget, MetadataEditor } from '@elyra/metadata-common';
 
 import {
   JupyterFrontEnd,
-  JupyterFrontEndPlugin
+  JupyterFrontEndPlugin,
+  ILabStatus
 } from '@jupyterlab/application';
 import { IThemeManager } from '@jupyterlab/apputils';
 import { IEditorServices } from '@jupyterlab/codeeditor';
@@ -41,11 +42,12 @@ const commandIDs = {
 const extension: JupyterFrontEndPlugin<void> = {
   id: METADATA_WIDGET_ID,
   autoStart: true,
-  requires: [IEditorServices],
+  requires: [IEditorServices, ILabStatus],
   optional: [IThemeManager],
   activate: (
     app: JupyterFrontEnd,
     editorServices: IEditorServices,
+    status: ILabStatus,
     themeManager: IThemeManager | null
   ) => {
     console.log('Elyra - metadata extension is activated!');
@@ -78,7 +80,8 @@ const extension: JupyterFrontEndPlugin<void> = {
 
       const metadataEditorWidget = new MetadataEditor({
         ...args,
-        editorServices
+        editorServices,
+        status
       });
       metadataEditorWidget.title.label = widgetLabel;
       metadataEditorWidget.id = widgetId;


### PR DESCRIPTION
Fixes #727. Opens this dialog when there are unsaved changes in the metadata editor and the user tries to reload:
![image](https://user-images.githubusercontent.com/6673460/90043328-910ae380-dc91-11ea-8069-f710c5aac6e5.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

