### PR TITLE
Unpin urllib3 package to version 1.24.2 or greater

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup_args = dict(
         'requests>=2.9.1,<3.0',
         'rfc3986-validator>=0.1.1',
         'traitlets>=4.3.2',
-        'urllib3==1.24.2',
+        'urllib3>=1.24.2',
     ],
     include_package_data=True,
     classifiers=(


### PR DESCRIPTION
Unpin to satisfy package resolution when using python 3.8 with
conda-forge feedstock

Fixes #914


