### PR TITLE
Remove use of capture_output - not available in py 3.6

### DIFF
--- a/elyra/pipeline/processor_local.py
+++ b/elyra/pipeline/processor_local.py
@@ -19,7 +19,7 @@ import time
 from abc import ABC, abstractmethod
 from elyra.pipeline import PipelineProcessor, PipelineProcessorResponse, Operation
 from elyra.util.path import get_absolute_path
-from subprocess import run, CalledProcessError
+from subprocess import run
 from traitlets import log
 from typing import Dict
 
@@ -148,11 +148,9 @@ class FileOperationProcessor(OperationProcessor):
         argv = self._create_execute_command(filepath, file_dir)
         envs = operation.env_vars_as_dict(self.log)
         try:
-            run(argv, cwd=file_dir, env=envs, capture_output=True, check=True)
-        except CalledProcessError as ex:
-            raise RuntimeError(f'Internal error executing {filepath}: {ex.stderr.decode("unicode_escape")}') from ex
+            run(argv, cwd=file_dir, env=envs, check=True)
         except Exception as ex:
-            raise RuntimeError(f'Internal error executing {filepath}') from ex
+            raise RuntimeError(f'Internal error executing {filepath}: {ex}') from ex
 
     @abstractmethod
     def _create_execute_command(self, filepath: str, cdw: str) -> list:


### PR DESCRIPTION
This is essentially a rollback of #955.  When making that change I failed to realize that the subprocess `run` argument `capture_output` was only available in Python versions >= 3.7.  I happened to run on Python 3.6 and got an error.  This also implies we need to fix up our local processor tests since we _should_ be able to run something locally.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

