### PR TITLE
fix bugs in circular reference detection

### DIFF
--- a/packages/pipeline-editor/src/test/validation.spec.ts
+++ b/packages/pipeline-editor/src/test/validation.spec.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { checkCircularReferences } from './validation';
+import { checkCircularReferences } from './../validation';
 
 const linkExamples = [
   // ╭───╮      ╭───╮

--- a/packages/pipeline-editor/src/validation.spec.ts
+++ b/packages/pipeline-editor/src/validation.spec.ts
@@ -1,0 +1,343 @@
+/*
+ * Copyright 2018-2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { checkCircularReferences } from './validation';
+
+const linkExamples = [
+  // ╭───╮      ╭───╮
+  // │ a │──l0─►│ b │
+  // ╰───╯      ╰───╯
+  //   ▲          │
+  //   ╰────l1────╯
+  {
+    it: 'should detect a simple cycle',
+    given: [
+      { id: 'l0', srcNodeId: 'a', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l1', srcNodeId: 'b', trgNodeId: 'a', type: 'nodeLink' }
+    ],
+    expected: ['l0', 'l1']
+  },
+
+  // ╭───╮      ╭───╮      ╭───╮
+  // │ f │──c0─►│ a │──l0─►│ b │
+  // ╰───╯      ╰───╯      ╰───╯
+  //              ▲          │
+  //             l4         l1
+  //              │          ▼
+  //            ╭───╮      ╭───╮      ╭───╮
+  //            │ e │◄─l3──│ c │──l2─►│ d │
+  //            ╰───╯      ╰───╯      ╰───╯
+  //              ▲
+  //             c1
+  //              │
+  //            ╭───╮
+  //            │ g │
+  //            ╰───╯
+  {
+    it: 'should ignore comment links',
+    given: [
+      { id: 'l0', srcNodeId: 'a', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l1', srcNodeId: 'b', trgNodeId: 'c', type: 'nodeLink' },
+      { id: 'l2', srcNodeId: 'c', trgNodeId: 'd', type: 'nodeLink' },
+      { id: 'l3', srcNodeId: 'c', trgNodeId: 'e', type: 'nodeLink' },
+      { id: 'l4', srcNodeId: 'e', trgNodeId: 'a', type: 'nodeLink' },
+      { id: 'c0', srcNodeId: 'f', trgNodeId: 'a', type: 'commentLink' },
+      { id: 'c1', srcNodeId: 'g', trgNodeId: 'c', type: 'commentLink' }
+    ],
+    expected: ['l0', 'l1', 'l3', 'l4']
+  },
+
+  //    ╭───╮       ╭───╮
+  //  ╭─│ a │◄╮   ╭─│ c │◄╮
+  //  │ ╰───╯ │   │ ╰───╯ │
+  //  │       │   │       │
+  // l0      l1  l2      l3
+  //  │       │   │       │
+  //  │ ╭───╮ │   │ ╭───╮ │
+  //  ╰►│ b │─╯   ╰►│ d │─╯
+  //    ╰───╯       ╰───╯
+  {
+    it: 'should detect multiple simple cycles',
+    given: [
+      { id: 'l0', srcNodeId: 'a', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l1', srcNodeId: 'b', trgNodeId: 'a', type: 'nodeLink' },
+      { id: 'l2', srcNodeId: 'c', trgNodeId: 'd', type: 'nodeLink' },
+      { id: 'l3', srcNodeId: 'd', trgNodeId: 'c', type: 'nodeLink' }
+    ],
+    expected: ['l0', 'l1', 'l2', 'l3']
+  },
+
+  //   ╭────l4────╮
+  //   ▼          │
+  // ╭───╮      ╭───╮      ╭───╮
+  // │ a │──l0─►│ b │    ╭─│ e │◄╮
+  // ╰───╯      ╰───╯    │ ╰───╯ │
+  //   │          ▲      │       │
+  //  l2         l1     l5      l6
+  //   ▼          │      │       │
+  // ╭───╮      ╭───╮    │ ╭───╮ │
+  // │ d │◄─l3──│ c │    ╰►│ f │─╯
+  // ╰───╯      ╰───╯      ╰───╯
+  {
+    it: 'should detect multiple cycles in a complex graph',
+    given: [
+      { id: 'l0', srcNodeId: 'a', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l1', srcNodeId: 'c', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l2', srcNodeId: 'a', trgNodeId: 'd', type: 'nodeLink' },
+      { id: 'l3', srcNodeId: 'c', trgNodeId: 'd', type: 'nodeLink' },
+      { id: 'l4', srcNodeId: 'b', trgNodeId: 'a', type: 'nodeLink' },
+      { id: 'l5', srcNodeId: 'e', trgNodeId: 'f', type: 'nodeLink' },
+      { id: 'l6', srcNodeId: 'f', trgNodeId: 'e', type: 'nodeLink' }
+    ],
+    expected: ['l0', 'l4', 'l5', 'l6']
+  },
+
+  // ╭───╮      ╭───╮      ╭───╮      ╭───╮
+  // │ a │──l0─►│ b │◄─l1──│ c │    ╭─│ f │◄╮
+  // ╰───╯      ╰───╯      ╰───╯    │ ╰───╯ │
+  //              │          │      │       │
+  //             l4         l3     l6      l7
+  //              ▼          ▼      │       │
+  //            ╭───╮      ╭───╮    │ ╭───╮ │
+  //            │ d │◄─l5──│ e │    ╰►│ g │─╯
+  //            ╰───╯      ╰───╯      ╰───╯
+  //              │          ▲
+  //              ╰────l2────╯
+  {
+    it: 'should detect multiple cycles in a complex graph - shuffled',
+    given: [
+      { id: 'l0', srcNodeId: 'a', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l1', srcNodeId: 'c', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l2', srcNodeId: 'd', trgNodeId: 'e', type: 'nodeLink' },
+      { id: 'l3', srcNodeId: 'c', trgNodeId: 'e', type: 'nodeLink' },
+      { id: 'l4', srcNodeId: 'b', trgNodeId: 'd', type: 'nodeLink' },
+      { id: 'l5', srcNodeId: 'e', trgNodeId: 'd', type: 'nodeLink' },
+      { id: 'l6', srcNodeId: 'f', trgNodeId: 'g', type: 'nodeLink' },
+      { id: 'l7', srcNodeId: 'g', trgNodeId: 'f', type: 'nodeLink' }
+    ],
+    expected: ['l2', 'l5', 'l6', 'l7']
+  },
+
+  // ╭───╮      ╭───╮      ╭───╮
+  // │ a │──l0─►│ b │◄─l1──│ c │
+  // ╰───╯      ╰───╯      ╰───╯
+  //              │          ▲
+  //              ╰────l2────╯
+  {
+    it: 'should only detect links contributing to the cycle',
+    given: [
+      { id: 'l0', srcNodeId: 'a', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l1', srcNodeId: 'c', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l2', srcNodeId: 'b', trgNodeId: 'c', type: 'nodeLink' }
+    ],
+    expected: ['l1', 'l2']
+  },
+
+  // ╭───╮      ╭───╮      ╭───╮
+  // │ a │──l0─►│ b │──l2─►│ c │
+  // ╰───╯      ╰───╯      ╰───╯
+  //   ▲         │ ▲         │
+  //   ╰────l1───╯ ╰───l3────╯
+  {
+    it: 'should detect joined cycles',
+    given: [
+      { id: 'l0', srcNodeId: 'a', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l1', srcNodeId: 'b', trgNodeId: 'a', type: 'nodeLink' },
+      { id: 'l2', srcNodeId: 'b', trgNodeId: 'c', type: 'nodeLink' },
+      { id: 'l3', srcNodeId: 'c', trgNodeId: 'b', type: 'nodeLink' }
+    ],
+    expected: ['l0', 'l1', 'l2', 'l3']
+  },
+
+  // ╭───╮      ╭───╮      ╭───╮
+  // │ a │──l0─►│ b │──l2─►│ c │
+  // ╰───╯      ╰───╯      ╰───╯
+  //   ▲         │ ▲         │
+  //   ╰────l1───╯ ╰───l3────╯
+  {
+    it: 'should detect joined cycles - shuffled',
+    given: [
+      { id: 'l3', srcNodeId: 'c', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l1', srcNodeId: 'b', trgNodeId: 'a', type: 'nodeLink' },
+      { id: 'l2', srcNodeId: 'b', trgNodeId: 'c', type: 'nodeLink' },
+      { id: 'l0', srcNodeId: 'a', trgNodeId: 'b', type: 'nodeLink' }
+    ],
+    expected: ['l0', 'l1', 'l2', 'l3']
+  },
+
+  // ╭───╮      ╭───╮
+  // │ a │──l0─►│ b │
+  // ╰───╯      ╰───╯
+  //   │          │
+  //  l3         l1
+  //   ▼          ▼
+  // ╭───╮      ╭───╮
+  // │ d │◄─l2──│ c │
+  // ╰───╯      ╰───╯
+  {
+    it: 'should not detect fake cycle',
+    given: [
+      { id: 'l0', srcNodeId: 'a', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l1', srcNodeId: 'b', trgNodeId: 'c', type: 'nodeLink' },
+      { id: 'l2', srcNodeId: 'c', trgNodeId: 'd', type: 'nodeLink' },
+      { id: 'l3', srcNodeId: 'a', trgNodeId: 'd', type: 'nodeLink' }
+    ],
+    expected: []
+  },
+
+  //   ╭────l4────╮
+  //   ▼          │
+  // ╭───╮      ╭───╮
+  // │ a │──l0─►│ b │
+  // ╰───╯      ╰───╯
+  //   │          ▲
+  //  l2         l1
+  //   ▼          │
+  // ╭───╮      ╭───╮
+  // │ d │◄─l3──│ c │
+  // ╰───╯      ╰───╯
+  {
+    it: 'should detect cycle when a fork that gets checked first is safe',
+    given: [
+      { id: 'l0', srcNodeId: 'a', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l1', srcNodeId: 'c', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l2', srcNodeId: 'a', trgNodeId: 'd', type: 'nodeLink' },
+      { id: 'l3', srcNodeId: 'c', trgNodeId: 'd', type: 'nodeLink' },
+      { id: 'l4', srcNodeId: 'b', trgNodeId: 'a', type: 'nodeLink' }
+    ],
+    expected: ['l0', 'l4']
+  },
+
+  // ╭───╮      ╭───╮      ╭───╮      ╭───╮      ╭───╮
+  // │ a │──l0─►│ b │──l1─►│ c │──l2─►│ d │──l3─►│ e │
+  // ╰───╯      ╰───╯      ╰───╯      ╰───╯      ╰───╯
+  //                         │
+  //                        l4
+  //                         ▼
+  //                       ╭───╮      ╭───╮      ╭───╮      ╭───╮      ╭───╮
+  //                       │ f │──l5─►│ g │──l6─►│ h │──l7─►│ i │──l8─►│ j │
+  //                       ╰───╯      ╰───╯      ╰───╯      ╰───╯      ╰───╯
+  //                                                          ▲          │
+  //                                                          ╰────l9────╯
+  {
+    it: 'should handle long forks',
+    given: [
+      { id: 'l0', srcNodeId: 'a', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l1', srcNodeId: 'b', trgNodeId: 'c', type: 'nodeLink' },
+      { id: 'l2', srcNodeId: 'c', trgNodeId: 'd', type: 'nodeLink' },
+      { id: 'l3', srcNodeId: 'd', trgNodeId: 'e', type: 'nodeLink' },
+      { id: 'l4', srcNodeId: 'c', trgNodeId: 'f', type: 'nodeLink' },
+      { id: 'l5', srcNodeId: 'f', trgNodeId: 'g', type: 'nodeLink' },
+      { id: 'l6', srcNodeId: 'g', trgNodeId: 'h', type: 'nodeLink' },
+      { id: 'l7', srcNodeId: 'h', trgNodeId: 'i', type: 'nodeLink' },
+      { id: 'l8', srcNodeId: 'i', trgNodeId: 'j', type: 'nodeLink' },
+      { id: 'l9', srcNodeId: 'j', trgNodeId: 'i', type: 'nodeLink' }
+    ],
+    expected: ['l8', 'l9']
+  },
+
+  // ╭───╮      ╭───╮      ╭───╮      ╭───╮      ╭───╮
+  // │ a │──l0─►│ b │──l1─►│ c │──l8─►│ i │──l9─►│ j │
+  // ╰───╯      ╰───╯      ╰───╯      ╰───╯      ╰───╯
+  //                         │
+  //                        l2
+  //                         ▼
+  //                       ╭───╮      ╭───╮      ╭───╮      ╭───╮      ╭───╮
+  //                       │ d │──l3─►│ e │──l4─►│ f │──l5─►│ g │──l6─►│ h │
+  //                       ╰───╯      ╰───╯      ╰───╯      ╰───╯      ╰───╯
+  //                                                          ▲          │
+  //                                                          ╰────l7────╯
+  {
+    it: 'should handle long forks - shuffled',
+    given: [
+      { id: 'l0', srcNodeId: 'a', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l1', srcNodeId: 'b', trgNodeId: 'c', type: 'nodeLink' },
+      { id: 'l2', srcNodeId: 'c', trgNodeId: 'd', type: 'nodeLink' },
+      { id: 'l3', srcNodeId: 'd', trgNodeId: 'e', type: 'nodeLink' },
+      { id: 'l4', srcNodeId: 'e', trgNodeId: 'f', type: 'nodeLink' },
+      { id: 'l5', srcNodeId: 'f', trgNodeId: 'g', type: 'nodeLink' },
+      { id: 'l6', srcNodeId: 'g', trgNodeId: 'h', type: 'nodeLink' },
+      { id: 'l7', srcNodeId: 'h', trgNodeId: 'g', type: 'nodeLink' },
+      { id: 'l8', srcNodeId: 'c', trgNodeId: 'i', type: 'nodeLink' },
+      { id: 'l9', srcNodeId: 'i', trgNodeId: 'j', type: 'nodeLink' }
+    ],
+    expected: ['l6', 'l7']
+  },
+
+  // ╭───╮      ╭───╮      ╭───╮      ╭───╮      ╭───╮
+  // │ a │──l0─►│ b │──l1─►│ c │──l5─►│ f │──l6─►│ g │
+  // ╰───╯      ╰───╯      ╰───╯      ╰───╯      ╰───╯
+  //                         │          ▲
+  //                        l2          l4
+  //                         ▼          │
+  //                       ╭───╮      ╭───╮
+  //                       │ d │──l3─►│ e │
+  //                       ╰───╯      ╰───╯
+  {
+    it: 'should not have a bug that a previous implementation had',
+    given: [
+      { id: 'l0', srcNodeId: 'a', trgNodeId: 'b', type: 'nodeLink' },
+      { id: 'l1', srcNodeId: 'b', trgNodeId: 'c', type: 'nodeLink' },
+      { id: 'l2', srcNodeId: 'c', trgNodeId: 'd', type: 'nodeLink' },
+      { id: 'l3', srcNodeId: 'd', trgNodeId: 'e', type: 'nodeLink' },
+      { id: 'l4', srcNodeId: 'e', trgNodeId: 'f', type: 'nodeLink' },
+      { id: 'l5', srcNodeId: 'c', trgNodeId: 'f', type: 'nodeLink' },
+      { id: 'l6', srcNodeId: 'f', trgNodeId: 'g', type: 'nodeLink' }
+    ],
+    expected: []
+  }
+];
+
+describe('@elyra/pipeline-editor', () => {
+  describe('checkCircularReferences', () => {
+    for (const { it: should, given, expected } of linkExamples) {
+      it(should, async () => {
+        const actual = checkCircularReferences(given);
+        expect(new Set(actual)).toEqual(new Set(expected));
+      });
+    }
+  });
+});
+
+// new: 13 passed, 0 failed
+//      ✓ should detect a simple cycle
+//      ✓ should ignore comment links
+//      ✓ should detect multiple simple cycles
+//      ✓ should detect multiple cycles in a complex graph
+//      ✓ should detect multiple cycles in a complex graph (shuffled)
+//      ✓ should only detect links contributing to the cycle
+//      ✓ should detect joined cycles
+//      ✓ should detect joined cycles (shuffled)
+//      ✓ should not detect fake cycle
+//      ✓ should detect cycle when a fork that gets checked first is safe
+//      ✓ should handle long forks
+//      ✓ should handle long forks (shuffled)
+//      ✓ should not have a bug that a previous implementation had
+
+// old: 6 passed, 7 failed
+//      ✓ should detect a simple cycle
+//      ✕ should ignore comment links                                      - Maximum call stack size exceeded
+//      ✓ should detect multiple simple cycles
+//      ✕ should detect multiple cycles in a complex graph                 - Maximum call stack size exceeded
+//      ✕ should detect multiple cycles in a complex graph (shuffled)      - Maximum call stack size exceeded
+//      ✕ should only detect links contributing to the cycle               - Maximum call stack size exceeded
+//      ✓ should detect joined cycles
+//      ✓ should detect joined cycles (shuffled)
+//      ✓ should not detect fake cycle
+//      ✕ should detect cycle when a fork that gets checked first is safe  - Maximum call stack size exceeded
+//      ✕ should handle long forks                                         - Maximum call stack size exceeded
+//      ✕ should handle long forks (shuffled)                              - Maximum call stack size exceeded
+//      ✓ should not have a bug that a previous implementation had

--- a/packages/pipeline-editor/src/validation.ts
+++ b/packages/pipeline-editor/src/validation.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018-2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// 3 seconds should be ample time.
+// should only protect against any infinite loops.
+const TIMEOUT = 3 * 1000;
+
+export interface ILink {
+  id: string;
+  trgNodeId: string;
+  srcNodeId: string;
+  type: string;
+}
+
+export const checkCircularReferences = (links: ILink[]): string[] => {
+  const startTime = Date.now();
+
+  // filter out comment links.
+  links = links.filter(l => l.type !== 'commentLink');
+
+  // organize links into easily indexable map:
+  // {srcNodeId: link[]}
+  const linkMap: { [key: string]: ILink[] } = {};
+  for (const l of links) {
+    if (linkMap[l.srcNodeId] === undefined) {
+      linkMap[l.srcNodeId] = [];
+    }
+    linkMap[l.srcNodeId].push(l);
+  }
+
+  let orderedChain: string[] = [];
+  const taintedLinks = new Set<string>();
+  const seen = new Set<string>();
+  const stack: ILink[] = [];
+  for (const l of links) {
+    if (seen.has(l.id)) {
+      continue;
+    }
+    seen.add(l.id);
+    orderedChain = [];
+    orderedChain.push(l.id);
+    const linksToVisit = linkMap[l.trgNodeId];
+    if (linksToVisit === undefined) {
+      continue;
+    }
+    stack.push(...linksToVisit);
+    const forkStack: number[] = [];
+    forkStack.push(...linksToVisit.map(() => orderedChain.length));
+
+    while (0 < stack.length && Date.now() - startTime < TIMEOUT) {
+      forkStack.pop();
+      const l = stack.pop()!; // we should be gauranteed an item.
+      seen.add(l.id);
+      const seenLinkIndex = orderedChain.indexOf(l.id);
+
+      // We hit a link we've already seen in the chain. This means there is a
+      // cycle from the seen link to the end of the chain.
+      if (seenLinkIndex > -1) {
+        for (const item of orderedChain.slice(seenLinkIndex)) {
+          taintedLinks.add(item);
+        }
+
+        const position = forkStack.pop();
+        orderedChain = orderedChain.slice(0, position);
+        continue;
+      }
+
+      orderedChain.push(l.id);
+
+      const linksToVisit = linkMap[l.trgNodeId];
+
+      // We reached the end of a chain.
+      if (linksToVisit === undefined) {
+        const position = forkStack.pop();
+        orderedChain = orderedChain.slice(0, position);
+        continue;
+      }
+
+      // Uncharted teritory, add it to the stack to be explored.
+      stack.push(...linksToVisit);
+      forkStack.push(...linksToVisit.map(() => orderedChain.length));
+    }
+  }
+
+  return [...taintedLinks];
+};

--- a/packages/pipeline-editor/src/validation.ts
+++ b/packages/pipeline-editor/src/validation.ts
@@ -25,6 +25,11 @@ export interface ILink {
   type: string;
 }
 
+/**
+ * Finds an exhaustive list of node links that are part of a circular reference.
+ *
+ * @returns array of link IDs.
+ */
 export const checkCircularReferences = (links: ILink[]): string[] => {
   const startTime = Date.now();
 


### PR DESCRIPTION
There were a few cases with the old cycle detection algorithm that would cause it to infinitely recurse. This PR instead uses a loop to make it easier to timeout on long checks or an unforeseen infinite loop. I also added some tests to check for some common cycle patterns and tests for where the previous algorithm was failing. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

