### PR TITLE
Fix docker build

### DIFF
--- a/etc/docker/elyra/Dockerfile
+++ b/etc/docker/elyra/Dockerfile
@@ -31,7 +31,8 @@ RUN chmod ugo+x /usr/local/bin/start-elyra.sh && \
 
 USER $NB_USER
 
-RUN python -m pip install --upgrade pip && \
+RUN conda remove --force -y terminado && \
+    python -m pip install --upgrade pip && \
     python -m pip install --ignore-installed --upgrade setuptools pandas && \
     echo "scripts-prepend-node-path=true" >> /home/jovyan/.npmrc && \
     echo "prefix=/home/jovyan/.npm-global" >> /home/jovyan/.npmrc && \


### PR DESCRIPTION
The docker build `make docker-image` was failing because the `terminado` installed in the base image (version `0.8.3`) cannot be upgraded, producing the following error message:
```
ERROR: Cannot uninstall 'terminado'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
```
This change forces the removal of the `terminado` package via `conda` so that the subsequent eager upgrade can proceed.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

