### PR TITLE
Build a source distribution of Elyra when creating a release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ build-ui: yarn-install lint-ui ## Build packages
 	export PATH=$$(pwd)/node_modules/.bin:$$PATH && lerna run build
 
 build-server: lint-server ## Build backend
-	python setup.py bdist_wheel
+	python setup.py bdist_wheel sdist
 
 build: build-server build-ui
 


### PR DESCRIPTION
Conda-forge packages require a source distribution to be used instead
of a wheel. This will need to be published alongside the wheel in Pypi

We will need to retroactively(if possible) publish a source dist of elyra for 1.0.0 using the tagged release into pypi to get the conda forge package going, or wait until the next 1.x.x release.




 
