### PR TITLE
Fix missing field value in Metadata Editor

### DIFF
--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -216,9 +216,9 @@ export class MetadataEditor extends ReactWidget {
     this.handleDirtyState(true);
     // Special case because all metadata has a display name
     if (schemaField === 'display_name') {
-      this.displayName = event.nativeEvent.srcElement.value;
+      this.displayName = event.nativeEvent.target.value;
     } else {
-      this.metadata[schemaField] = event.nativeEvent.srcElement.value;
+      this.metadata[schemaField] = event.nativeEvent.target.value;
     }
   }
 
@@ -450,15 +450,17 @@ export class MetadataEditor extends ReactWidget {
     return (
       <div className={ELYRA_METADATA_EDITOR_CLASS}>
         <h3> {headerText} </h3>
-        {this.renderTextInput(
-          'Name',
-          '',
-          'display_name',
-          this.displayName,
-          '(required)',
-          false,
-          intent
-        )}
+        {this.displayName
+          ? this.renderTextInput(
+              'Name',
+              '',
+              'display_name',
+              this.displayName,
+              '(required)',
+              false,
+              intent
+            )
+          : null}
         {inputElements}
         <FormGroup className={'elyra-metadataEditor-saveButton'}>
           <Button

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -367,8 +367,10 @@ export class MetadataEditor extends ReactWidget {
     const input = document.querySelector(
       `.${this.widgetClass} .elyra-metadataEditor-form-display_name input`
     ) as HTMLInputElement;
-    input.focus();
-    input.setSelectionRange(input.value.length, input.value.length);
+    if (input) {
+      input.focus();
+      input.setSelectionRange(input.value.length, input.value.length);
+    }
   }
 
   renderField(fieldName: string): React.ReactElement {
@@ -450,7 +452,7 @@ export class MetadataEditor extends ReactWidget {
     return (
       <div className={ELYRA_METADATA_EDITOR_CLASS}>
         <h3> {headerText} </h3>
-        {this.displayName
+        {this.displayName !== undefined
           ? this.renderTextInput(
               'Name',
               '',


### PR DESCRIPTION
The latest release of JupyterLab updated to the latest release
of blueprintjs core, which included an async bugfix for`InputGroup`
which broke how our async update interacts with fields. Thus
causing any already rendered `InputGroup` to not update it's value
on an async call to `update()` such as the one we do after calling
the metadata api.

I solved this by making the rendering of the display_name field
conditional on the existance of an inital value, just like we
already do with the other fields.

Fixes #883



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

