### PR TITLE
Create a button in palette for all schema

### DIFF
--- a/elyra/metadata/schemas/code-snippet.json
+++ b/elyra/metadata/schemas/code-snippet.json
@@ -4,6 +4,9 @@
   "name": "code-snippet",
   "display_name": "Code Snippet",
   "namespace": "code-snippets",
+  "uihints": {
+    "title": "Code Snippets"
+  },
   "properties": {
     "schema_name": {
       "title": "Schema Name",

--- a/elyra/metadata/schemas/code-snippet.json
+++ b/elyra/metadata/schemas/code-snippet.json
@@ -5,7 +5,8 @@
   "display_name": "Code Snippet",
   "namespace": "code-snippets",
   "uihints": {
-    "title": "Code Snippets"
+    "title": "Code Snippets",
+    "icon": "elyra:code-snippet"
   },
   "properties": {
     "schema_name": {

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -5,7 +5,8 @@
   "display_name": "Kubeflow Pipelines runtime",
   "namespace": "runtimes",
   "uihints": {
-    "title": "Kubeflow Pipelines runtimes"
+    "title": "Kubeflow Pipelines runtimes",
+    "icon": "elyra:runtimes"
   },
   "properties": {
     "schema_name": {

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -4,6 +4,9 @@
   "name": "kfp",
   "display_name": "Kubeflow Pipelines runtime",
   "namespace": "runtimes",
+  "uihints": {
+    "title": "Kubeflow Pipelines runtimes"
+  },
   "properties": {
     "schema_name": {
       "title": "Schema Name",

--- a/elyra/metadata/schemas/runtime-image.json
+++ b/elyra/metadata/schemas/runtime-image.json
@@ -4,6 +4,9 @@
   "name": "runtime-image",
   "display_name": "Runtime Image",
   "namespace": "runtime-images",
+  "uihints": {
+    "icon": "elyra:container"
+  },
   "properties": {
     "schema_name": {
       "title": "Schema Name",

--- a/elyra/metadata/schemas/runtime-image.json
+++ b/elyra/metadata/schemas/runtime-image.json
@@ -5,7 +5,8 @@
   "display_name": "Runtime Image",
   "namespace": "runtime-images",
   "uihints": {
-    "icon": "elyra:container"
+    "icon": "elyra:container",
+    "title": "Runtime Images"
   },
   "properties": {
     "schema_name": {

--- a/packages/application/src/services.tsx
+++ b/packages/application/src/services.tsx
@@ -147,4 +147,30 @@ export class FrontendServices {
 
     return schemaResponse[namespace];
   }
+
+  /**
+   * Service function for making GET calls to the elyra schema API.
+   *
+   * @returns a promise that resolves with the requested schemas or
+   * an error dialog result
+   */
+  static async getAllSchema(): Promise<any> {
+    const namespaces = await RequestHandler.makeGetRequest(
+      'elyra/namespace',
+      false
+    );
+    const schemas = [];
+    for (const namespace of namespaces['namespaces']) {
+      const schemaResponse = await RequestHandler.makeGetRequest(
+        ELYRA_SCHEMA_API_ENDPOINT + namespace,
+        false
+      );
+
+      if (schemaResponse[namespace]) {
+        this.schemaCache[namespace] = schemaResponse[namespace];
+      }
+      schemas.push(...schemaResponse[namespace]);
+    }
+    return schemas;
+  }
 }

--- a/packages/application/src/services.tsx
+++ b/packages/application/src/services.tsx
@@ -161,15 +161,8 @@ export class FrontendServices {
     );
     const schemas = [];
     for (const namespace of namespaces['namespaces']) {
-      const schemaResponse = await RequestHandler.makeGetRequest(
-        ELYRA_SCHEMA_API_ENDPOINT + namespace,
-        false
-      );
-
-      if (schemaResponse[namespace]) {
-        this.schemaCache[namespace] = schemaResponse[namespace];
-      }
-      schemas.push(...schemaResponse[namespace]);
+      const schema = await this.getSchema(namespace);
+      schemas.push(...schema);
     }
     return schemas;
   }

--- a/packages/code-snippet/src/index.ts
+++ b/packages/code-snippet/src/index.ts
@@ -64,11 +64,12 @@ export const code_snippet_extension: JupyterFrontEndPlugin<void> = {
       getCurrentWidget,
       editorServices
     });
-    codeSnippetWidget.id = CODE_SNIPPET_EXTENSION_ID;
+    const codeSnippetWidgetId = `elyra-metadata:${CODE_SNIPPET_NAMESPACE}:${CODE_SNIPPET_SCHEMA}`;
+    codeSnippetWidget.id = codeSnippetWidgetId;
     codeSnippetWidget.title.icon = codeSnippetIcon;
     codeSnippetWidget.title.caption = 'Code Snippets';
 
-    restorer.add(codeSnippetWidget, CODE_SNIPPET_EXTENSION_ID);
+    restorer.add(codeSnippetWidget, codeSnippetWidgetId);
 
     // Rank has been chosen somewhat arbitrarily to give priority to the running
     // sessions widget in the sidebar.

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -182,7 +182,8 @@ const extension: JupyterFrontEndPlugin<void> = {
       }
     });
     app.contextMenu.addItem({
-      selector: '[data-id^="elyra-metadata:"]',
+      selector:
+        '[data-id^="elyra-metadata:"]:not([data-id$="code-snippet"]):not([data-id$="runtimes"])',
       command: closeTabCommand
     });
 

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -159,17 +159,22 @@ const extension: JupyterFrontEndPlugin<void> = {
     });
 
     const schemas = await FrontendServices.getAllSchema();
-    console.log(schemas);
     for (const schema of schemas) {
       let icon = 'ui-components:text-editor';
-      if (schema.uihints && schema.uihints.icon) {
-        icon = schema.uihints.icon;
+      let title = schema.title;
+      if (schema.uihints) {
+        if (schema.uihints.icon) {
+          icon = schema.uihints.icon;
+        }
+        if (schema.uihints.title) {
+          title = schema.uihints.title;
+        }
       }
       palette.addItem({
         command: commandIDs.openMetadata,
         args: {
-          label: `Show ${schema.display_name}`,
-          display_name: schema.display_name,
+          label: `Manage ${title}`,
+          display_name: schema.title,
           namespace: schema.namespace,
           schema: schema.name,
           icon: icon

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -183,7 +183,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     });
     app.contextMenu.addItem({
       selector:
-        '[data-id^="elyra-metadata:"]:not([data-id$="code-snippet"]):not([data-id$="runtimes"])',
+        '[data-id^="elyra-metadata:"]:not([data-id$="code-snippet"]):not([data-id$="runtimes:kfp"])',
       command: closeTabCommand
     });
 

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -159,7 +159,7 @@ const extension: JupyterFrontEndPlugin<void> = {
       }
     });
 
-    // Add command to add file to pipeline
+    // Add command to close metadata tab
     const closeTabCommand: string = commandIDs.closeTabCommand;
     app.commands.addCommand(closeTabCommand, {
       label: 'Close Tab',

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -34,7 +34,8 @@ const METADATA_EDITOR_ID = 'elyra-metadata-editor';
 const METADATA_WIDGET_ID = 'elyra-metadata';
 
 const commandIDs = {
-  openMetadata: 'elyra-metadata:open'
+  openMetadata: 'elyra-metadata:open',
+  closeTabCommand: 'elyra-metadata:close'
 };
 
 /**
@@ -156,6 +157,33 @@ const extension: JupyterFrontEndPlugin<void> = {
         // to the running sessions widget in the sidebar.
         openMetadataWidget(args);
       }
+    });
+
+    // Add command to add file to pipeline
+    const closeTabCommand: string = commandIDs.closeTabCommand;
+    app.commands.addCommand(closeTabCommand, {
+      label: 'Close Tab',
+      execute: args => {
+        const contextNode: HTMLElement | undefined = app.contextMenuHitTest(
+          node => !!node.dataset.id
+        );
+        if (contextNode) {
+          const id = contextNode.dataset['id']!;
+          const widget = find(
+            app.shell.widgets('left'),
+            (widget: Widget, index: number) => {
+              return widget.id === id;
+            }
+          );
+          if (widget) {
+            widget.dispose();
+          }
+        }
+      }
+    });
+    app.contextMenu.addItem({
+      selector: '[data-id^="elyra-metadata:"]',
+      command: closeTabCommand
     });
 
     const schemas = await FrontendServices.getAllSchema();

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { FrontendServices } from '@elyra/application';
 import { MetadataWidget, MetadataEditor } from '@elyra/metadata-common';
 
 import {
@@ -21,7 +22,7 @@ import {
   JupyterFrontEndPlugin,
   ILabStatus
 } from '@jupyterlab/application';
-import { IThemeManager } from '@jupyterlab/apputils';
+import { IThemeManager, ICommandPalette } from '@jupyterlab/apputils';
 import { IEditorServices } from '@jupyterlab/codeeditor';
 import { textEditorIcon, LabIcon } from '@jupyterlab/ui-components';
 
@@ -42,10 +43,11 @@ const commandIDs = {
 const extension: JupyterFrontEndPlugin<void> = {
   id: METADATA_WIDGET_ID,
   autoStart: true,
-  requires: [IEditorServices, ILabStatus],
+  requires: [ICommandPalette, IEditorServices, ILabStatus],
   optional: [IThemeManager],
-  activate: (
+  activate: async (
     app: JupyterFrontEnd,
+    palette: ICommandPalette,
     editorServices: IEditorServices,
     status: ILabStatus,
     themeManager: IThemeManager | null
@@ -155,6 +157,26 @@ const extension: JupyterFrontEndPlugin<void> = {
         openMetadataWidget(args);
       }
     });
+
+    const schemas = await FrontendServices.getAllSchema();
+    console.log(schemas);
+    for (const schema of schemas) {
+      let icon = 'ui-components:text-editor';
+      if (schema.uihints && schema.uihints.icon) {
+        icon = schema.uihints.icon;
+      }
+      palette.addItem({
+        command: commandIDs.openMetadata,
+        args: {
+          label: `Show ${schema.display_name}`,
+          display_name: schema.display_name,
+          namespace: schema.namespace,
+          schema: schema.name,
+          icon: icon
+        },
+        category: 'Elyra'
+      });
+    }
   }
 };
 

--- a/packages/pipeline-editor/src/index.ts
+++ b/packages/pipeline-editor/src/index.ts
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  containerIcon,
-  pipelineIcon,
-  runtimesIcon
-} from '@elyra/ui-components';
+import { pipelineIcon, runtimesIcon } from '@elyra/ui-components';
 
 import {
   JupyterFrontEnd,
@@ -33,12 +29,7 @@ import { IMainMenu } from '@jupyterlab/mainmenu';
 import { addIcon } from '@jupyterlab/ui-components';
 
 import { PipelineEditorFactory, commandIDs } from './PipelineEditorWidget';
-import {
-  RUNTIME_IMAGE_SCHEMA,
-  RUNTIME_IMAGES_NAMESPACE,
-  KFP_SCHEMA,
-  RUNTIMES_NAMESPACE
-} from './PipelineService';
+import { KFP_SCHEMA, RUNTIMES_NAMESPACE } from './PipelineService';
 import { RuntimesWidget } from './RuntimesWidget';
 import { SubmitNotebookButtonExtension } from './SubmitNotebookButtonExtension';
 
@@ -155,17 +146,7 @@ const extension: JupyterFrontEndPlugin<void> = {
       args: { isPalette: true },
       category: 'Elyra'
     });
-    palette.addItem({
-      command: commandIDs.openMetadata,
-      args: {
-        label: 'Show Runtime Images',
-        display_name: 'Runtime Images',
-        namespace: RUNTIME_IMAGES_NAMESPACE,
-        schema: RUNTIME_IMAGE_SCHEMA,
-        icon: containerIcon.name
-      },
-      category: 'Elyra'
-    });
+
     // Add the command to the launcher
     if (launcher) {
       launcher.add({


### PR DESCRIPTION
Automatically detects all schema and creates a button to open the widget for a given schema.
![image](https://user-images.githubusercontent.com/6673460/91911481-cc884480-ec76-11ea-93c0-5edc9c8a9861.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

