### PR TITLE
Use JupyterLab SessionManager to execute Python scripts

### DIFF
--- a/packages/python-editor/src/PythonFileEditor.tsx
+++ b/packages/python-editor/src/PythonFileEditor.tsx
@@ -86,7 +86,7 @@ export class PythonFileEditor extends DocumentWidget<
     super(options);
     this.addClass(PYTHON_FILE_EDITOR_CLASS);
     this.model = this.content.model;
-    this.runner = new PythonRunner(this.model, this.disableRun);
+    this.runner = new PythonRunner(this.model, this.context, this.disableRun);
     this.kernelName = null;
     this.emptyOutput = true;
     this.runDisabled = false;
@@ -174,7 +174,7 @@ export class PythonFileEditor extends DocumentWidget<
   };
 
   private stopRun = async (): Promise<void> => {
-    this.runner.shutDownKernel();
+    this.runner.shutdownSession();
     if (!this.dockPanel.isEmpty) {
       this.updatePromptText(' ');
     }


### PR DESCRIPTION
The Session service provides a better way to configure and
manage context while using kernels, that enables us to properly
set working directory when executing python scripts

Fixes #1046 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

