### PR TITLE
add link to openshift deployment instructions

### DIFF
--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -149,3 +149,8 @@ Open the displayed URL in your browser to start using JupyterLab and Elyra.
         http://4d17829ecd4c:8888/?token=d690bde267ec75d6f88c64a39825f8b05b919dd084451f82
      or http://127.0.0.1:8888/?token=d690bde267ec75d6f88c64a39825f8b05b919dd084451f82
 ```
+
+
+### Red Hat OpenShift
+
+JupyterLab and Elyra are included in the Open Data Hub community operator. Follow the instructions in [this document](/recipes/deploying-elyra-with-opendatahub.html) to deploy the operator in a Red Hat OpenShift cluster.


### PR DESCRIPTION

 This PR adds a new "Red Hat OpenShift" section to the installation documentation, which links to the deployment recipe.

![image](https://user-images.githubusercontent.com/13068832/93373541-548b5400-f80a-11ea-9dba-9b58ca275621.png)


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

