### PR TITLE
Pipeline export: update file format labels

### DIFF
--- a/packages/pipeline-editor/src/PipelineExportDialog.tsx
+++ b/packages/pipeline-editor/src/PipelineExportDialog.tsx
@@ -18,7 +18,10 @@ import * as React from 'react';
 
 import { IRuntime } from './PipelineService';
 
-const FILE_TYPES = ['yaml', 'py'];
+const FILE_TYPES = [
+  { label: 'KFP static configuration file (YAML formatted)', key: 'yaml' },
+  { label: 'KFP domain-specific language Python code', key: 'py' }
+];
 
 interface IProps {
   runtimes: IRuntime[];
@@ -52,8 +55,8 @@ export class PipelineExportDialog extends React.Component<IProps> {
           data-form-required
         >
           {FILE_TYPES.map(filetype => (
-            <option key={filetype} value={filetype}>
-              {filetype}
+            <option key={filetype['key']} value={filetype['key']}>
+              {filetype['label']}
             </option>
           ))}
         </select>


### PR DESCRIPTION
This PR 
- updates the output file format labels to make them more user-friendly
- separates option label text from key/value

![image](https://user-images.githubusercontent.com/13068832/92974544-597f8a80-f43b-11ea-9bad-a6b24b6b96fb.png)

A few thoughts:
- I  do believe we need to indicate that the exported file is Kubeflow Pipelines specific
- I would prefer if we didn't use the `KFP` acronym but also realized that by spelling out Kubeflow Pipelines the labels ceome very long 
- Possible alternatives:
   - `KFP pipeline configuration (YAML formatted)` / `KFP  pipeline DSL Python code` 
  - ...?
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

