### PR TITLE
Only flow kernel-name and path to HTTPKernelManager

### DIFF
--- a/elyra/pipeline/elyra_engine.py
+++ b/elyra/pipeline/elyra_engine.py
@@ -71,6 +71,12 @@ class ElyraEngine(NBClientEngine):
             stdout_file=stdout_file,
             stderr_file=stderr_file,
         )
-        return PapermillNotebookClient(nb_man, **final_kwargs).execute(env=kwargs.get('kernel_env'),
-                                                                       cwd=kwargs['kernel_cwd'],
-                                                                       kernel_name=kernel_name)
+        kernel_kwargs = dict()
+        kernel_kwargs['env'] = kwargs.get('kernel_env')
+        # Only include kernel_name and set path if HTTPKernelManager will be used
+        kernel_manager_class = final_kwargs.get('kernel_manager_class')
+        if kernel_manager_class == 'elyra.pipeline.http_kernel_manager.HTTPKernelManager':
+            kernel_kwargs['kernel_name'] = kernel_name
+            kernel_kwargs['path'] = kwargs.get('kernel_cwd')
+
+        return PapermillNotebookClient(nb_man, **final_kwargs).execute(**kernel_kwargs)


### PR DESCRIPTION
Keyword arguments that are relative to what is needed by EG are not compatible with local kernels.  This change only flows kernel-name (and path for cwd purposes) when the `HTTPKernelManager` is configured (i.e., EG is in use).
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

