### PR TITLE
Fix jest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@4tw/cypress-drag-drop": "^1.3.1",
     "@cypress/webpack-preprocessor": "^4.1.5",
-    "@jupyterlab/testutils": "^2.2.4",
+    "@jupyterlab/testutils": "^3.0.0-rc.6",
     "@types/enzyme": "^3.10.5",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^26.0.9",


### PR DESCRIPTION
Fixes the jest test failures by updating the testutils version. Changes to using port 8890 by default for tests to avoid conflicts when JupyterLab is running. 

Edit: no longer changes the port used by tests because of #1024 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that: 799189
       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

