### PR TITLE
Improve subprocess error handling

### DIFF
--- a/elyra/pipeline/processor_local.py
+++ b/elyra/pipeline/processor_local.py
@@ -170,7 +170,7 @@ class NotebookOperationProcessor(FileOperationProcessor):
         super(NotebookOperationProcessor, self).__init__(root_dir)
 
     def _create_execute_command(self, filepath: str, cdw: str) -> list:
-        return ['papermill', filepath, filepath, '--cwd', cdw, '--no-progress-bar']
+        return ['papermill', filepath, filepath, '--cwd', cdw]
 
 
 class PythonScriptOperationProcessor(FileOperationProcessor):

--- a/elyra/pipeline/processor_local.py
+++ b/elyra/pipeline/processor_local.py
@@ -14,12 +14,12 @@
 # limitations under the License.
 #
 import os
-import subprocess
 import time
 
 from abc import ABC, abstractmethod
 from elyra.pipeline import PipelineProcessor, PipelineProcessorResponse, Operation
 from elyra.util.path import get_absolute_path
+from subprocess import run, CalledProcessError
 from traitlets import log
 from typing import Dict
 
@@ -148,9 +148,10 @@ class FileOperationProcessor(OperationProcessor):
         envs = operation.env_vars_as_dict
         t0 = time.time()
         try:
-            subprocess.run(argv, cwd=file_dir, env=envs, check=True)
+            run(argv, cwd=file_dir, env=envs, capture_output=True, check=True)
+        except CalledProcessError as ex:
+            raise RuntimeError(f'Internal error executing {filepath}: {ex.stderr.decode("unicode_escape")}') from ex
         except Exception as ex:
-            self.log.error(f'Internal error executing {filepath}')
             raise RuntimeError(f'Internal error executing {filepath}') from ex
 
         t1 = time.time()
@@ -169,7 +170,7 @@ class NotebookOperationProcessor(FileOperationProcessor):
         super(NotebookOperationProcessor, self).__init__(root_dir)
 
     def _create_execute_command(self, filepath: str, cdw: str) -> list:
-        return ['papermill', filepath, filepath, '--cwd', cdw]
+        return ['papermill', filepath, filepath, '--cwd', cdw, '--no-progress-bar']
 
 
 class PythonScriptOperationProcessor(FileOperationProcessor):


### PR DESCRIPTION
This change improves the messages that users receive when encountering issues during node operation failures.  

For both notebook and python processes, the `capture_output` parameter has been enabled which results in the raised error object instance representing the error in its `stderr` property.  This property value is then decoded to unescape newlines - and stderr becomes part of the message that hereto now only appeared in the server log file - as discussed on #951.

For notebook operations, it also turns off the progress bar output of the `papermill` command that had been captured in the log file and was included in the `stderr` property following the previous change.  

Fixes #951 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

