### PR TITLE
Update node properties to allow changing file

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -466,9 +466,7 @@ export class PipelineEditor extends React.Component<
 
     if (app_data.filename !== propertySet.filename) {
       app_data.filename = propertySet.filename;
-      node.label = propertySet.filename
-        .replace(/^.*[\\/]/, '')
-        .replace(/\.[^/.]+$/, '');
+      node.label = Utils.getFilenameFromPath(propertySet.filename, true);
     }
 
     app_data.runtime_image = propertySet.runtime_image;
@@ -714,11 +712,7 @@ export class PipelineEditor extends React.Component<
             str => str + '='
           );
 
-          data.nodeTemplate.label = item.path.replace(/^.*[\\/]/, '');
-          data.nodeTemplate.label = data.nodeTemplate.label.replace(
-            /\.[^/.]+$/,
-            ''
-          );
+          data.nodeTemplate.label = Utils.getFilenameFromPath(item.path, true);
           data.nodeTemplate.image = IconUtil.encode(notebookIcon);
           data.nodeTemplate.app_data['filename'] = item.path;
           data.nodeTemplate.app_data[

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -466,7 +466,10 @@ export class PipelineEditor extends React.Component<
 
     if (app_data.filename !== propertySet.filename) {
       app_data.filename = propertySet.filename;
-      node.label = Utils.getFilenameFromPath(propertySet.filename, true);
+      node.label = path.basename(
+        propertySet.filename,
+        path.extname(propertySet.filename)
+      );
     }
 
     app_data.runtime_image = propertySet.runtime_image;
@@ -712,7 +715,10 @@ export class PipelineEditor extends React.Component<
             str => str + '='
           );
 
-          data.nodeTemplate.label = Utils.getFilenameFromPath(item.path, true);
+          data.nodeTemplate.label = path.basename(
+            item.path,
+            path.extname(item.path)
+          );
           data.nodeTemplate.image = IconUtil.encode(notebookIcon);
           data.nodeTemplate.app_data['filename'] = item.path;
           data.nodeTemplate.app_data[

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -30,6 +30,7 @@ import {
   pipelineIcon,
   savePipelineIcon,
   runtimesIcon,
+  showBrowseFileDialog,
   showFormDialog,
   errorIcon
 } from '@elyra/ui-components';
@@ -200,6 +201,7 @@ export class PipelineEditor extends React.Component<
   position = 10;
   node: React.RefObject<HTMLDivElement>;
   propertiesInfo: any;
+  propertiesController: any;
 
   constructor(props: any) {
     super(props);
@@ -233,6 +235,10 @@ export class PipelineEditor extends React.Component<
     this.applyPropertyChanges = this.applyPropertyChanges.bind(this);
     this.closePropertiesDialog = this.closePropertiesDialog.bind(this);
     this.openPropertiesDialog = this.openPropertiesDialog.bind(this);
+    this.propertiesActionHandler = this.propertiesActionHandler.bind(this);
+    this.propertiesControllerHandler = this.propertiesControllerHandler.bind(
+      this
+    );
 
     this.node = React.createRef();
     this.handleEvent = this.handleEvent.bind(this);
@@ -342,6 +348,8 @@ export class PipelineEditor extends React.Component<
     ];
 
     const propertiesCallbacks = {
+      actionHandler: this.propertiesActionHandler,
+      controllerHandler: this.propertiesControllerHandler,
       applyPropertyChanges: this.applyPropertyChanges,
       closePropertiesDialog: this.closePropertiesDialog
     };
@@ -456,6 +464,13 @@ export class PipelineEditor extends React.Component<
     }
     const app_data = node.app_data;
 
+    if (app_data.filename !== propertySet.filename) {
+      app_data.filename = propertySet.filename;
+      node.label = propertySet.filename
+        .replace(/^.*[\\/]/, '')
+        .replace(/\.[^/.]+$/, '');
+    }
+
     app_data.runtime_image = propertySet.runtime_image;
     app_data.outputs = propertySet.outputs;
     app_data.env_vars = propertySet.env_vars;
@@ -469,6 +484,28 @@ export class PipelineEditor extends React.Component<
     console.log('Closing properties dialog');
     const propsInfo = JSON.parse(JSON.stringify(this.propertiesInfo));
     this.setState({ showPropertiesDialog: false, propertiesInfo: propsInfo });
+  }
+
+  propertiesControllerHandler(propertiesController: any): void {
+    this.propertiesController = propertiesController;
+  }
+
+  propertiesActionHandler(id: string, appData: any, data: any): void {
+    if (id === 'browse_file') {
+      const propertyId = { name: data.parameter_ref };
+      showBrowseFileDialog(this.browserFactory.defaultBrowser.model.manager, {
+        filter: (model: any): boolean => {
+          return model.type == 'notebook';
+        }
+      }).then((result: any) => {
+        if (result.button.accept && result.value.length) {
+          this.propertiesController.updatePropertyValue(
+            propertyId,
+            result.value[0].path
+          );
+        }
+      });
+    }
   }
 
   /*

--- a/packages/pipeline-editor/src/properties.json
+++ b/packages/pipeline-editor/src/properties.json
@@ -105,23 +105,14 @@
         "type": "panels",
         "group_info": [
           {
-            "id": "browseFilePanel",
-            "type": "columnPanel",
-            "label": {
-              "default": "Browse File Panel"
-            },
-            "group_info": [
-              {
-                "id": "nodeFileControl",
-                "type": "controls",
-                "parameter_refs": ["filename"]
-              },
-              {
-                "id": "nodeBrowseFileAction",
-                "type": "actionPanel",
-                "action_refs": ["browse_file"]
-              }
-            ]
+            "id": "nodeFileControl",
+            "type": "controls",
+            "parameter_refs": ["filename"]
+          },
+          {
+            "id": "nodeBrowseFileAction",
+            "type": "actionPanel",
+            "action_refs": ["browse_file"]
           },
           {
             "id": "nodePropertiesControls",

--- a/packages/pipeline-editor/src/properties.json
+++ b/packages/pipeline-editor/src/properties.json
@@ -83,6 +83,59 @@
           "default": "Files generated during execution that will become available to all subsequent pipeline steps.\nOne filename (including subdirectory) per line."
         }
       }
+    ],
+    "action_info": [
+      {
+        "id": "browse_file",
+        "label": {
+          "default": "Browse..."
+        },
+        "control": "button",
+        "data": {
+          "parameter_ref": "filename"
+        }
+      }
+    ],
+    "group_info": [
+      {
+        "id": "nodeGroupInfo",
+        "label": {
+          "default": "Node Properties"
+        },
+        "type": "panels",
+        "group_info": [
+          {
+            "id": "browseFilePanel",
+            "type": "columnPanel",
+            "label": {
+              "default": "Browse File Panel"
+            },
+            "group_info": [
+              {
+                "id": "nodeFileControl",
+                "type": "controls",
+                "parameter_refs": ["filename"]
+              },
+              {
+                "id": "nodeBrowseFileAction",
+                "type": "actionPanel",
+                "action_refs": ["browse_file"]
+              }
+            ]
+          },
+          {
+            "id": "nodePropertiesControls",
+            "type": "controls",
+            "parameter_refs": [
+              "runtime_image",
+              "dependencies",
+              "include_subdirectories",
+              "env_vars",
+              "outputs"
+            ]
+          }
+        ]
+      }
     ]
   },
   "resources": {}

--- a/packages/pipeline-editor/src/utils.ts
+++ b/packages/pipeline-editor/src/utils.ts
@@ -146,23 +146,4 @@ export default class Utils {
       this.deletePipelineAppdataField(node, currentFieldName);
     }
   }
-
-  /**
-   * Return the last portion (filename) of a path. The file extension is
-   * stripped if `excludeExtension` is set to true.
-   *
-   * @param path
-   * @param excludeExtension
-   */
-  static getFilenameFromPath(path: string, excludeExtension?: boolean): string {
-    // strip directory prefixes
-    let filename = path.replace(/^.*[\\/]/, '');
-
-    if (excludeExtension) {
-      //strip file extension
-      filename = filename.replace(/\.[^/.]+$/, '');
-    }
-
-    return filename;
-  }
 }

--- a/packages/pipeline-editor/src/utils.ts
+++ b/packages/pipeline-editor/src/utils.ts
@@ -146,4 +146,23 @@ export default class Utils {
       this.deletePipelineAppdataField(node, currentFieldName);
     }
   }
+
+  /**
+   * Return the last portion (filename) of a path. The file extension is
+   * stripped if `excludeExtension` is set to true.
+   *
+   * @param path
+   * @param excludeExtension
+   */
+  static getFilenameFromPath(path: string, excludeExtension?: boolean): string {
+    // strip directory prefixes
+    let filename = path.replace(/^.*[\\/]/, '');
+
+    if (excludeExtension) {
+      //strip file extension
+      filename = filename.replace(/\.[^/.]+$/, '');
+    }
+
+    return filename;
+  }
 }

--- a/packages/pipeline-editor/style/canvas.css
+++ b/packages/pipeline-editor/style/canvas.css
@@ -323,6 +323,15 @@ body[data-jp-theme-light='false'] .bx--modal.is-visible {
 .bx--modal-footer .bx--btn--secondary {
   background: var(--md-grey-500);
 }
+.bx--modal-content .bx--btn--tertiary {
+  border-color: var(--md-blue-500);
+  color: var(--md-blue-500);
+  margin-top: 0.6rem;
+}
+.bx--modal-content .bx--btn--tertiary:hover {
+  background: var(--md-blue-500);
+  color: #ffffff;
+}
 .bx--modal-footer .bx--btn:disabled {
   background-color: var(--jp-layout-color3);
   opacity: 0.3;

--- a/packages/pipeline-editor/style/canvas.css
+++ b/packages/pipeline-editor/style/canvas.css
@@ -326,7 +326,6 @@ body[data-jp-theme-light='false'] .bx--modal.is-visible {
 .bx--modal-content .bx--btn--tertiary {
   border-color: var(--md-blue-500);
   color: var(--md-blue-500);
-  margin-top: 0.6rem;
 }
 .bx--modal-content .bx--btn--tertiary:hover {
   background: var(--md-blue-500);

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -119,3 +119,8 @@ td {
   padding-left: 10px;
   padding-right: 10px;
 }
+
+[data-id='properties-nodeBrowseFileAction'] {
+  flex-direction: row;
+  justify-content: end;
+}

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -131,3 +131,7 @@ td {
   right: 0;
   top: 0.6rem;
 }
+
+body.elyra-browseFileDialog-open .properties-modal {
+  display: none;
+}

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -125,3 +125,6 @@ td {
   justify-content: end;
   align-items: flex-end;
 }
+[data-id='properties-nodeBrowseFileAction'] .bx--btn--tertiary {
+  margin-bottom: 0.6rem;
+}

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -121,6 +121,7 @@ td {
 }
 
 [data-id='properties-nodeBrowseFileAction'] {
-  flex-direction: row;
+  flex-direction: column;
   justify-content: end;
+  align-items: flex-end;
 }

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -120,11 +120,14 @@ td {
   padding-right: 10px;
 }
 
-[data-id='properties-nodeBrowseFileAction'] {
-  flex-direction: column;
-  justify-content: end;
-  align-items: flex-end;
+.properties-control-panel[data-id='properties-nodeGroupInfo'] {
+  position: relative;
 }
-[data-id='properties-nodeBrowseFileAction'] .bx--btn--tertiary {
-  margin-bottom: 0.6rem;
+.properties-control-panel[data-id='properties-nodeFileControl'] {
+  width: calc(100% - 100px);
+}
+.properties-action-panel[data-id='properties-nodeBrowseFileAction'] {
+  position: absolute;
+  right: 0;
+  top: 0.6rem;
 }

--- a/packages/ui-components/src/BrowseFileDialog.tsx
+++ b/packages/ui-components/src/BrowseFileDialog.tsx
@@ -30,6 +30,7 @@ export interface IBrowseFileDialogOptions {
   filter?: (model: any) => boolean;
   multiselect?: boolean;
   includeDir?: boolean;
+  acceptFileOnDblClick?: boolean;
 }
 
 /**
@@ -42,6 +43,7 @@ export class BrowseFileDialog extends Widget
   dirListingHandleEvent: (event: Event) => void;
   multiselect: boolean;
   includeDir: boolean;
+  acceptFileOnDblClick: boolean;
 
   constructor(props: any) {
     super(props);
@@ -57,6 +59,7 @@ export class BrowseFileDialog extends Widget
       model: model
     });
 
+    this.acceptFileOnDblClick = props.acceptFileOnDblClick;
     this.multiselect = props.multiselect;
     this.includeDir = props.includeDir;
     this.dirListingHandleEvent = this.directoryListing.handleEvent;
@@ -115,6 +118,14 @@ export class BrowseFileDialog extends Widget
         } else {
           event.preventDefault();
           event.stopPropagation();
+          if (this.acceptFileOnDblClick) {
+            const okButton = document.querySelector(
+              `.${BROWSE_FILE_OPEN_CLASS} .jp-mod-accept`
+            );
+            if (okButton) {
+              (okButton as HTMLButtonElement).click();
+            }
+          }
         }
         break;
       }
@@ -135,7 +146,13 @@ export const showBrowseFileDialog = (
       manager: manager,
       filter: options.filter,
       multiselect: options.multiselect,
-      includeDir: options.includeDir
+      includeDir: options.includeDir,
+      acceptFileOnDblClick: Object.prototype.hasOwnProperty.call(
+        options,
+        'acceptFileOnDblClick'
+      )
+        ? options.acceptFileOnDblClick
+        : true
     }),
     buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'Select' })]
   });

--- a/packages/ui-components/src/BrowseFileDialog.tsx
+++ b/packages/ui-components/src/BrowseFileDialog.tsx
@@ -24,6 +24,7 @@ import {
 import { Widget, PanelLayout } from '@lumino/widgets';
 
 const BROWSE_FILE_CLASS = 'elyra-browseFileDialog';
+const BROWSE_FILE_OPEN_CLASS = 'elyra-browseFileDialog-open';
 
 export interface IBrowseFileDialogOptions {
   filter?: (model: any) => boolean;
@@ -140,6 +141,12 @@ export const showBrowseFileDialog = (
   });
 
   dialog.addClass(BROWSE_FILE_CLASS);
+  document.body.className += ` ${BROWSE_FILE_OPEN_CLASS}`;
 
-  return dialog.launch();
+  return dialog.launch().then((result: any) => {
+    document.body.className = document.body.className
+      .replace(BROWSE_FILE_OPEN_CLASS, '')
+      .trim();
+    return result;
+  });
 };

--- a/packages/ui-components/src/BrowseFileDialog.tsx
+++ b/packages/ui-components/src/BrowseFileDialog.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2018-2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Dialog } from '@jupyterlab/apputils';
+import { IDocumentManager } from '@jupyterlab/docmanager';
+import {
+  BreadCrumbs,
+  DirListing,
+  FilterFileBrowserModel
+} from '@jupyterlab/filebrowser';
+import { Widget, PanelLayout } from '@lumino/widgets';
+
+const BROWSE_FILE_CLASS = 'elyra-browseFileDialog';
+
+export interface IBrowseFileDialogOptions {
+  filter?: (model: any) => boolean;
+  multiselect?: boolean;
+  includeDir?: boolean;
+}
+
+/**
+ * Browse file widget for dialog body
+ */
+export class BrowseFileDialog extends Widget
+  implements Dialog.IBodyWidget<IBrowseFileDialogOptions> {
+  directoryListing: DirListing;
+  breadCrumbs: BreadCrumbs;
+  dirListingHandleEvent: (event: Event) => void;
+  multiselect: boolean;
+  includeDir: boolean;
+
+  constructor(props: any) {
+    super(props);
+
+    const model = new FilterFileBrowserModel({
+      manager: props.manager,
+      filter: props.filter
+    });
+
+    const layout = (this.layout = new PanelLayout());
+
+    this.directoryListing = new DirListing({
+      model: model
+    });
+
+    this.multiselect = props.multiselect;
+    this.includeDir = props.includeDir;
+    this.dirListingHandleEvent = this.directoryListing.handleEvent;
+    this.directoryListing.handleEvent = (event: Event): void => {
+      this.handleEvent(event);
+    };
+
+    this.breadCrumbs = new BreadCrumbs({
+      model: model
+    });
+
+    layout.addWidget(this.breadCrumbs);
+    layout.addWidget(this.directoryListing);
+  }
+
+  getValue(): any {
+    const itemsIter = this.directoryListing.selectedItems();
+    const selected = [];
+    let item = null;
+
+    while ((item = itemsIter.next()) !== undefined) {
+      if (this.includeDir || item.type !== 'directory') {
+        selected.push(item);
+      }
+    }
+
+    return selected;
+  }
+
+  handleEvent(event: Event): void {
+    let modifierKey = false;
+    if (event instanceof MouseEvent) {
+      modifierKey =
+        (event as MouseEvent).shiftKey || (event as MouseEvent).metaKey;
+    } else if (event instanceof KeyboardEvent) {
+      modifierKey =
+        (event as KeyboardEvent).shiftKey || (event as KeyboardEvent).metaKey;
+    }
+
+    switch (event.type) {
+      case 'keydown':
+      case 'keyup':
+      case 'mousedown':
+      case 'mouseup':
+      case 'click':
+        if (this.multiselect || !modifierKey) {
+          this.dirListingHandleEvent.call(this.directoryListing, event);
+        }
+        break;
+      case 'dblclick': {
+        const clickedItem = this.directoryListing.modelForClick(
+          event as MouseEvent
+        );
+        if (clickedItem.type === 'directory') {
+          this.dirListingHandleEvent.call(this.directoryListing, event);
+        } else {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+        break;
+      }
+      default:
+        this.dirListingHandleEvent.call(this.directoryListing, event);
+        break;
+    }
+  }
+}
+
+export const showBrowseFileDialog = (
+  manager: IDocumentManager,
+  options: IBrowseFileDialogOptions
+): Promise<Dialog.IResult<any>> => {
+  const dialog = new Dialog({
+    title: 'Select a file',
+    body: new BrowseFileDialog({
+      manager: manager,
+      filter: options.filter,
+      multiselect: options.multiselect,
+      includeDir: options.includeDir
+    }),
+    buttons: [Dialog.cancelButton(), Dialog.okButton({ label: 'Select' })]
+  });
+
+  dialog.addClass(BROWSE_FILE_CLASS);
+
+  return dialog.launch();
+};

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export * from './BrowseFileDialog';
 export * from './ExpandableErrorDialog';
 export * from './ExpandableComponent';
 export * from './FormDialog';

--- a/packages/ui-components/style/index.css
+++ b/packages/ui-components/style/index.css
@@ -174,3 +174,8 @@
   word-wrap: break-word;
   z-index: 999;
 }
+
+.elyra-browseFileDialog .jp-Dialog-content {
+  height: 400px;
+  width: 600px;
+}


### PR DESCRIPTION
This PR adds support for changing the file associated with a node in the Pipeline Editor.

Fixes #732

To achieve this a new `BrowseFileDialog` was added into `@elyra/ui-components`. The `BrowseFileDialog` displays a file browser in a dialog window which resolves to the selected files when accepted. 

It is worth noting JupyterLab already contains a `FileDialog` in `@jupyterlab/filebrowser`. However, this does not allow flexibility and customization easily, hence the reason for creating the new `BrowseFileDialog`. Unlike the `FileDialog`, the `BrowseFileDialog` can be configured to allow for disabling/preventing multiselect and also allow for selecting directories (if needed). The `FileDialog` does includes the New Folder, Upload, and Refresh buttons (that appear in the default FileBrowser) but not options to opt out of displaying those buttons.

![elyra-browse-file](https://user-images.githubusercontent.com/13156555/90445612-eee26580-e0ad-11ea-851d-c1ac60c6db72.gif)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

