### PR TITLE
Update Binder build config (option 1)

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -37,10 +37,17 @@ jupyter labextension link --no-build packages/application/
 jupyter labextension link --no-build packages/ui-components/
 jupyter labextension link --no-build packages/metadata-common/
 jupyter lab build --dev-build=False --minimize=False --debug
+
+pwd
+
 mkdir -p binder-demo
 
 # Enable debug output
 set -x
+
+# Hack option 2: "hide" the fact that the root directory is a cloned github repository
+# by removing the git related files
+rm -rf ~/.git*
 
 # Add getting started assets to Docker image
 # (1) Clone the examples repository.

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -43,7 +43,7 @@ mkdir -p binder-demo
 # Enable debug output
 set -x
 
-# repo2docker clones the Elyra repository before the Docker image is build
+# repo2docker clones the Elyra repository before the Docker image is built
 # and uses the cloned directory as "root". The git extension recognizes that
 # the directory is git-enabled and therefore prevents the user from 
 # cloning other repositories using the UI. Remove the git artifacts in the

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -38,15 +38,16 @@ jupyter labextension link --no-build packages/ui-components/
 jupyter labextension link --no-build packages/metadata-common/
 jupyter lab build --dev-build=False --minimize=False --debug
 
-pwd
-
 mkdir -p binder-demo
 
 # Enable debug output
 set -x
 
-# Hack option 2: "hide" the fact that the root directory is a cloned github repository
-# by removing the git related files
+# repo2docker clones the Elyra repository before the Docker image is build
+# and uses the cloned directory as "root". The git extension recognizes that
+# the directory is git-enabled and therefore prevents the user from 
+# cloning other repositories using the UI. Remove the git artifacts in the
+# root directory to work around this issue. 
 rm -rf ~/.git*
 
 # Add getting started assets to Docker image


### PR DESCRIPTION
This PR updates the Binder build file removing git related directories to hide the fact that the work directory itself is a cloned git repository. See #962 for details and other approaches that didn't seem to yield the desired result.

Closes #962 



Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

