### PR TITLE
Update Python prerequisites in docker runtime image documentation

### DIFF
--- a/docs/source/recipes/creating-a-custom-runtime-image.md
+++ b/docs/source/recipes/creating-a-custom-runtime-image.md
@@ -22,7 +22,7 @@ A runtime image provides the execution environment in which nodes are executed w
 
 Should none of these images meet your needs, you can utilize a custom Docker image, as long as it meets the following pre-requisites:
 - The Docker image is published on the public Docker container registry [https://hub.docker.com](https://hub.docker.com). (Elyra currently does not support private registries.)
-- [Python 3](https://www.python.org/) is pre-installed and in the search path.
+- [Python 3](https://www.python.org/) is pre-installed and in the search path. Python versions that have reached their "end of life" are not supported.
 - [`curl`](https://curl.haxx.se/) is pre-installed and in the search path.
 
 Refer to the [Additional considerations](#additional-considerations) section for important implementation details.

--- a/docs/source/user_guide/runtime-image-conf.md
+++ b/docs/source/user_guide/runtime-image-conf.md
@@ -23,8 +23,8 @@ A runtime image configuration identifies a Docker image that Elyra can utilize t
 
 A runtime image configuration is associated with a Docker image that must meet these prerequisites:
 - The image must be stored in the public Docker Hub container registry https://hub.docker.com/.
-- The image must have `Python 3` pre-installed.
-- The image must have `curl` pre-installed.
+- The image must have a current `Python 3` version pre-installed and in the search path.
+- The image must have `curl` pre-installed and in the search path.
 
 Refer to [Creating a custom runtime Docker image](/recipes/creating-a-custom-runtime-image.md) for details.
 


### PR DESCRIPTION
This PR clarifies the stated prerequisites a Docker image must meet in order to be usable as a runtime image in a pipeline.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

