### PR TITLE
Add python script to unsupported files message

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -802,7 +802,7 @@ export class PipelineEditor extends React.Component<
       return showDialog({
         title: 'Unsupported File(s)',
         body:
-          'Currently, only selected notebook files can be added to a pipeline',
+          'Currently, only selected notebook and python script files can be added to a pipeline',
         buttons: [Dialog.okButton()]
       });
     }


### PR DESCRIPTION
While testing the lab 3.0 branch I found the 'unsupported files' message required an update from:
![Screen Shot 2020-10-27 at 2 32 52 PM](https://user-images.githubusercontent.com/22599560/97365107-60832080-1862-11eb-8f37-9b880c7dda63.png)

to:
![Screen Shot 2020-10-27 at 2 33 19 PM](https://user-images.githubusercontent.com/22599560/97365117-6547d480-1862-11eb-9da7-f41f06474255.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

