### PR TITLE
Allow name to default from display_name in CLI tool

### DIFF
--- a/elyra/metadata/metadata_app.py
+++ b/elyra/metadata/metadata_app.py
@@ -148,7 +148,7 @@ class NamespaceInstall(NamespaceBase):
     replace_flag = Flag("--replace", name='replace',
                         description='Replace existing instance', default_value=False)
     name_option = CliOption("--name", name='name',
-                            description='The name of the metadata instance to install', required=True)
+                            description='The name of the metadata instance to install')
 
     # 'Install' options
     options = [replace_flag]  # defer name_option until after schema_option
@@ -229,11 +229,11 @@ class NamespaceInstall(NamespaceBase):
 
         if new_instance:
             print("Metadata instance '{}' for schema '{}' has been written to: {}"
-                  .format(name, schema_name, new_instance.resource))
+                  .format(new_instance.name, schema_name, new_instance.resource))
         else:
             if ex_msg:
-                self.log_and_exit("The following exception occurred saving metadata instance '{}' for schema '{}': {}"
-                                  .format(name, schema_name, ex_msg), display_help=True)
+                self.log_and_exit("The following exception occurred saving metadata instance for schema '{}': {}"
+                                  .format(schema_name, ex_msg), display_help=True)
             else:
                 self.log_and_exit("A failure occurred saving metadata instance '{}' for schema '{}'."
                                   .format(name, schema_name), display_help=True)


### PR DESCRIPTION
The `--name` parameter is no longer required when creating (installing) metadata instances using the `elyra-metadata` CLI tool.  It is required for updates (replace) and deletes (remove) operations - just like via the REST API.

Fixes #898
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

