### PR TITLE
Update runtime-images so lint side-effect doesn't occur

### DIFF
--- a/etc/config/metadata/runtime-images/anaconda.json
+++ b/etc/config/metadata/runtime-images/anaconda.json
@@ -3,9 +3,7 @@
   "metadata": {
     "description": "Anaconda 2020.07",
     "image_name": "continuumio/anaconda3:2020.07",
-    "tags": [
-      "anaconda"
-    ]
+    "tags": ["anaconda"]
   },
   "schema_name": "runtime-image"
 }

--- a/etc/config/metadata/runtime-images/pandas.json
+++ b/etc/config/metadata/runtime-images/pandas.json
@@ -3,9 +3,7 @@
   "metadata": {
     "description": "Pandas 1.1.1",
     "image_name": "amancevice/pandas:1.1.1",
-    "tags": [
-      "pandas"
-    ]
+    "tags": ["pandas"]
   },
   "schema_name": "runtime-image"
 }

--- a/etc/config/metadata/runtime-images/pytorch-devel.json
+++ b/etc/config/metadata/runtime-images/pytorch-devel.json
@@ -3,10 +3,7 @@
   "metadata": {
     "description": "PyTorch 1.4 (with GPU support)",
     "image_name": "pytorch/pytorch:1.4-cuda10.1-cudnn7-devel",
-    "tags": [
-      "gpu",
-      "pytorch"
-    ]
+    "tags": ["gpu", "pytorch"]
   },
   "schema_name": "runtime-image"
 }

--- a/etc/config/metadata/runtime-images/pytorch-runtime.json
+++ b/etc/config/metadata/runtime-images/pytorch-runtime.json
@@ -3,10 +3,7 @@
   "metadata": {
     "description": "PyTorch 1.4 (with GPU support)",
     "image_name": "pytorch/pytorch:1.4-cuda10.1-cudnn7-runtime",
-    "tags": [
-      "gpu",
-      "pytorch"
-    ]
+    "tags": ["gpu", "pytorch"]
   },
   "schema_name": "runtime-image"
 }

--- a/etc/config/metadata/runtime-images/tensorflow_2x_gpu_py3.json
+++ b/etc/config/metadata/runtime-images/tensorflow_2x_gpu_py3.json
@@ -3,10 +3,7 @@
   "metadata": {
     "description": "TensorFlow 2.3 (with GPU support)",
     "image_name": "tensorflow/tensorflow:2.3.0-gpu",
-    "tags": [
-      "gpu",
-      "tensorflow"
-    ]  
+    "tags": ["gpu", "tensorflow"]
   },
   "schema_name": "runtime-image"
 }

--- a/etc/config/metadata/runtime-images/tensorflow_2x_py3.json
+++ b/etc/config/metadata/runtime-images/tensorflow_2x_py3.json
@@ -3,9 +3,7 @@
   "metadata": {
     "description": "TensorFlow 2.3",
     "image_name": "tensorflow/tensorflow:2.3.0",
-    "tags": [
-      "tensorflow"
-    ]
+    "tags": ["tensorflow"]
   },
   "schema_name": "runtime-image"
 }

--- a/etc/config/metadata/runtime-images/tensorflow_gpu_py3.json
+++ b/etc/config/metadata/runtime-images/tensorflow_gpu_py3.json
@@ -3,10 +3,7 @@
   "metadata": {
     "description": "TensorFlow 1.15 (with GPU support)",
     "image_name": "elyra/tensorflow:1.15.2-gpu-py3",
-    "tags": [
-      "gpu",
-      "tensorflow"
-    ]    
+    "tags": ["gpu", "tensorflow"]
   },
   "schema_name": "runtime-image"
 }

--- a/etc/config/metadata/runtime-images/tensorflow_py3.json
+++ b/etc/config/metadata/runtime-images/tensorflow_py3.json
@@ -3,9 +3,7 @@
   "metadata": {
     "description": "TensorFlow 1.15",
     "image_name": "elyra/tensorflow:1.15.2-py3",
-    "tags": [
-      "tensorflow"
-    ]
+    "tags": ["tensorflow"]
   },
   "schema_name": "runtime-image"
 }


### PR DESCRIPTION
The addition of tags recently added to runtime-images is not in a format that `make lint-ui` wants so it automatically updates each json file - which ends up getting marked as changed files.  This update makes the files compatible with `make lint-ui`.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

