### PR TITLE
Add local pipeline execution tests and utilities

### DIFF
--- a/elyra/pipeline/tests/resources/node_util/__init__.py
+++ b/elyra/pipeline/tests/resources/node_util/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright 2018-2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .node_util import NotebookNode, PythonNode

--- a/elyra/pipeline/tests/resources/node_util/__init__.py
+++ b/elyra/pipeline/tests/resources/node_util/__init__.py
@@ -14,3 +14,4 @@
 # limitations under the License.
 #
 from .node_util import NotebookNode, PythonNode
+

--- a/elyra/pipeline/tests/resources/node_util/node.ipynb
+++ b/elyra/pipeline/tests/resources/node_util/node.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pipeline NotebookNode\n",
+    "This notebook will represent a single node of a pipeline.  It will be completely driven via the following environment variables configured on the node properties dialog of the pipeline:\n",
+    "- `NODE_FILENAME`: (Required) The filename associated with the node.  The extension is used to validate that the node matches the associated file.  The basename portion represents the node name - and is used in producing the output files.\n",
+    "- `INPUT_FILENAMES`: (Optional) A SEMI-COLON-separated list of filenames.  Each entry can include a _relative_ path as a prefix to the filename.  Each file is expected to exist and contain content.  The content will be printed and should appear in the out of a cell.\n",
+    "- `OUTPUT_FILENAMES`: (Optional) A SEMI-COLON-separated list of filenames.  Each entry can include a _relative_ path as a prefix to the filename.  Each file is NOT expected to exist, but will be created as a function of the notebook's execution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from node_util import NotebookNode\n",
+    "# These getenv calls are here to help seed the environment variables \n",
+    "# dialog in the node properties of the pipeline editor\n",
+    "os.getenv(\"NODE_FILENAME\")\n",
+    "os.getenv(\"INPUT_FILENAMES\")\n",
+    "os.getenv(\"OUTPUT_FILENAMES\")\n",
+    "# Execute the node\n",
+    "NotebookNode().run()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/elyra/pipeline/tests/resources/node_util/node.py
+++ b/elyra/pipeline/tests/resources/node_util/node.py
@@ -1,0 +1,33 @@
+#
+# Copyright 2018-2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Pipeline PythonNode
+
+This python script will represent a single node of a pipeline.  It will be completely driven via the following environment variables configured on the node properties dialog of the pipeline:
+- `NODE_FILENAME`: (Required) The filename associated with the node.  The extension is used to validate that the node matches the associated file.  The basename portion represents the node name - and is used in producing the output files.
+- `INPUT_FILENAMES`: (Optional) A SEMI-COLON-separated list of filenames.  Each entry can include a _relative_ path as a prefix to the filename.  Each file is expected to exist and contain content.  The content will be printed and should appear in the out of a cell.
+- `OUTPUT_FILENAMES`: (Optional) A SEMI-COLON-separated list of filenames.  Each entry can include a _relative_ path as a prefix to the filename.  Each file is NOT expected to exist, but will be created as a function of the notebook's execution.
+"""
+import os
+from node_util import PythonNode
+
+# These getenv calls are here to help seed the environment variables 
+# dialog in the node properties of the pipeline editor
+os.getenv("NODE_FILENAME")
+os.getenv("INPUT_FILENAMES")
+os.getenv("OUTPUT_FILENAMES")
+# Execute the node
+PythonNode().run()

--- a/elyra/pipeline/tests/resources/node_util/node_util.py
+++ b/elyra/pipeline/tests/resources/node_util/node_util.py
@@ -1,0 +1,159 @@
+#
+# Copyright 2018-2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+import os
+
+from abc import ABC, abstractmethod
+from typing import List
+
+
+class NodeFile():
+    """Base class for input and output node files"""
+    def __init__(self, filename: str) -> None:
+        self.filename = filename
+        
+        
+class InputNodeFile(NodeFile):
+    """Given a filename, it ensures the file exists and can read its contents."""
+    def __init__(self, filename: str) -> None:
+        super(InputNodeFile, self).__init__(filename)
+        self.data = None
+        
+        if not os.path.exists(self.filename):
+            raise FileNotFoundError("File '{}' does not exist!".format(self.filename))
+    
+    def read(self) -> str:
+        with open(self.filename) as f:
+            self.data = f.read()
+        return self.data
+    
+    def data(self) -> str:
+        return self.data
+    
+
+class OutputNodeFile(NodeFile):
+    """Given a filename, it ensures the file does not exist and will write data to that file."""
+    def __init__(self, filename: str) -> None:
+        super(OutputNodeFile, self).__init__(filename)
+        
+        #if os.path.exists(self.filename):
+        #    raise FileExistsError("File '{}' already exists!".format(self.filename))
+    
+    def write(self, data) -> None:
+        with open(self.filename, 'w+') as f:
+            f.write(data)
+
+
+class ExecutionNode(ABC):
+    """Represents an excutable node of a pipeline.  This class must be subclassed."""
+
+    node_name = None
+    filename = None
+    extension = None
+
+    def __init__(self) -> None:
+        self.filename = os.getenv('NODE_FILENAME')
+        if not self.filename:
+            raise ValueError("NODE_FILENAME environment variable must be set!")
+
+        node_file_splits = os.path.basename(self.filename).split(".")
+        self.node_name = node_file_splits[0]
+        self.extension = node_file_splits[1]
+        self.validate()
+
+    def validate(self) -> None:
+        """Validate the filename as best as possible, depending on subclass. """
+
+        # Validate its extension and that the file exists.
+        self.validate_extension()
+        if not os.path.exists(self.filename):
+            raise FileNotFoundError("ExecutionNode filename '{}' does not exist!".format(self.filename))
+
+    def run(self) -> None:
+        self.process_inputs("INPUT_FILENAMES")
+        self.perform_experiment()
+        self.process_outputs("OUTPUT_FILENAMES")
+
+    def perform_experiment(self) -> None:
+        """Emulates the experiment to run."""
+        print("NODE_NAME: {}".format(self.node_name))
+
+    def process_inputs(self, env_var: str) -> List[InputNodeFile]:
+        """Given an environment variable `env_var`, that contains a SEMI-COLON-separated
+           list of filenames, it processes each entry by instantiating an instance of
+           InputNodeFile corresponding to each entry and returns the list of instances.
+        """
+        inputs = []
+        filenames = os.getenv(env_var, "").split(';')
+
+        for filename in filenames:
+            if filename:
+                inputs.append(InputNodeFile(filename))
+
+        for input_file in inputs:
+            print("FROM: {}".format(input_file.read()))
+
+        return inputs
+
+    def process_outputs(self, env_var: str) -> List[OutputNodeFile]:
+        """Given an environment variable `env_var`, that contains a SEMI-COLON-separated
+           list of filenames, it processes each entry by instantiating an instance of
+           OutputNodeFile corresponding to each entry and returns the list of instances.
+        """
+        outputs = []
+        filenames = os.getenv(env_var, "").split(';')
+
+        for filename in filenames:
+            if filename:
+                outputs.append(OutputNodeFile(filename))
+
+
+        for output_file in outputs:
+            output_file.write(self.node_name)
+
+        return outputs
+
+    @abstractmethod
+    def expected_extension(self) -> str:
+        raise NotImplementedError("Method 'expected_extension()' must be implemented by subclass '{}'!".
+                                  format(self.__class__.__name__))
+
+    def validate_extension(self) -> None:
+        if self.expected_extension() != self.extension:
+            raise ValueError("Filename '{}' does not have a proper extension: '{}'".
+                             format(self.filename, self.expected_extension()))
+
+
+class NotebookNode(ExecutionNode):
+    """Represents a Notebook execution node of a pipeline."""
+
+    def expected_extension(self) -> str:
+        return "ipynb"
+
+    def validate(self) -> None:
+        """For notebooks, we can also ensure the file can be loaded as JSON."""
+        super(NotebookNode, self).validate()
+
+        # Confirm file can be loaded as JSON
+        with open(self.filename) as f:
+            json.load(f)
+
+
+class PythonNode(ExecutionNode):
+    """Represents a Python file execution node of a pipeline."""
+
+    def expected_extension(self) -> str:
+        return "py"

--- a/elyra/pipeline/tests/test_pipeline_processor_local.py
+++ b/elyra/pipeline/tests/test_pipeline_processor_local.py
@@ -13,9 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
+import pytest
+
 from elyra.pipeline import PipelineParser
 from elyra.pipeline.processor_local import LocalPipelineProcessor
-from .util import _read_pipeline_resource
+from .util import _read_pipeline_resource, NotebookNode, PythonNode, construct_pipeline
+
+
+@pytest.fixture
+def pipeline_dir(tmp_path):
+    pipeline_path = os.path.join(tmp_path, "pipeline")
+    os.makedirs(pipeline_path)
+    return pipeline_path
 
 
 def test_pipeline_execution_order_in_complex_pipeline():
@@ -61,6 +71,78 @@ def test_pipeline_get_envs():
     for op in pipeline.operations.values():
         op_envs = op.env_vars_as_dict()
         assert op_envs['OP_NAME'] == op.name
+
+
+def test_pipeline_execution(pipeline_dir):
+    # Construct 4-node pipeline consisting of 3 notebooks and 1 python script.
+    # This pipeline is "diamond shaped" with node1 feeding nodes 2 and 3, each then
+    # feeding node4.
+    node1 = NotebookNode("node1", num_outputs=2)
+    node2 = PythonNode("node2", num_outputs=2, input_nodes=[node1])
+    node3 = NotebookNode("node3", num_outputs=2, input_nodes=[node1])
+    node4 = NotebookNode("node4", num_outputs=2, input_nodes=[node2, node3])
+    nodes = [node1, node2, node3, node4]
+
+    pipeline = construct_pipeline("p1", nodes=nodes, location=pipeline_dir)
+
+    LocalPipelineProcessor(pipeline_dir).process(pipeline)
+
+    # Confirm outputs
+    for node in nodes:
+        for output in node.outputs:
+            assert os.path.exists(os.path.join(pipeline_dir, output))
+
+
+def test_pipeline_execution_bad_notebook(pipeline_dir):
+    # Construct 4-node pipeline where node 3 (nodebook) produces a failure
+    node1 = NotebookNode("node1", num_outputs=2)
+    node2 = PythonNode("node2", num_outputs=2, input_nodes=[node1])
+    node3 = NotebookNode("node3", num_outputs=2, input_nodes=[node1], fail=True)
+    node4 = NotebookNode("node4", num_outputs=2, input_nodes=[node2, node3])
+    nodes = [node1, node2, node3, node4]
+    processed_nodes = [node1, node2]
+    unprocessed_nodes = [node3, node4]
+
+    pipeline = construct_pipeline("p1", nodes=nodes, location=pipeline_dir)
+
+    with pytest.raises(RuntimeError) as e:
+        LocalPipelineProcessor(pipeline_dir).process(pipeline)
+    assert str(e.value) == 'Error processing operation node3.'
+
+    # Confirm outputs (and non-outputs)
+    for node in processed_nodes:
+        for output in node.outputs:
+            assert os.path.exists(os.path.join(pipeline_dir, output))
+
+    for node in unprocessed_nodes:
+        for output in node.outputs:
+            assert not os.path.exists(os.path.join(pipeline_dir, output))
+
+
+def test_pipeline_execution_bad_python(pipeline_dir):
+    # Construct 4-node pipeline where node 2 (python) produces a failure
+    node1 = NotebookNode("node1", num_outputs=2)
+    node2 = PythonNode("node2", num_outputs=2, input_nodes=[node1], fail=True)
+    node3 = NotebookNode("node3", num_outputs=2, input_nodes=[node1])
+    node4 = NotebookNode("node4", num_outputs=2, input_nodes=[node2, node3])
+    nodes = [node1, node2, node3, node4]
+    processed_nodes = [node1]
+    unprocessed_nodes = [node2, node3, node4]
+
+    pipeline = construct_pipeline("p1", nodes=nodes, location=pipeline_dir)
+
+    with pytest.raises(RuntimeError) as e:
+        LocalPipelineProcessor(pipeline_dir).process(pipeline)
+    assert str(e.value) == 'Error processing operation node2.'
+
+    # Confirm outputs (and non-outputs)
+    for node in processed_nodes:
+        for output in node.outputs:
+            assert os.path.exists(os.path.join(pipeline_dir, output))
+
+    for node in unprocessed_nodes:
+        for output in node.outputs:
+            assert not os.path.exists(os.path.join(pipeline_dir, output))
 
 
 def _get_operation_names(operations):

--- a/elyra/pipeline/tests/util.py
+++ b/elyra/pipeline/tests/util.py
@@ -108,22 +108,22 @@ def construct_pipeline(name: str, nodes: List[NodeBase], location,
                        runtime_type: Optional[str] = 'local',
                        runtime_config: Optional[str] = 'local') -> Pipeline:
     """Returns an instance of a local Pipeline consisting of each node and populates the
-       specified location with the necessary files to run the pipeline form that location.
+       specified location with the necessary files to run the pipeline from that location.
     """
     pipeline = Pipeline(str(uuid.uuid4()), name, runtime_type, runtime_config)
     for node in nodes:
         pipeline.operations[node.id] = node.get_operation()
-        # get the file into position
+        # copy the node file into the "working directory"
         if isinstance(node, NotebookNode):
-            shutil.copy(os.path.join(os.path.dirname(__file__), 'resources/node_util/node.ipynb'),
-                        os.path.join(location, node.filename))
+            src_file = os.path.join(os.path.dirname(__file__), 'resources/node_util/node.ipynb')
         elif isinstance(node, PythonNode):
-            shutil.copy(os.path.join(os.path.dirname(__file__), 'resources/node_util/node.py'),
-                        os.path.join(location, node.filename))
+            src_file = os.path.join(os.path.dirname(__file__), 'resources/node_util/node.py')
         else:
             assert False, f"Invalid node type detected: {node.__class__.__name__}"
 
-    # copy the node_util directory to location
+        shutil.copy(src_file, os.path.join(location, node.filename))
+
+    # copy the node_util directory into the "working directory"
     shutil.copytree(os.path.join(os.path.dirname(__file__), 'resources/node_util'), os.path.join(location, 'node_util'))
 
     return pipeline

--- a/elyra/pipeline/tests/util.py
+++ b/elyra/pipeline/tests/util.py
@@ -15,6 +15,11 @@
 #
 import os
 import json
+import shutil
+import uuid
+
+from typing import Optional, List, Any
+from elyra.pipeline.pipeline import Operation, Pipeline
 
 
 def _read_pipeline_resource(pipeline_filename):
@@ -25,3 +30,93 @@ def _read_pipeline_resource(pipeline_filename):
         pipeline_json = json.load(f)
 
     return pipeline_json
+
+
+class NodeBase:
+    """Represents a node of a constructed pipeline based on files in resources/node_util. """
+    id: str
+    name: str
+    outputs: List[str]
+    dependencies: List[str]
+    env_vars = List[str]
+    fail: bool
+    # from subclasses
+    classifier: str
+    filename: str
+
+    def __init__(self, name: str, num_outputs: Optional[int] = 0,
+                 input_nodes: Optional[List[Any]] = None,
+                 fail: Optional[bool] = False):
+        self.id = str(uuid.uuid4())
+        self.name = name
+        self.fail = fail
+        self.outputs = []
+        for i in range(1, num_outputs+1):
+            self.outputs.append(f"{self.name}_{i}.out")
+
+        self.inputs = []
+        self.parent_operations = []
+        if input_nodes:
+            for node in input_nodes:
+                self.inputs.extend(node.outputs)
+                self.parent_operations.append(node.id)
+
+        self.dependencies = ['node_util/*']
+
+    def get_operation(self) -> Operation:
+
+        self.env_vars = []
+        if not self.fail:  # NODE_FILENAME is required, so skip if triggering failure
+            self.env_vars.append(f"NODE_FILENAME={self.filename}")
+        if self.inputs:
+            self.env_vars.append(f"INPUT_FILENAMES={';'.join(self.inputs)}")
+        if self.outputs:
+            self.env_vars.append(f"OUTPUT_FILENAMES={';'.join(self.outputs)}")
+
+        return Operation(self.id, 'execution_node', self.classifier, self.filename, "elyra-test-NA",
+                         dependencies=self.dependencies, env_vars=self.env_vars,
+                         inputs=self.inputs, outputs=self.outputs,
+                         parent_operations=self.parent_operations)
+
+
+class NotebookNode(NodeBase):
+    def __init__(self, name: str, num_outputs: Optional[int] = 0,
+                 input_nodes: Optional[List[Any]] = None,
+                 fail: Optional[bool] = False):
+
+        super().__init__(name, num_outputs, input_nodes, fail)
+        self.classifier = 'execute-notebook-node'
+        self.filename = f"{self.name}.ipynb"
+
+
+class PythonNode(NodeBase):
+    def __init__(self, name: str, num_outputs: Optional[int] = 0,
+                 input_nodes: Optional[List[Any]] = None,
+                 fail: Optional[bool] = False):
+
+        super().__init__(name, num_outputs, input_nodes, fail)
+        self.classifier = 'execute-python-node'
+        self.filename = f"{self.name}.py"
+
+
+def construct_pipeline(name: str, nodes: List[NodeBase], location) -> Pipeline:
+    """Returns an instance of a local Pipeline consisting of each node and populates the
+       specified location with the necessary files to run the pipeline form that location.
+    """
+    pipeline = Pipeline(str(uuid.uuid4()), name, 'local', 'local')
+    for node in nodes:
+        pipeline.operations[node.id] = node.get_operation()
+        # get the file into position
+        if isinstance(node, NotebookNode):
+            shutil.copy(os.path.join(os.path.dirname(__file__), 'resources/node_util/node.ipynb'),
+                        os.path.join(location, node.filename))
+        elif isinstance(node, PythonNode):
+            shutil.copy(os.path.join(os.path.dirname(__file__), 'resources/node_util/node.py'),
+                        os.path.join(location, node.filename))
+        else:
+            assert False, f"Invalid node type detected: {node.__class__.__name__}"
+
+    # copy the node_util directory to location
+    shutil.copytree(os.path.join(os.path.dirname(__file__), 'resources/node_util'), os.path.join(location, 'node_util'))
+
+    return pipeline


### PR DESCRIPTION
This adds 3 local pipeline tests - one successful, two failures.  It also adds the ability to construct various pipeline structures of notebook or python script nodes/operations.

The recent fixes for local pipeline failures were (temporarily) reintroduced during my testing to confirm the successful test would fail, and it did for both cases.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

