### PR TITLE
[WIP] Fix migrate dialog bug

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -942,8 +942,10 @@ export class PipelineEditor extends React.Component<
             // in this case, pipeline was last edited in a "old" version of Elyra and
             // it needs to be updated/migrated.
             const filePath = this.widgetContext.path;
-            const extension = path.extname(filePath);
-            const pipelineName = path.basename(filePath, extension);
+            const pipelineName = path.basename(
+              filePath,
+              path.extname(filePath)
+            );
 
             const migrateDialogResult = await showDialog({
               title: "Migrate pipeline '" + pipelineName + "'?",

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -970,7 +970,7 @@ export class PipelineEditor extends React.Component<
               // proceed with migration
               pipelineJson = PipelineService.convertPipeline(
                 pipelineJson,
-                this.widgetContext.path
+                filePath
               );
               this.canvasController.setPipelineFlow(pipelineJson);
             } else {

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -941,9 +941,9 @@ export class PipelineEditor extends React.Component<
           } else {
             // in this case, pipeline was last edited in a "old" version of Elyra and
             // it needs to be updated/migrated.
-            const path = this.widgetContext.path;
+            const filename = this.widgetContext.path.split('/').pop();
             const migrateDialogResult = await showDialog({
-              title: 'Migrate pipeline ' + path + '?',
+              title: 'Migrate pipeline ' + filename + '?',
               body: (
                 <p>
                   This pipeline corresponds to an older version of Elyra and
@@ -961,17 +961,15 @@ export class PipelineEditor extends React.Component<
               ),
               buttons: [Dialog.cancelButton(), Dialog.okButton()]
             });
-            if (migrateDialogResult) {
-              if (migrateDialogResult.button.accept) {
-                // proceed with migration
-                pipelineJson = PipelineService.convertPipeline(
-                  pipelineJson,
-                  this.widgetContext.path
-                );
-                this.canvasController.setPipelineFlow(pipelineJson);
-              } else {
-                this.handleClosePipeline();
-              }
+            if (migrateDialogResult && migrateDialogResult.button.accept) {
+              // proceed with migration
+              pipelineJson = PipelineService.convertPipeline(
+                pipelineJson,
+                this.widgetContext.path
+              );
+              this.canvasController.setPipelineFlow(pipelineJson);
+            } else {
+              this.handleClosePipeline();
             }
           }
         }
@@ -1292,20 +1290,18 @@ export class PipelineEditor extends React.Component<
 
     const labShell = this.shell as LabShell;
 
-    const activeWidgetListener = (_: any, args: any) => {
-      const activeWidget = args.newValue;
+    this.initPropertiesInfo().finally(() => {
+      const activeWidgetListener = (_: any, args: any): void => {
+        const activeWidget = args.newValue;
 
-      // Only handle open pipeline if PipelineEditorWidget is active
-      if (activeWidget && activeWidget.id === this.widgetId) {
-        this.initPropertiesInfo().finally(() => {
+        // Only handle open pipeline if PipelineEditorWidget is active
+        if (activeWidget && activeWidget.id === this.widgetId) {
           this.handleOpenPipeline();
-        });
-
-        labShell.activeChanged.disconnect(activeWidgetListener);
-      }
-    };
-
-    labShell.activeChanged.connect(activeWidgetListener);
+          labShell.activeChanged.disconnect(activeWidgetListener);
+        }
+      };
+      labShell.activeChanged.connect(activeWidgetListener);
+    });
   }
 
   componentWillUnmount(): void {

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -653,13 +653,9 @@ export class PipelineEditor extends React.Component<
         this.canvasController.getLinks()
       )
     ) {
-      this.setState({
-        validationError: {
-          errorMessage: 'Invalid operation: circular references in pipeline.',
-          errorSeverity: 'error'
-        },
-        showValidationError: true
-      });
+      this.displayErrorMessage(
+        'Invalid operation: circular references in pipeline.'
+      );
       // Don't proceed with adding the link if invalid.
       return null;
     } else {
@@ -1290,18 +1286,18 @@ export class PipelineEditor extends React.Component<
 
     const labShell = this.shell as LabShell;
 
-    this.initPropertiesInfo().finally(() => {
-      const activeWidgetListener = (_: any, args: any): void => {
-        const activeWidget = args.newValue;
+    const activeWidgetListener = (_: any, args: any): void => {
+      const activeWidget = args.newValue;
 
-        // Only handle open pipeline if PipelineEditorWidget is active
-        if (activeWidget && activeWidget.id === this.widgetId) {
+      // Only handle open pipeline if PipelineEditorWidget is active
+      if (activeWidget && activeWidget.id === this.widgetId) {
+        this.initPropertiesInfo().finally(() => {
           this.handleOpenPipeline();
-          labShell.activeChanged.disconnect(activeWidgetListener);
-        }
-      };
-      labShell.activeChanged.connect(activeWidgetListener);
-    });
+        });
+        labShell.activeChanged.disconnect(activeWidgetListener);
+      }
+    };
+    labShell.activeChanged.connect(activeWidgetListener);
   }
 
   componentWillUnmount(): void {

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -846,13 +846,7 @@ export class PipelineEditor extends React.Component<
     // Warn user if the pipeline has invalid nodes
     const errorMessage = await this.validatePipeline();
     if (errorMessage) {
-      this.setState({
-        showValidationError: true,
-        validationError: {
-          errorMessage: errorMessage,
-          errorSeverity: 'error'
-        }
-      });
+      this.displayErrorMessage(errorMessage);
       return;
     }
     const runtimes = await PipelineService.getRuntimes();
@@ -979,19 +973,16 @@ export class PipelineEditor extends React.Component<
           }
         }
       }
-      this.setState({ emptyPipeline: Utils.isEmptyPipeline(pipelineJson) });
       this.canvasController.setPipelineFlow(pipelineJson);
       const errorMessage = await this.validatePipeline();
       if (errorMessage) {
+        this.displayErrorMessage(errorMessage);
+      } else {
         this.setState({
-          showValidationError: true,
-          validationError: {
-            errorMessage: errorMessage,
-            errorSeverity: 'error'
-          }
+          emptyPipeline: Utils.isEmptyPipeline(pipelineJson),
+          showValidationError: false
         });
       }
-      this.validateAllNodes();
     });
   }
 
@@ -1187,17 +1178,21 @@ export class PipelineEditor extends React.Component<
     }
   }
 
+  displayErrorMessage(errorMessage: string): void {
+    this.setState({
+      showValidationError: true,
+      validationError: {
+        errorMessage: errorMessage,
+        errorSeverity: 'error'
+      }
+    });
+  }
+
   async handleRunPipeline(): Promise<void> {
     // Check that all nodes are valid
     const errorMessage = await this.validatePipeline();
     if (errorMessage) {
-      this.setState({
-        showValidationError: true,
-        validationError: {
-          errorMessage: errorMessage,
-          errorSeverity: 'error'
-        }
-      });
+      this.displayErrorMessage(errorMessage);
       return;
     }
 

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -911,6 +911,8 @@ export class PipelineEditor extends React.Component<
       } else {
         // opening an existing pipeline
         const pipelineVersion: number = +Utils.getPipelineVersion(pipelineJson);
+        this.setAndVerifyPipelineFlow(pipelineJson);
+
         if (pipelineVersion !== PIPELINE_CURRENT_VERSION) {
           // pipeline version and current version are divergent
           if (pipelineVersion > PIPELINE_CURRENT_VERSION) {

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -35,7 +35,7 @@ import {
   errorIcon
 } from '@elyra/ui-components';
 
-import { JupyterFrontEnd } from '@jupyterlab/application';
+import { JupyterFrontEnd, LabShell } from '@jupyterlab/application';
 import { showDialog, Dialog, ReactWidget } from '@jupyterlab/apputils';
 import {
   DocumentRegistry,

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -941,9 +941,12 @@ export class PipelineEditor extends React.Component<
           } else {
             // in this case, pipeline was last edited in a "old" version of Elyra and
             // it needs to be updated/migrated.
-            const filename = this.widgetContext.path.split('/').pop();
+            const filePath = this.widgetContext.path;
+            const extension = path.extname(filePath);
+            const pipelineName = path.basename(filePath, extension);
+
             const migrateDialogResult = await showDialog({
-              title: 'Migrate pipeline ' + filename + '?',
+              title: "Migrate pipeline '" + pipelineName + "'?",
               body: (
                 <p>
                   This pipeline corresponds to an older version of Elyra and


### PR DESCRIPTION
Fixes #863 

Before these changes, the migrate pipeline dialog would pop up on a page reload or lab restart, even when the pipeline in old version tab wasn't on focus.
Now `PipelideEditorWidget` listens to `activeChanged` shell event and only handles open pipeline when the requested one actually becomes active (on reload or tab change).
The active pipeline title was also added to the dialog to give it more context.

Example below on a page reload to a python editor widget and `untitled.pipeline` version is outdated:
![migrate-bug-fix](https://user-images.githubusercontent.com/25207344/90935365-0af94600-e3d1-11ea-9928-15258b6aaeb8.gif)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

