### PR TITLE
Link metadata-common package to binder build

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -35,7 +35,8 @@ pip install dist/*.whl
 # Rebuild Jupyter Lab to enable extensions
 jupyter labextension link --no-build packages/application/
 jupyter labextension link --no-build packages/ui-components/
-jupyter lab build --dev-build=False --minimize=False
+jupyter labextension link --no-build packages/metadata-common/
+jupyter lab build --dev-build=False --minimize=False --debug
 mkdir -p binder-demo
 
 # Enable debug output


### PR DESCRIPTION
Link instead of attempting to pull from online from npm since
dev packages are not published

Fixes #884



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

