### PR TITLE
Runtime metadata fields used for DEX auth should be optional

### DIFF
--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -49,8 +49,8 @@ class KfpPipelineProcessor(PipelineProcessor):
         cos_bucket = runtime_configuration.metadata['cos_bucket']
 
         # TODO: try to encapsulate the info below
-        api_username = runtime_configuration.metadata['api_username']
-        api_password = runtime_configuration.metadata['api_password']
+        api_username = runtime_configuration.metadata.get('api_username')
+        api_password = runtime_configuration.metadata.get('api_password')
 
         with tempfile.TemporaryDirectory() as temp_dir:
             pipeline_path = os.path.join(temp_dir, f'{pipeline_name}.tar.gz')


### PR DESCRIPTION
Fixes #865



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

