### PR TITLE
Add common format for pipeline process logging

### DIFF
--- a/elyra/__init__.py
+++ b/elyra/__init__.py
@@ -48,5 +48,5 @@ def load_jupyter_server_extension(nb_server_app):
         (url_path_join(web_app.settings['base_url'], r'/elyra/pipeline/export'), PipelineExportHandler),
     ])
     # Create PipelineProcessorManager instance passing root directory
-    PipelineProcessorManager.instance(root_dir=web_app.settings['server_root_dir'])
+    PipelineProcessorManager.instance(root_dir=web_app.settings['server_root_dir'], parent=nb_server_app)
 

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import os
-from typing import Dict
+from typing import Dict, Optional
 
 
 class Operation(object):
@@ -103,8 +103,7 @@ class Operation(object):
     def env_vars(self):
         return self._env_vars
 
-    @property
-    def env_vars_as_dict(self) -> Dict:
+    def env_vars_as_dict(self, logger: Optional[object] = None) -> Dict:
         """Operation stores environment variables in a list of name=value pairs, while
            subprocess.run() requires a dictionary - so we must convert.  If no envs are
            configured on the Operation, the existing env is returned, otherwise envs
@@ -112,11 +111,15 @@ class Operation(object):
         """
         envs = os.environ.copy()
         for nv in self.env_vars:
-            nv_pair = nv.split("=")
-            if len(nv_pair) == 2:
-                envs[nv_pair[0]] = nv_pair[1]
-            else:
-                self.log.warning(f"Could not process environment variable entry `{nv}`, skipping...")
+            if len(nv) > 0:
+                nv_pair = nv.split("=")
+                if len(nv_pair) == 2:
+                    envs[nv_pair[0]] = nv_pair[1]
+                else:
+                    if logger:
+                        logger.warning(f"Could not process environment variable entry `{nv}`, skipping...")
+                    else:
+                        print(f"Could not process environment variable entry `{nv}`, skipping...")
         return envs
 
     @property

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -19,7 +19,6 @@ import entrypoints
 from abc import abstractmethod
 from elyra.util.path import get_expanded_path
 from traitlets.config import SingletonConfigurable, LoggingConfigurable
-from typing import Optional
 
 
 class PipelineProcessorRegistry(SingletonConfigurable):

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -143,6 +143,26 @@ class PipelineProcessor(LoggingConfigurable):  # ABC
     def export(self, pipeline, pipeline_export_format, pipeline_export_path, overwrite):
         raise NotImplementedError()
 
-    def log_pipeline_info(self, name: str, action_clause: str, duration_secs: Optional[float] = None):
-        duration_clause = f"({duration_secs:.3f} secs)" if duration_secs else ""
-        self.log.info(f"{self._type} pipeline '{name}' - {action_clause} {duration_clause}")
+    def log_pipeline_info(self, pipeline_name: str, action_clause: str, **kwargs):
+        """Produces a formatted log INFO message used entirely for support purposes.
+
+        This method is intended to be called for any entries that should be captured across aggregated
+        log files to identify steps within a given pipeline and each of its operations.  As a result,
+        calls to this method should produce single-line entries in the log (no embedded newlines).
+        Each entry is prefixed with the pipeline name.
+
+        General logging should NOT use this method but use logger.<level>() statements directly.
+
+        :param pipeline_name: str representing the name of the pipeline that is being executed
+        :param action_clause: str representing the action that is being logged
+        :param **kwargs: dict representing the keyword arguments.  Recognized keywords include:
+               operation_name: str representing the name of the operation applicable for this entry
+               duration: float value representing the duration of the action being logged
+        """
+        duration = kwargs.get('duration')
+        duration_clause = f"({duration:.3f} secs)" if duration else ""
+
+        operation_name = kwargs.get('operation_name')
+        op_clause = f":'{operation_name}'" if operation_name else ""
+
+        self.log.info(f"{self._type} '{pipeline_name}'{op_clause} - {action_clause} {duration_clause}")

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -19,6 +19,7 @@ import entrypoints
 from abc import abstractmethod
 from elyra.util.path import get_expanded_path
 from traitlets.config import SingletonConfigurable, LoggingConfigurable
+from typing import Optional
 
 
 class PipelineProcessorRegistry(SingletonConfigurable):
@@ -119,6 +120,8 @@ class PipelineProcessorResponse(object):
 
 class PipelineProcessor(LoggingConfigurable):  # ABC
 
+    _type = None
+
     @property
     def root_dir(self):
         return self._root_dir
@@ -139,3 +142,7 @@ class PipelineProcessor(LoggingConfigurable):  # ABC
     @abstractmethod
     def export(self, pipeline, pipeline_export_format, pipeline_export_path, overwrite):
         raise NotImplementedError()
+
+    def log_pipeline_info(self, name: str, action_clause: str, duration_secs: Optional[float] = None):
+        duration_clause = f"({duration_secs:.3f} secs)" if duration_secs else ""
+        self.log.info(f"{self._type} pipeline '{name}' - {action_clause} {duration_clause}")

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -36,9 +36,6 @@ from urllib3.exceptions import MaxRetryError
 class KfpPipelineProcessor(PipelineProcessor):
     _type = 'kfp'
 
-    def __init__(self, root_dir):
-        self.root_dir = root_dir
-
     @property
     def type(self):
         return self._type

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -231,6 +231,8 @@ class KfpPipelineProcessor(PipelineProcessor):
             pipeline_envs = dict()
             pipeline_envs['AWS_ACCESS_KEY_ID'] = cos_username
             pipeline_envs['AWS_SECRET_ACCESS_KEY'] = cos_password
+            # Convey pipeline logging enablement to operation
+            pipeline_envs['ELYRA_ENABLE_PIPELINE_INFO'] = str(self.enable_pipeline_info)
 
             if operation.env_vars:
                 for env_var in operation.env_vars:

--- a/elyra/pipeline/processor_local.py
+++ b/elyra/pipeline/processor_local.py
@@ -39,8 +39,8 @@ class LocalPipelineProcessor(PipelineProcessor):
     _operation_processor_registry: Dict
     _type = 'local'
 
-    def __init__(self, root_dir):
-        self.root_dir = root_dir
+    def __init__(self, root_dir, **kwargs):
+        super(LocalPipelineProcessor, self).__init__(root_dir, **kwargs)
         notebook_op_processor = NotebookOperationProcessor(self.root_dir)
         python_op_processor = PythonScriptOperationProcessor(self.root_dir)
         self._operation_processor_registry = {

--- a/elyra/pipeline/processor_local.py
+++ b/elyra/pipeline/processor_local.py
@@ -70,13 +70,13 @@ class LocalPipelineProcessor(PipelineProcessor):
                 t0 = time.time()
                 operation_processor = self._operation_processor_registry[operation.classifier]
                 operation_processor.process(operation)
-                duration = time.time() - t0
-                self.log_pipeline_info(pipeline.name, f"operation '{operation.name}' - completed", duration)
+                self.log_pipeline_info(pipeline.name, f"completed {operation.filename}",
+                                       operation_name=operation.name,
+                                       duration=(time.time() - t0))
             except Exception as ex:
                 raise RuntimeError(f'Error processing operation {operation.name}.') from ex
 
-        duration = time.time() - t0_all
-        self.log_pipeline_info(pipeline.name, "pipeline processed", duration)
+        self.log_pipeline_info(pipeline.name, "pipeline processed", duration=(time.time() - t0_all))
 
         return PipelineProcessorResponse('', '', '')
 

--- a/elyra/pipeline/tests/test_pipeline_processor_local.py
+++ b/elyra/pipeline/tests/test_pipeline_processor_local.py
@@ -59,7 +59,7 @@ def test_pipeline_get_envs():
     pipeline = PipelineParser().parse(pipeline_definitions)
 
     for op in pipeline.operations.values():
-        op_envs = op.env_vars_as_dict
+        op_envs = op.env_vars_as_dict()
         assert op_envs['OP_NAME'] == op.name
 
 


### PR DESCRIPTION
This change uses a base class method `log_pipeline_info()` to issue consistently formatted log messages that can be used to help diagnose where bottlenecks may be occurring or help identify other issues as pipelines are being submitted and processed.  

A similar pull request will be submitted for kfp-notebook, although the two changes are independent of each other.

A couple of bugs were fixed regarding the conversion of env_vars to a dictionary that this pull request includes since they were preventing local-mode from completing.  

Fixes #939 

Here is the output from a KFP pipeline submission and export, as well as a Local pipeline run:

**KFP Submission:**
```
[I 17:04:53.619 LabApp] kfp pipeline 'p2-1001170453' - submitting pipeline 
[I 17:04:53.624 LabApp] kfp pipeline 'p2-1001170453' - processing pipeline dependencies to: http://cloning1.fyre.ibm.com:31671 bucket: kbates folder: p2-1001170453 
[I 17:04:53.625 LabApp] kfp pipeline 'p2-1001170453' - operation 'node1' - processing operation dependencies for id: 17cdb879-d6e6-4e8d-b3b6-57ba38ff0d0e 
[I 17:04:53.647 LabApp] kfp pipeline 'p2-1001170453' - operation 'node1' - generated dependency archive: /var/folders/4w/qxgsbhyx1y93qlk9mnzwjryc0000gn/T/elyra/node1-17cdb879-d6e6-4e8d-b3b6-57ba38ff0d0e.tar.gz (0.021 secs)
[I 17:04:54.164 LabApp] kfp pipeline 'p2-1001170453' - operation 'node1' - uploaded dependency archive to: p2-1001170453/node1-17cdb879-d6e6-4e8d-b3b6-57ba38ff0d0e.tar.gz (0.151 secs)
[I 17:04:54.165 LabApp] kfp pipeline 'p2-1001170453' - operation 'node2' - processing operation dependencies for id: f43dcd72-a149-42dc-81eb-7e809ee505ae 
[I 17:04:54.178 LabApp] kfp pipeline 'p2-1001170453' - operation 'node2' - generated dependency archive: /var/folders/4w/qxgsbhyx1y93qlk9mnzwjryc0000gn/T/elyra/node2-f43dcd72-a149-42dc-81eb-7e809ee505ae.tar.gz (0.013 secs)
[I 17:04:54.544 LabApp] kfp pipeline 'p2-1001170453' - operation 'node2' - uploaded dependency archive to: p2-1001170453/node2-f43dcd72-a149-42dc-81eb-7e809ee505ae.tar.gz (0.148 secs)
[I 17:04:54.545 LabApp] kfp pipeline 'p2-1001170453' - operation 'node3' - processing operation dependencies for id: d16cc319-8201-4365-9d6c-c8e9a68e552d 
[I 17:04:54.552 LabApp] kfp pipeline 'p2-1001170453' - operation 'node3' - generated dependency archive: /var/folders/4w/qxgsbhyx1y93qlk9mnzwjryc0000gn/T/elyra/node3-d16cc319-8201-4365-9d6c-c8e9a68e552d.tar.gz (0.007 secs)
[I 17:04:54.926 LabApp] kfp pipeline 'p2-1001170453' - operation 'node3' - uploaded dependency archive to: p2-1001170453/node3-d16cc319-8201-4365-9d6c-c8e9a68e552d.tar.gz (0.155 secs)
[I 17:04:54.926 LabApp] kfp pipeline 'p2-1001170453' - pipeline dependencies processed (1.302 secs)
[I 17:04:55.876 LabApp] kfp pipeline 'p2-1001170453' - pipeline uploaded (0.918 secs)
[I 17:04:56.183 LabApp] kfp pipeline 'p2-1001170453' - pipeline submitted: http://cloning1.fyre.ibm.com:31380/pipeline/#/runs/details/66c8117f-9859-44b9-9700-2027223464e6 (2.567 secs)
```

**KFP Export:**
```
[I 15:21:02.255 LabApp] kfp pipeline 'p2' - exporting pipeline as a .yaml file
[I 15:21:02.259 LabApp] kfp pipeline 'p2' - processing pipeline dependencies to: http://cloning1.fyre.ibm.com:31671 bucket: kbates folder: p2 
[I 15:21:02.260 LabApp] kfp pipeline 'p2' - operation 'node1' - processing operation dependencies for id: 17cdb879-d6e6-4e8d-b3b6-57ba38ff0d0e 
[I 15:21:02.267 LabApp] kfp pipeline 'p2' - operation 'node1' - generated dependency archive: /var/folders/4w/qxgsbhyx1y93qlk9mnzwjryc0000gn/T/elyra/node1-17cdb879-d6e6-4e8d-b3b6-57ba38ff0d0e.tar.gz (0.008 secs)
[I 15:21:02.816 LabApp] kfp pipeline 'p2' - operation 'node1' - uploaded dependency archive to: p2/node1-17cdb879-d6e6-4e8d-b3b6-57ba38ff0d0e.tar.gz (0.315 secs)
[I 15:21:02.817 LabApp] kfp pipeline 'p2' - operation 'node2' - processing operation dependencies for id: f43dcd72-a149-42dc-81eb-7e809ee505ae 
[I 15:21:02.824 LabApp] kfp pipeline 'p2' - operation 'node2' - generated dependency archive: /var/folders/4w/qxgsbhyx1y93qlk9mnzwjryc0000gn/T/elyra/node2-f43dcd72-a149-42dc-81eb-7e809ee505ae.tar.gz (0.007 secs)
[I 15:21:03.238 LabApp] kfp pipeline 'p2' - operation 'node2' - uploaded dependency archive to: p2/node2-f43dcd72-a149-42dc-81eb-7e809ee505ae.tar.gz (0.190 secs)
[I 15:21:03.239 LabApp] kfp pipeline 'p2' - operation 'node3' - processing operation dependencies for id: d16cc319-8201-4365-9d6c-c8e9a68e552d 
[I 15:21:03.246 LabApp] kfp pipeline 'p2' - operation 'node3' - generated dependency archive: /var/folders/4w/qxgsbhyx1y93qlk9mnzwjryc0000gn/T/elyra/node3-d16cc319-8201-4365-9d6c-c8e9a68e552d.tar.gz (0.007 secs)
[I 15:21:03.612 LabApp] kfp pipeline 'p2' - operation 'node3' - uploaded dependency archive to: p2/node3-d16cc319-8201-4365-9d6c-c8e9a68e552d.tar.gz (0.151 secs)
[I 15:21:03.613 LabApp] kfp pipeline 'p2' - pipeline dependencies processed (1.354 secs)
[I 15:21:03.643 LabApp] kfp pipeline 'p2' - pipeline exported: elyra/pipeline1/p2.yaml (1.392 secs)
```

**Local Run:**
```
[I 16:17:06.652 LabApp] local pipeline 'p2' - processing pipeline 
[I 16:17:09.684 LabApp] local pipeline 'p2' - operation 'node1' - completed (3.032 secs)
[I 16:17:12.082 LabApp] local pipeline 'p2' - operation 'node2' - completed (2.398 secs)
[I 16:17:14.469 LabApp] local pipeline 'p2' - operation 'node3' - completed (2.386 secs)
[I 16:17:14.469 LabApp] local pipeline 'p2' - pipeline processed (7.817 secs)
```


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

