### PR TITLE
Remove elyra build area to reduce image size

### DIFF
--- a/etc/docker/elyra/Dockerfile
+++ b/etc/docker/elyra/Dockerfile
@@ -40,7 +40,9 @@ RUN conda remove --force -y terminado && \
     npm install -g yarn && \
     npm install -g npm && \
     cd /tmp && git clone https://github.com/elyra-ai/elyra.git && \
-    cd /tmp/elyra && git checkout tags/v1.2.0 -b v1.2.0 && make UPGRADE_STRATEGY=eager install
+    cd /tmp/elyra && git checkout tags/v1.2.0 -b v1.2.0 && \
+    make UPGRADE_STRATEGY=eager install && \
+    rm -rf /tmp/elyra
 
 WORKDIR /home/jovyan/work
 


### PR DESCRIPTION
By removing the elyra build directory `/tmp/elyra` we can reduce the docker image size by 590mb (from 4.05gb to 3.46gb).
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

