### PR TITLE
add tags and descriptions to default runtime images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ docker-image: ## Build docker image
 validate-runtime-images: ## Validates delivered runtime-images meet minimum criteria
 	@required_commands=$(REQUIRED_RUNTIME_IMAGE_COMMANDS) ; \
 	for file in `find etc/config/metadata/runtime-images -name "*.json"` ; do \
-		image=`grep image_name $$file | awk '{print $$2}' | sed s/\"//g` ; \
+		image=`grep image_name $$file | awk '{print $$2}' | sed s/\"//g | sed s/,//g` ; \
 		fail=0; \
 		for cmd in $$required_commands ; do \
 			echo Checking $$image in $$file for $$cmd... ; \

--- a/Makefile
+++ b/Makefile
@@ -155,8 +155,13 @@ docker-image: ## Build docker image
 
 validate-runtime-images: ## Validates delivered runtime-images meet minimum criteria
 	@required_commands=$(REQUIRED_RUNTIME_IMAGE_COMMANDS) ; \
+	pip install jq ; \
 	for file in `find etc/config/metadata/runtime-images -name "*.json"` ; do \
-		image=`grep image_name $$file | awk '{print $$2}' | sed s/\"//g | sed s/,//g` ; \
+		image=`cat $$file | jq -e -r '.metadata.image_name'` ; \
+		if [ $$? -ne 0 ]; then \
+			echo ERROR: $$file does not define the image_name property ; \
+			exit 1; \
+		fi; \
 		fail=0; \
 		for cmd in $$required_commands ; do \
 			echo Checking $$image in $$file for $$cmd... ; \

--- a/etc/config/metadata/runtime-images/anaconda.json
+++ b/etc/config/metadata/runtime-images/anaconda.json
@@ -1,7 +1,11 @@
 {
   "display_name": "Anaconda (2020.07) with Python 3.x",
   "metadata": {
-    "image_name": "continuumio/anaconda3:2020.07"
+    "description": "Anaconda 2020.07",
+    "image_name": "continuumio/anaconda3:2020.07",
+    "tags": [
+      "anaconda"
+    ]
   },
   "schema_name": "runtime-image"
 }

--- a/etc/config/metadata/runtime-images/pandas.json
+++ b/etc/config/metadata/runtime-images/pandas.json
@@ -1,7 +1,11 @@
 {
   "display_name": "Pandas 1.1.1",
   "metadata": {
-    "image_name": "amancevice/pandas:1.1.1"
+    "description": "Pandas 1.1.1",
+    "image_name": "amancevice/pandas:1.1.1",
+    "tags": [
+      "pandas"
+    ]
   },
   "schema_name": "runtime-image"
 }

--- a/etc/config/metadata/runtime-images/pytorch-devel.json
+++ b/etc/config/metadata/runtime-images/pytorch-devel.json
@@ -1,7 +1,12 @@
 {
   "display_name": "Pytorch 1.4 with CUDA-devel",
   "metadata": {
-    "image_name": "pytorch/pytorch:1.4-cuda10.1-cudnn7-devel"
+    "description": "PyTorch 1.4 (with GPU support)",
+    "image_name": "pytorch/pytorch:1.4-cuda10.1-cudnn7-devel",
+    "tags": [
+      "gpu",
+      "pytorch"
+    ]
   },
   "schema_name": "runtime-image"
 }

--- a/etc/config/metadata/runtime-images/pytorch-runtime.json
+++ b/etc/config/metadata/runtime-images/pytorch-runtime.json
@@ -1,7 +1,12 @@
 {
   "display_name": "Pytorch 1.4 with CUDA-runtime",
   "metadata": {
-    "image_name": "pytorch/pytorch:1.4-cuda10.1-cudnn7-runtime"
+    "description": "PyTorch 1.4 (with GPU support)",
+    "image_name": "pytorch/pytorch:1.4-cuda10.1-cudnn7-runtime",
+    "tags": [
+      "gpu",
+      "pytorch"
+    ]
   },
   "schema_name": "runtime-image"
 }

--- a/etc/config/metadata/runtime-images/tensorflow_2x_gpu_py3.json
+++ b/etc/config/metadata/runtime-images/tensorflow_2x_gpu_py3.json
@@ -1,7 +1,12 @@
 {
   "display_name": "Tensorflow 2.3.0 with GPU",
   "metadata": {
-    "image_name": "tensorflow/tensorflow:2.3.0-gpu"
+    "description": "TensorFlow 2.3 (with GPU support)",
+    "image_name": "tensorflow/tensorflow:2.3.0-gpu",
+    "tags": [
+      "gpu",
+      "tensorflow"
+    ]  
   },
   "schema_name": "runtime-image"
 }

--- a/etc/config/metadata/runtime-images/tensorflow_2x_py3.json
+++ b/etc/config/metadata/runtime-images/tensorflow_2x_py3.json
@@ -1,7 +1,11 @@
 {
   "display_name": "Tensorflow 2.3.0",
   "metadata": {
-    "image_name": "tensorflow/tensorflow:2.3.0"
+    "description": "TensorFlow 1.15",
+    "image_name": "tensorflow/tensorflow:2.3.0",
+    "tags": [
+      "tensorflow"
+    ]
   },
   "schema_name": "runtime-image"
 }

--- a/etc/config/metadata/runtime-images/tensorflow_2x_py3.json
+++ b/etc/config/metadata/runtime-images/tensorflow_2x_py3.json
@@ -1,7 +1,7 @@
 {
   "display_name": "Tensorflow 2.3.0",
   "metadata": {
-    "description": "TensorFlow 1.15",
+    "description": "TensorFlow 2.3",
     "image_name": "tensorflow/tensorflow:2.3.0",
     "tags": [
       "tensorflow"

--- a/etc/config/metadata/runtime-images/tensorflow_gpu_py3.json
+++ b/etc/config/metadata/runtime-images/tensorflow_gpu_py3.json
@@ -1,7 +1,12 @@
 {
   "display_name": "Tensorflow 1.15.2 with GPU",
   "metadata": {
-    "image_name": "elyra/tensorflow:1.15.2-gpu-py3"
+    "description": "TensorFlow 1.15 (with GPU support)",
+    "image_name": "elyra/tensorflow:1.15.2-gpu-py3",
+    "tags": [
+      "gpu",
+      "tensorflow"
+    ]    
   },
   "schema_name": "runtime-image"
 }

--- a/etc/config/metadata/runtime-images/tensorflow_py3.json
+++ b/etc/config/metadata/runtime-images/tensorflow_py3.json
@@ -1,7 +1,11 @@
 {
   "display_name": "Tensorflow 1.15.2",
   "metadata": {
-    "image_name": "elyra/tensorflow:1.15.2-py3"
+    "description": "TensorFlow 1.15",
+    "image_name": "elyra/tensorflow:1.15.2-py3",
+    "tags": [
+      "tensorflow"
+    ]
   },
   "schema_name": "runtime-image"
 }


### PR DESCRIPTION
This PR
 - adds tags and descriptions to all pre-defined runtime images
 - updates the `Makefile` to address a parsing error that was triggered by above changes
 - closes #1022 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

