### PR TITLE
Add documentation documentation to the Developer Guide

### DIFF
--- a/docs/source/developer_guide/documentation.md
+++ b/docs/source/developer_guide/documentation.md
@@ -1,0 +1,57 @@
+<!--
+{% comment %}
+Copyright 2018-2020 IBM Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+## Elyra documentation
+
+The Elyra documentation's source is stored in the https://github.com/elyra-ai/elyra repository and hosted at https://elyra.readthedocs.io/. The documentation is written in [markdown](https://www.sphinx-doc.org/en/master/usage/markdown.html) and built using [Sphinx](https://www.sphinx-doc.org/en/master/).
+
+
+### Contributing to the Elyra documentation
+
+To contribute content to the Elyra documentation follow these steps:
+
+1. Fork the https://github.com/elyra-ai/elyra repository.
+
+1. Clone your fork.
+
+   ```
+   git clone https://github.com/git-id-or-org/elyra
+   ```
+
+   The documentation assets are located in the `/docs` directory.
+
+   - To add a new document create a new markdown file in the appropriate section subdirectory (e.g. `/docs/source/getting_started`) and add an entry to that section in `/docs/source/index.rst`.
+   - To update an existing document edit the corresponding markdown file.
+   - Place new or updated images in the `/docs/source/images` directory. `PNG` is the recommended format.
+
+1. Build the documentation assets locally.
+
+   In the repository's _root directory_ (not the `/docs` directory) run
+
+   ```
+   make docs
+   ```
+
+1. Review the build output and verify that your updates introduced no warnings or errors. 
+
+1. Review the updated documentation assets.
+    1. Navigate to the `/docs/_build/html/` directory.
+    1. Open `index.html` in a web browser.
+
+1. Commit your updates to a new branch and open a pull request.
+    

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -65,3 +65,4 @@ Elyra is a set of AI-centric extensions to JupyterLab Notebooks.
    developer_guide/pipelines
    developer_guide/trackers
    developer_guide/testing
+   developer_guide/documentation


### PR DESCRIPTION
This PR
 - adds a new document to the `Developer Guide`, outlining how the documentation is structured and built.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

