### PR TITLE
Code Snippet should insert new cell after inserting a snippet

### DIFF
--- a/packages/code-snippet/src/CodeSnippetWidget.tsx
+++ b/packages/code-snippet/src/CodeSnippetWidget.tsx
@@ -103,6 +103,8 @@ class CodeSnippetDisplay extends MetadataDisplay<ICodeSnippetDisplayProps> {
     } else if (widget instanceof NotebookPanel) {
       const notebookWidget = widget as NotebookPanel;
       const notebookCell = (notebookWidget.content as Notebook).activeCell;
+      const notebookCellIndex = (notebookWidget.content as Notebook)
+        .activeCellIndex;
       const notebookCellEditor = notebookCell.editor;
 
       if (notebookCell instanceof CodeCell) {
@@ -125,6 +127,8 @@ class CodeSnippetDisplay extends MetadataDisplay<ICodeSnippetDisplayProps> {
       } else {
         notebookCellEditor.replaceSelection(snippetStr);
       }
+      const cell = notebookWidget.model.contentFactory.createCodeCell({});
+      notebookWidget.model.cells.insert(notebookCellIndex + 1, cell);
     } else {
       this.showErrDialog('Code snippet insert failed: Unsupported widget');
     }


### PR DESCRIPTION
When the user inserts a code-snippet into an "existing" cell, it most likely will need to work on something else on a new cell. The idea here is to give the user the same env as he started before adding the snippet (with a new cell to work on), similar to how Notebook does when you are on the last cell of the notebook where it creates a new one.  

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

