### PR TITLE
add tutorial section to the documentation

### DIFF
--- a/docs/source/getting_started/tutorials.md
+++ b/docs/source/getting_started/tutorials.md
@@ -1,0 +1,28 @@
+<!--
+{% comment %}
+Copyright 2018-2020 IBM Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+## Tutorials
+
+The following tutorials highlight key features of Elyra.
+
+### Running notebook pipelines in JupyterLab
+
+Learn how to [create a notebook pipeline and run it in your local JupyterLab environment](https://github.com/elyra-ai/examples/tree/master/pipelines/hello_world).
+
+### Running notebook pipelines in Kubeflow Pipelines
+
+Learn how to [create a notebook pipeline and run it on Kubeflow Pipelines](https://github.com/elyra-ai/examples/tree/master/pipelines/hello_world_kubeflow_pipelines). This tutorial requires a Kubeflow Pipelines deployment in a local environment or on the cloud.

--- a/docs/source/getting_started/tutorials.md
+++ b/docs/source/getting_started/tutorials.md
@@ -23,6 +23,6 @@ The following tutorials highlight key features of Elyra.
 
 Learn how to [create a notebook pipeline and run it in your local JupyterLab environment](https://github.com/elyra-ai/examples/tree/master/pipelines/hello_world).
 
-### Running notebook pipelines in Kubeflow Pipelines
+### Running notebook pipelines on Kubeflow Pipelines
 
 Learn how to [create a notebook pipeline and run it on Kubeflow Pipelines](https://github.com/elyra-ai/examples/tree/master/pipelines/hello_world_kubeflow_pipelines). This tutorial requires a Kubeflow Pipelines deployment in a local environment or on the cloud.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,6 +32,7 @@ Elyra is a set of AI-centric extensions to JupyterLab Notebooks.
    getting_started/overview
    getting_started/installation
    getting_started/starting
+   getting_started/tutorials
    getting_started/changelog
 
 .. toctree::


### PR DESCRIPTION
The new tutorial page includes links to two notebook pipelines tutorials. this PR requires https://github.com/elyra-ai/examples/pull/14 to be merged or the second tutorial link will raise a 404.

![image](https://user-images.githubusercontent.com/13068832/92163243-307e4a80-ede8-11ea-881b-79b5975ecc2e.png)


Closes #905 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

