### PR TITLE
Ensure local python nodes use local env

### DIFF
--- a/elyra/pipeline/processor_local.py
+++ b/elyra/pipeline/processor_local.py
@@ -214,7 +214,9 @@ class PythonScriptOperationProcessor(FileOperationProcessor):
         self.log.debug(f'Processing python script: {filepath}')
 
         argv = ['python3', filepath, '--PYTHONHOME', file_dir]
-        envs = operation.env_vars_as_dict()
+
+        envs = os.environ  # Make sure this process's env is "available" in subprocess
+        envs.update(operation.env_vars_as_dict())
         t0 = time.time()
         try:
             run(argv, cwd=file_dir, env=envs, check=True)

--- a/elyra/pipeline/tests/resources/node_util/node.py
+++ b/elyra/pipeline/tests/resources/node_util/node.py
@@ -31,6 +31,7 @@ dialog of the pipeline:
   to exist, but will be created as a function of the notebook's execution.
 """
 import os
+import requests  # reference an import not in the stardard python builtins  # noqa
 from node_util import PythonNode
 
 # These getenv calls are here to help seed the environment variables

--- a/elyra/pipeline/tests/util.py
+++ b/elyra/pipeline/tests/util.py
@@ -69,7 +69,9 @@ class NodeBase:
     def get_operation(self) -> Operation:
 
         self.env_vars = []
-        if not self.fail:  # NODE_FILENAME is required, so skip if triggering failure
+        if self.fail:  # NODE_FILENAME is required, so skip if triggering failure
+            os.environ.pop("NODE_FILENAME")  # remove entry that might already be present
+        else:
             self.env_vars.append(f"NODE_FILENAME={self.filename}")
         if self.inputs:
             self.env_vars.append(f"INPUT_FILENAMES={';'.join(self.inputs)}")


### PR DESCRIPTION
Local Python script nodes were not conveying the local env to the subprocess in which they are run in - resulting in only the builtin modules being available. This change ensures the local env is conveyed to the subprocess.
 
Fixes #1042 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

