### PR TITLE
Update UI integration tests to use non-standard port

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:8888/lab",
+  "baseUrl": "http://localhost:58888/lab",
   "integrationFolder": "./tests/integration",
   "supportFile": false,
   "pluginsFile": "./tests/plugins/index.js",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "prettier": "prettier --ignore-path .gitignore --write \"**/*{.ts,.tsx,.js,.jsx,.css,.json}\"",
     "prettier:check": "prettier --ignore-path .gitignore --check \"**/*{.ts,.tsx,.js,.jsx,.css,.json}\"",
     "start-jupyter": "mkdir -p build/cypress-tests && jupyter lab --config=./tests/test-config.py",
-    "test:integration": "start-server-and-test start-jupyter http-get://localhost:8888?token=test cy:run",
-    "test:integration:debug": "start-server-and-test start-jupyter http-get://localhost:8888?token=test cy:open",
+    "test:integration": "start-server-and-test start-jupyter http-get://localhost:58888?token=test cy:run",
+    "test:integration:debug": "start-server-and-test start-jupyter http-get://localhost:58888?token=test cy:open",
     "test:unit": "lerna run test --scope \"@elyra/*\" --concurrency 1 --stream",
     "test": "npm run test:unit && npm run test:integration"
   },

--- a/tests/test-config.py
+++ b/tests/test-config.py
@@ -16,6 +16,7 @@
 c.Session.debug = True
 c.LabApp.token = 'test'
 c.LabApp.open_browser = False
+c.NotebookApp.port = 58888
 c.NotebookApp.port_retries = 0
 c.LabApp.workspaces_dir = './build/cypress-tests'
 c.FileContentsManager.root_dir = './build/cypress-tests'


### PR DESCRIPTION
Current UI tests will fail if jupyter lab or any other application
is using port 8888. The issue is resolved by using an explicit
non-registered port >=49152

Fixes #1011



 

