### PR TITLE
Flow kernel name to Enterprise Gateway

### DIFF
--- a/elyra/pipeline/elyra_engine.py
+++ b/elyra/pipeline/elyra_engine.py
@@ -72,4 +72,5 @@ class ElyraEngine(NBClientEngine):
             stderr_file=stderr_file,
         )
         return PapermillNotebookClient(nb_man, **final_kwargs).execute(env=kwargs.get('kernel_env'),
-                                                                       cwd=kwargs['kernel_cwd'])
+                                                                       cwd=kwargs['kernel_cwd'],
+                                                                       kernel_name=kernel_name)


### PR DESCRIPTION
Turns out the kernel name was not properly conveyed to EG - resulting in a local `python3` kernel being used.

Fixes #1030 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

