### PR TITLE
Ensure local notebook nodes use local env

### DIFF
--- a/elyra/pipeline/processor_local.py
+++ b/elyra/pipeline/processor_local.py
@@ -180,7 +180,9 @@ class NotebookOperationProcessor(FileOperationProcessor):
         additional_kwargs['engine_name'] = "ElyraEngine"
         additional_kwargs['cwd'] = file_dir  # For local operations, papermill runs from this dir
         additional_kwargs['kernel_cwd'] = file_dir
-        additional_kwargs['kernel_env'] = operation.env_vars_as_dict()
+        envs = os.environ.copy()  # Make sure this process's env is "available" in the kernel subprocess
+        envs.update(operation.env_vars_as_dict())
+        additional_kwargs['kernel_env'] = envs
         if GatewayClient.instance().gateway_enabled:
             additional_kwargs['kernel_manager_class'] = 'elyra.pipeline.http_kernel_manager.HTTPKernelManager'
 
@@ -215,7 +217,7 @@ class PythonScriptOperationProcessor(FileOperationProcessor):
 
         argv = ['python3', filepath, '--PYTHONHOME', file_dir]
 
-        envs = os.environ  # Make sure this process's env is "available" in subprocess
+        envs = os.environ.copy()  # Make sure this process's env is "available" in subprocess
         envs.update(operation.env_vars_as_dict())
         t0 = time.time()
         try:

--- a/elyra/pipeline/tests/resources/node_util/node.ipynb
+++ b/elyra/pipeline/tests/resources/node_util/node.ipynb
@@ -17,6 +17,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!pip3 install --upgrade pygithub"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from github import Github"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import os\n",
     "from node_util import NotebookNode\n",
     "# These getenv calls are here to help seed the environment variables \n",

--- a/elyra/pipeline/tests/util.py
+++ b/elyra/pipeline/tests/util.py
@@ -70,7 +70,8 @@ class NodeBase(object):
 
         self.env_vars = []
         if self.fail:  # NODE_FILENAME is required, so skip if triggering failure
-            os.environ.pop("NODE_FILENAME")  # remove entry that might already be present
+            if "NODE_FILENAME" in os.environ:  # remove entry if present
+                os.environ.pop("NODE_FILENAME")
         else:
             self.env_vars.append(f"NODE_FILENAME={self.filename}")
         if self.inputs:


### PR DESCRIPTION
This change mirrors that of #1047 but for notebooks.  Also, the local environment should be copied so as to not be side-affected by updates.

Updated the tests to include a pip install and import of the installed module to ensure its completion.  If there are other lighter and more obscure packages than `pygithub`, suggestions are welcome.  The primary requirement is that it can't exist prior to CI.

Fixes #1058 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

