### PR TITLE
Support namespace configuration when using dex with kfp

### DIFF
--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -57,6 +57,16 @@
             "category": "Kubeflow Pipelines"
           }
         },
+        "user_namespace": {
+          "title": "Kubeflow Pipelines User Namespace",
+          "description": "The Kubeflow Pipelines user namespace used to create experiments",
+          "type": "string",
+          "pattern": "^[a-z0-9][-a-z0-9]*[a-z0-9]$",
+          "maxLength": 63,
+          "uihints": {
+            "category": "Kubeflow Pipelines"
+          }
+        },
         "cos_endpoint": {
           "title": "Cloud Object Storage Endpoint",
           "description": "The Cloud Object Storage endpoint",

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -53,6 +53,7 @@ class KfpPipelineProcessor(PipelineProcessor):
         # TODO: try to encapsulate the info below
         api_username = runtime_configuration.metadata.get('api_username')
         api_password = runtime_configuration.metadata.get('api_password')
+        user_namespace = runtime_configuration.metadata['user_namespace']
 
         self.log_pipeline_info(pipeline_name, "submitting pipeline")
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -99,7 +100,10 @@ class KfpPipelineProcessor(PipelineProcessor):
                 else:
                     raise lve
 
-            run = client.run_pipeline(experiment_id=client.create_experiment(pipeline_name).id,
+            experiment = client.create_experiment(name=pipeline_name,
+                                                  namespace=user_namespace)
+
+            run = client.run_pipeline(experiment_id=experiment.id,
                                       job_name=timestamp,
                                       pipeline_id=kfp_pipeline.id)
 

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -51,7 +51,7 @@ class KfpPipelineProcessor(PipelineProcessor):
         cos_bucket = runtime_configuration.metadata['cos_bucket']
 
         user_namespace = None
-        if runtime_configuration.metadata['user_namespace']:
+        if runtime_configuration.metadata.get('user_namespace'):
             user_namespace = runtime_configuration.metadata['user_namespace']
 
         # TODO: try to encapsulate the info below

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -50,9 +50,7 @@ class KfpPipelineProcessor(PipelineProcessor):
         cos_endpoint = runtime_configuration.metadata['cos_endpoint']
         cos_bucket = runtime_configuration.metadata['cos_bucket']
 
-        user_namespace = None
-        if runtime_configuration.metadata.get('user_namespace'):
-            user_namespace = runtime_configuration.metadata['user_namespace']
+        user_namespace = runtime_configuration.metadata.get('user_namespace')
 
         # TODO: try to encapsulate the info below
         api_username = runtime_configuration.metadata.get('api_username')

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -50,10 +50,13 @@ class KfpPipelineProcessor(PipelineProcessor):
         cos_endpoint = runtime_configuration.metadata['cos_endpoint']
         cos_bucket = runtime_configuration.metadata['cos_bucket']
 
+        user_namespace = None
+        if runtime_configuration.metadata['user_namespace']:
+            user_namespace = runtime_configuration.metadata['user_namespace']
+
         # TODO: try to encapsulate the info below
         api_username = runtime_configuration.metadata.get('api_username')
         api_password = runtime_configuration.metadata.get('api_password')
-        user_namespace = runtime_configuration.metadata['user_namespace']
 
         self.log_pipeline_info(pipeline_name, "submitting pipeline")
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Add user_namespace field to kfp metadata schema and
update kfp processor to allow submission of pipelines
to a dex enabled kfp cluster

Fixes #1053

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

