### PR TITLE
Remove ui-components dependency from application

### DIFF
--- a/packages/application/package.json
+++ b/packages/application/package.json
@@ -32,11 +32,9 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@elyra/ui-components": "^1.5.0-dev",
     "@jupyterlab/apputils": "^2.0.2",
     "@jupyterlab/coreutils": "^4.0.2",
     "@jupyterlab/services": "^5.0.2",
-    "@jupyterlab/ui-components": "^2.0.2",
     "react": "^16.8.6"
   },
   "devDependencies": {

--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -17,5 +17,4 @@
 import '../style/index.css';
 
 export * from './parsing';
-export * from './services';
 export * from './requests';

--- a/packages/application/src/requests.tsx
+++ b/packages/application/src/requests.tsx
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { ExpandableErrorDialog } from '@elyra/ui-components';
-import { showDialog, Dialog } from '@jupyterlab/apputils';
+import { Dialog, showDialog } from '@jupyterlab/apputils';
 import { URLExt } from '@jupyterlab/coreutils';
 import { ServerConnection } from '@jupyterlab/services';
 
@@ -25,40 +24,6 @@ import * as React from 'react';
  * A service class for making requests to the jupyter lab server.
  */
 export class RequestHandler {
-  /**
-   * Displays an error dialog showing error data and stacktrace, if available.
-   *
-   * @param response - The server response containing the error data
-   *
-   * @returns A promise that resolves with whether the dialog was accepted.
-   */
-  private static serverError(response: any): Promise<Dialog.IResult<any>> {
-    const reason = response.reason ? response.reason : '';
-    const message = response.message ? response.message : '';
-    const timestamp = response.timestamp ? response.timestamp : '';
-    const traceback = response.traceback ? response.traceback : '';
-    const default_body = response.timestamp
-      ? 'Check the JupyterLab log for more details at ' + response.timestamp
-      : 'Check the JupyterLab log for more details';
-
-    return showDialog({
-      title: 'Error making request',
-      body:
-        reason || message ? (
-          <ExpandableErrorDialog
-            reason={reason}
-            message={message}
-            timestamp={timestamp}
-            traceback={traceback}
-            default_msg={default_body}
-          />
-        ) : (
-          <p>{default_body}</p>
-        ),
-      buttons: [Dialog.okButton()]
-    });
-  }
-
   /**
    * Displays an error dialog for when a server request returns a 404.
    *
@@ -250,7 +215,7 @@ export class RequestHandler {
             // handle cases where the server returns a valid response
             (result: any) => {
               if (response.status < 200 || response.status >= 300) {
-                return this.serverError(result);
+                reject(result);
               }
 
               resolve(result);
@@ -262,7 +227,7 @@ export class RequestHandler {
               } else if (response.status == 204) {
                 resolve();
               } else {
-                return this.serverError(reason);
+                reject(reason);
               }
             }
           );
@@ -270,7 +235,7 @@ export class RequestHandler {
         // something unexpected went wrong with the request
         (reason: any) => {
           console.error(reason);
-          return this.serverError(reason);
+          reject(reason);
         }
       );
     });

--- a/packages/application/src/test/application.spec.ts
+++ b/packages/application/src/test/application.spec.ts
@@ -20,7 +20,6 @@ import { JupyterServer, NBTestUtils } from '@jupyterlab/testutils';
 
 import { NotebookParser } from '../parsing';
 import { RequestHandler } from '../requests';
-import { FrontendServices } from '../services';
 
 const server = new JupyterServer();
 const notebookWithEnvVars: any = {
@@ -83,79 +82,6 @@ afterAll(async () => {
 });
 
 describe('@elyra/application', () => {
-  describe('FrontendServices', () => {
-    describe('#getSchema', () => {
-      it('should get schema', async () => {
-        const schemaResponse = await FrontendServices.getSchema(
-          'code-snippets'
-        );
-        expect(schemaResponse[0]).toHaveProperty(
-          'properties.schema_name.description',
-          'The schema associated with this instance'
-        );
-      });
-    });
-    describe('#getAllSchema', () => {
-      it('should get all schema', async () => {
-        const schemas = await FrontendServices.getAllSchema();
-        const schemaNames = schemas.map((schema: any) => {
-          return schema.name;
-        });
-        const knownSchemaNames = ['code-snippet', 'runtime-image', 'kfp'];
-        for (const schemaName of knownSchemaNames) {
-          expect(schemaNames).toContain(schemaName);
-        }
-        expect(schemas.length).toBeGreaterThanOrEqual(knownSchemaNames.length);
-      });
-    });
-    describe('metadata requests', () => {
-      beforeAll(async () => {
-        const existingSnippets = await FrontendServices.getMetadata(
-          'code-snippets'
-        );
-        if (
-          existingSnippets.find((snippet: any) => {
-            return snippet.name === 'tester';
-          })
-        ) {
-          await FrontendServices.deleteMetadata('code-snippet', 'tester');
-        }
-      });
-
-      it('should create metadata instance', async () => {
-        expect(
-          await FrontendServices.postMetadata(
-            'code-snippets',
-            JSON.stringify(codeSnippetMetadata)
-          )
-        ).toMatchObject(codeSnippetMetadata);
-      });
-
-      it('should get the correct metadata instance', async () => {
-        expect(
-          await FrontendServices.getMetadata('code-snippets')
-        ).toContainEqual(codeSnippetMetadata);
-      });
-
-      it('should update the metadata instance', async () => {
-        codeSnippetMetadata.metadata.code = ['testing'];
-        expect(
-          await FrontendServices.putMetadata(
-            'code-snippets',
-            'tester',
-            JSON.stringify(codeSnippetMetadata)
-          )
-        ).toHaveProperty('metadata.code', ['testing']);
-      });
-
-      it('should delete the metadata instance', async () => {
-        await FrontendServices.deleteMetadata('code-snippets', 'tester');
-        const snippets = await FrontendServices.getMetadata('code-snippets');
-        expect(snippets).not.toContain(codeSnippetMetadata);
-      });
-    });
-  });
-
   describe('RequestHandler', () => {
     describe('#makeGetRequest', () => {
       it('should make get request', async () => {

--- a/packages/code-snippet/package.json
+++ b/packages/code-snippet/package.json
@@ -31,7 +31,6 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@elyra/application": "^1.5.0-dev",
     "@elyra/metadata-common": "^1.5.0-dev",
     "@elyra/ui-components": "^1.5.0-dev",
     "@jupyterlab/application": "^2.0.2",

--- a/packages/code-snippet/src/CodeSnippetService.ts
+++ b/packages/code-snippet/src/CodeSnippetService.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FrontendServices, IMetadata } from '@elyra/metadata-common';
+import { MetadataService, IMetadata } from '@elyra/metadata-common';
 
 import { Dialog, showDialog } from '@jupyterlab/apputils';
 
@@ -23,7 +23,7 @@ export const CODE_SNIPPET_SCHEMA = 'code-snippet';
 
 export class CodeSnippetService {
   static async findAll(): Promise<IMetadata[]> {
-    const codeSnippetsResponse = await FrontendServices.getMetadata(
+    const codeSnippetsResponse = await MetadataService.getMetadata(
       CODE_SNIPPET_NAMESPACE
     );
 
@@ -60,7 +60,7 @@ export class CodeSnippetService {
     }).then((result: any) => {
       // Do nothing if the cancel button is pressed
       if (result.button.accept) {
-        FrontendServices.deleteMetadata(
+        MetadataService.deleteMetadata(
           CODE_SNIPPET_NAMESPACE,
           codeSnippet.name
         );

--- a/packages/code-snippet/src/CodeSnippetService.ts
+++ b/packages/code-snippet/src/CodeSnippetService.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { FrontendServices } from '@elyra/application';
-import { IMetadata } from '@elyra/metadata-common';
+import { FrontendServices, IMetadata } from '@elyra/metadata-common';
 
 import { Dialog, showDialog } from '@jupyterlab/apputils';
 

--- a/packages/metadata-common/jest.config.js
+++ b/packages/metadata-common/jest.config.js
@@ -13,9 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import '../style/index.css';
-
-export * from './MetadataEditor';
-export * from './MetadataWidget';
-export * from './services';
+/* global module, require */
+module.exports = require('../../testutils/jest.config');

--- a/packages/metadata-common/package.json
+++ b/packages/metadata-common/package.json
@@ -27,6 +27,7 @@
     "clean": "rimraf lib",
     "dist": "npm pack .",
     "prepare": "npm run build",
+    "test": "jest",
     "watch": "tsc -w"
   },
   "dependencies": {
@@ -43,7 +44,21 @@
     "react": "^16.8.6"
   },
   "devDependencies": {
+    "@types/enzyme": "^3.10.5",
+    "@types/enzyme-adapter-react-16": "^1.0.6",
+    "@types/jest": "^23.3.11",
+    "@types/react": "^16.8.23",
+    "@types/react-dom": "^16.8.5",
+    "@types/react-intl": "^2.3.0",
+    "enzyme": "^3.11.0",
+    "enzyme-adapter-react-16": "^1.15.3",
+    "install": "^0.13.0",
+    "jest": "^24.7.1",
+    "jest-raw-loader": "^1.0.1",
     "rimraf": "~3.0.0",
+    "source-map-loader": "^0.2.4",
+    "ts-jest": "^24.0.2",
+    "ts-loader": "^6.2.1",
     "typescript": "~3.7.3"
   },
   "publishConfig": {

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -31,7 +31,7 @@ import { Message } from '@lumino/messaging';
 import * as React from 'react';
 
 import { MetadataEditorTags } from './MetadataEditorTags';
-import { FrontendServices } from './services';
+import { MetadataService } from './MetadataService';
 
 const ELYRA_METADATA_EDITOR_CLASS = 'elyra-metadataEditor';
 const DIRTY_CLASS = 'jp-mod-dirty';
@@ -98,7 +98,7 @@ export class MetadataEditor extends ReactWidget {
   }
 
   async initializeMetadata(): Promise<void> {
-    const schemas = await FrontendServices.getSchema(this.namespace);
+    const schemas = await MetadataService.getSchema(this.namespace);
     for (const schema of schemas) {
       if (this.schemaName === schema.name) {
         this.schema = schema.properties.metadata.properties;
@@ -125,7 +125,7 @@ export class MetadataEditor extends ReactWidget {
       }
     }
 
-    this.allMetadata = await FrontendServices.getMetadata(this.namespace);
+    this.allMetadata = await MetadataService.getMetadata(this.namespace);
     if (this.name) {
       for (const metadata of this.allMetadata) {
         if (metadata.metadata.tags) {
@@ -220,7 +220,7 @@ export class MetadataEditor extends ReactWidget {
     }
 
     if (!this.name) {
-      FrontendServices.postMetadata(
+      MetadataService.postMetadata(
         this.namespace,
         JSON.stringify(newMetadata)
       ).then((response: any): void => {
@@ -229,7 +229,7 @@ export class MetadataEditor extends ReactWidget {
         this.close();
       });
     } else {
-      FrontendServices.putMetadata(
+      MetadataService.putMetadata(
         this.namespace,
         this.name,
         JSON.stringify(newMetadata)

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -16,7 +16,7 @@
 
 import { FormGroup, Intent, ResizeSensor, Tooltip } from '@blueprintjs/core';
 
-import { FrontendServices, IDictionary } from '@elyra/application';
+import { IDictionary } from '@elyra/application';
 import { DropDown } from '@elyra/ui-components';
 
 import { ILabStatus } from '@jupyterlab/application';
@@ -31,6 +31,7 @@ import { Message } from '@lumino/messaging';
 import * as React from 'react';
 
 import { MetadataEditorTags } from './MetadataEditorTags';
+import { FrontendServices } from './services';
 
 const ELYRA_METADATA_EDITOR_CLASS = 'elyra-metadataEditor';
 const DIRTY_CLASS = 'jp-mod-dirty';

--- a/packages/metadata-common/src/MetadataService.tsx
+++ b/packages/metadata-common/src/MetadataService.tsx
@@ -24,7 +24,7 @@ const ELYRA_METADATA_API_ENDPOINT = 'elyra/metadata/';
 /**
  * A service class for accessing the elyra api.
  */
-export class FrontendServices {
+export class MetadataService {
   /**
    * Displays a dialog for error cases during metadata calls.
    *

--- a/packages/metadata-common/src/MetadataService.tsx
+++ b/packages/metadata-common/src/MetadataService.tsx
@@ -15,6 +15,7 @@
  */
 
 import { IDictionary, RequestHandler } from '@elyra/application';
+import { RequestErrors } from '@elyra/ui-components';
 import { Dialog, showDialog } from '@jupyterlab/apputils';
 import * as React from 'react';
 
@@ -50,12 +51,16 @@ export class MetadataService {
    * an error dialog result
    */
   static async getMetadata(namespace: string): Promise<any> {
-    const metadataResponse: any = await RequestHandler.makeGetRequest(
-      ELYRA_METADATA_API_ENDPOINT + namespace,
-      false
-    );
+    try {
+      const metadataResponse: any = await RequestHandler.makeGetRequest(
+        ELYRA_METADATA_API_ENDPOINT + namespace,
+        false
+      );
 
-    return metadataResponse[namespace];
+      return metadataResponse[namespace];
+    } catch (error) {
+      return RequestErrors.serverError(error);
+    }
   }
 
   /**
@@ -68,13 +73,17 @@ export class MetadataService {
    * an error dialog result
    */
   static async postMetadata(namespace: string, requestBody: any): Promise<any> {
-    const metadataResponse: any = await RequestHandler.makePostRequest(
-      ELYRA_METADATA_API_ENDPOINT + namespace,
-      requestBody,
-      false
-    );
+    try {
+      const metadataResponse: any = await RequestHandler.makePostRequest(
+        ELYRA_METADATA_API_ENDPOINT + namespace,
+        requestBody,
+        false
+      );
 
-    return metadataResponse;
+      return metadataResponse;
+    } catch (error) {
+      return RequestErrors.serverError(error);
+    }
   }
 
   /**
@@ -92,13 +101,17 @@ export class MetadataService {
     name: string,
     requestBody: any
   ): Promise<any> {
-    const metadataResponse: any = await RequestHandler.makePutRequest(
-      ELYRA_METADATA_API_ENDPOINT + namespace + '/' + name,
-      requestBody,
-      false
-    );
+    try {
+      const metadataResponse: any = await RequestHandler.makePutRequest(
+        ELYRA_METADATA_API_ENDPOINT + namespace + '/' + name,
+        requestBody,
+        false
+      );
 
-    return metadataResponse;
+      return metadataResponse;
+    } catch (error) {
+      return RequestErrors.serverError(error);
+    }
   }
 
   /**
@@ -110,12 +123,16 @@ export class MetadataService {
    * @returns void or an error dialog result
    */
   static async deleteMetadata(namespace: string, name: string): Promise<any> {
-    const metadataResponse: any = await RequestHandler.makeDeleteRequest(
-      ELYRA_METADATA_API_ENDPOINT + namespace + '/' + name,
-      false
-    );
+    try {
+      const metadataResponse: any = await RequestHandler.makeDeleteRequest(
+        ELYRA_METADATA_API_ENDPOINT + namespace + '/' + name,
+        false
+      );
 
-    return metadataResponse;
+      return metadataResponse;
+    } catch (error) {
+      return RequestErrors.serverError(error);
+    }
   }
 
   private static schemaCache: IDictionary<any> = {};
@@ -129,21 +146,25 @@ export class MetadataService {
    * an error dialog result
    */
   static async getSchema(namespace: string): Promise<any> {
-    if (this.schemaCache[namespace]) {
-      // Deep copy cached schema to mimic request call
-      return JSON.parse(JSON.stringify(this.schemaCache[namespace]));
+    try {
+      if (this.schemaCache[namespace]) {
+        // Deep copy cached schema to mimic request call
+        return JSON.parse(JSON.stringify(this.schemaCache[namespace]));
+      }
+
+      const schemaResponse: any = await RequestHandler.makeGetRequest(
+        ELYRA_SCHEMA_API_ENDPOINT + namespace,
+        false
+      );
+
+      if (schemaResponse[namespace]) {
+        this.schemaCache[namespace] = schemaResponse[namespace];
+      }
+
+      return schemaResponse[namespace];
+    } catch (error) {
+      return RequestErrors.serverError(error);
     }
-
-    const schemaResponse: any = await RequestHandler.makeGetRequest(
-      ELYRA_SCHEMA_API_ENDPOINT + namespace,
-      false
-    );
-
-    if (schemaResponse[namespace]) {
-      this.schemaCache[namespace] = schemaResponse[namespace];
-    }
-
-    return schemaResponse[namespace];
   }
 
   /**
@@ -153,15 +174,19 @@ export class MetadataService {
    * an error dialog result
    */
   static async getAllSchema(): Promise<any> {
-    const namespaces = await RequestHandler.makeGetRequest(
-      'elyra/namespace',
-      false
-    );
-    const schemas = [];
-    for (const namespace of namespaces['namespaces']) {
-      const schema = await this.getSchema(namespace);
-      schemas.push(...schema);
+    try {
+      const namespaces = await RequestHandler.makeGetRequest(
+        'elyra/namespace',
+        false
+      );
+      const schemas = [];
+      for (const namespace of namespaces['namespaces']) {
+        const schema = await this.getSchema(namespace);
+        schemas.push(...schema);
+      }
+      return schemas;
+    } catch (error) {
+      return RequestErrors.serverError(error);
     }
-    return schemas;
   }
 }

--- a/packages/metadata-common/src/MetadataWidget.tsx
+++ b/packages/metadata-common/src/MetadataWidget.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { IDictionary, FrontendServices } from '@elyra/application';
+import { IDictionary } from '@elyra/application';
 import {
   ExpandableComponent,
   JSONComponent,
@@ -34,6 +34,7 @@ import { Signal } from '@lumino/signaling';
 import React from 'react';
 
 import { FilterTools } from './FilterTools';
+import { FrontendServices } from './services';
 
 /**
  * The CSS class added to metadata widgets.

--- a/packages/metadata-common/src/MetadataWidget.tsx
+++ b/packages/metadata-common/src/MetadataWidget.tsx
@@ -34,7 +34,7 @@ import { Signal } from '@lumino/signaling';
 import React from 'react';
 
 import { FilterTools } from './FilterTools';
-import { FrontendServices } from './services';
+import { MetadataService } from './MetadataService';
 
 /**
  * The CSS class added to metadata widgets.
@@ -110,7 +110,7 @@ export class MetadataDisplay<
     }).then((result: any) => {
       // Do nothing if the cancel button is pressed
       if (result.button.accept) {
-        FrontendServices.deleteMetadata(this.props.namespace, metadata.name);
+        MetadataService.deleteMetadata(this.props.namespace, metadata.name);
       }
     });
   };
@@ -342,7 +342,7 @@ export class MetadataWidget extends ReactWidget {
   }
 
   async getSchema(): Promise<void> {
-    const schemas = await FrontendServices.getSchema(this.props.namespace);
+    const schemas = await MetadataService.getSchema(this.props.namespace);
     for (const schema of schemas) {
       if (this.props.schema === schema.name) {
         this.schemaDisplayName = schema.title;
@@ -369,7 +369,7 @@ export class MetadataWidget extends ReactWidget {
    * @returns metadata in the format expected by `renderDisplay`
    */
   async fetchMetadata(): Promise<any> {
-    return await FrontendServices.getMetadata(this.props.namespace);
+    return await MetadataService.getMetadata(this.props.namespace);
   }
 
   updateMetadata(): void {

--- a/packages/metadata-common/src/index.ts
+++ b/packages/metadata-common/src/index.ts
@@ -18,4 +18,4 @@ import '../style/index.css';
 
 export * from './MetadataEditor';
 export * from './MetadataWidget';
-export * from './services';
+export * from './MetadataService';

--- a/packages/metadata-common/src/services.tsx
+++ b/packages/metadata-common/src/services.tsx
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 
+import { IDictionary, RequestHandler } from '@elyra/application';
 import { Dialog, showDialog } from '@jupyterlab/apputils';
 import * as React from 'react';
-
-import { IDictionary } from './parsing';
-import { RequestHandler } from './requests';
 
 const ELYRA_SCHEMA_API_ENDPOINT = 'elyra/schema/';
 const ELYRA_METADATA_API_ENDPOINT = 'elyra/metadata/';

--- a/packages/metadata-common/src/test/metadata-common.spec.ts
+++ b/packages/metadata-common/src/test/metadata-common.spec.ts
@@ -16,7 +16,7 @@
 
 import { JupyterServer } from '@jupyterlab/testutils';
 
-import { FrontendServices } from '../services';
+import { MetadataService } from '../MetadataService';
 
 const server = new JupyterServer();
 
@@ -39,12 +39,10 @@ afterAll(async () => {
 });
 
 describe('@elyra/metadata-common', () => {
-  describe('FrontendServices', () => {
+  describe('MetadataService', () => {
     describe('#getSchema', () => {
       it('should get schema', async () => {
-        const schemaResponse = await FrontendServices.getSchema(
-          'code-snippets'
-        );
+        const schemaResponse = await MetadataService.getSchema('code-snippets');
         expect(schemaResponse[0]).toHaveProperty(
           'properties.schema_name.description',
           'The schema associated with this instance'
@@ -53,7 +51,7 @@ describe('@elyra/metadata-common', () => {
     });
     describe('#getAllSchema', () => {
       it('should get all schema', async () => {
-        const schemas = await FrontendServices.getAllSchema();
+        const schemas = await MetadataService.getAllSchema();
         const schemaNames = schemas.map((schema: any) => {
           return schema.name;
         });
@@ -66,7 +64,7 @@ describe('@elyra/metadata-common', () => {
     });
     describe('metadata requests', () => {
       beforeAll(async () => {
-        const existingSnippets = await FrontendServices.getMetadata(
+        const existingSnippets = await MetadataService.getMetadata(
           'code-snippets'
         );
         if (
@@ -74,13 +72,13 @@ describe('@elyra/metadata-common', () => {
             return snippet.name === 'tester';
           })
         ) {
-          await FrontendServices.deleteMetadata('code-snippet', 'tester');
+          await MetadataService.deleteMetadata('code-snippet', 'tester');
         }
       });
 
       it('should create metadata instance', async () => {
         expect(
-          await FrontendServices.postMetadata(
+          await MetadataService.postMetadata(
             'code-snippets',
             JSON.stringify(codeSnippetMetadata)
           )
@@ -89,14 +87,14 @@ describe('@elyra/metadata-common', () => {
 
       it('should get the correct metadata instance', async () => {
         expect(
-          await FrontendServices.getMetadata('code-snippets')
+          await MetadataService.getMetadata('code-snippets')
         ).toContainEqual(codeSnippetMetadata);
       });
 
       it('should update the metadata instance', async () => {
         codeSnippetMetadata.metadata.code = ['testing'];
         expect(
-          await FrontendServices.putMetadata(
+          await MetadataService.putMetadata(
             'code-snippets',
             'tester',
             JSON.stringify(codeSnippetMetadata)
@@ -105,8 +103,8 @@ describe('@elyra/metadata-common', () => {
       });
 
       it('should delete the metadata instance', async () => {
-        await FrontendServices.deleteMetadata('code-snippets', 'tester');
-        const snippets = await FrontendServices.getMetadata('code-snippets');
+        await MetadataService.deleteMetadata('code-snippets', 'tester');
+        const snippets = await MetadataService.getMetadata('code-snippets');
         expect(snippets).not.toContain(codeSnippetMetadata);
       });
     });

--- a/packages/metadata-common/src/test/metadata-common.spec.ts
+++ b/packages/metadata-common/src/test/metadata-common.spec.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2018-2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JupyterServer } from '@jupyterlab/testutils';
+
+import { FrontendServices } from '../services';
+
+const server = new JupyterServer();
+
+const codeSnippetMetadata = {
+  schema_name: 'code-snippet',
+  display_name: 'tester',
+  name: 'tester',
+  metadata: {
+    language: 'Python',
+    code: ['hello_world']
+  }
+};
+
+beforeAll(async () => {
+  await server.start();
+});
+
+afterAll(async () => {
+  await server.shutdown();
+});
+
+describe('@elyra/metadata-common', () => {
+  describe('FrontendServices', () => {
+    describe('#getSchema', () => {
+      it('should get schema', async () => {
+        const schemaResponse = await FrontendServices.getSchema(
+          'code-snippets'
+        );
+        expect(schemaResponse[0]).toHaveProperty(
+          'properties.schema_name.description',
+          'The schema associated with this instance'
+        );
+      });
+    });
+    describe('#getAllSchema', () => {
+      it('should get all schema', async () => {
+        const schemas = await FrontendServices.getAllSchema();
+        const schemaNames = schemas.map((schema: any) => {
+          return schema.name;
+        });
+        const knownSchemaNames = ['code-snippet', 'runtime-image', 'kfp'];
+        for (const schemaName of knownSchemaNames) {
+          expect(schemaNames).toContain(schemaName);
+        }
+        expect(schemas.length).toBeGreaterThanOrEqual(knownSchemaNames.length);
+      });
+    });
+    describe('metadata requests', () => {
+      beforeAll(async () => {
+        const existingSnippets = await FrontendServices.getMetadata(
+          'code-snippets'
+        );
+        if (
+          existingSnippets.find((snippet: any) => {
+            return snippet.name === 'tester';
+          })
+        ) {
+          await FrontendServices.deleteMetadata('code-snippet', 'tester');
+        }
+      });
+
+      it('should create metadata instance', async () => {
+        expect(
+          await FrontendServices.postMetadata(
+            'code-snippets',
+            JSON.stringify(codeSnippetMetadata)
+          )
+        ).toMatchObject(codeSnippetMetadata);
+      });
+
+      it('should get the correct metadata instance', async () => {
+        expect(
+          await FrontendServices.getMetadata('code-snippets')
+        ).toContainEqual(codeSnippetMetadata);
+      });
+
+      it('should update the metadata instance', async () => {
+        codeSnippetMetadata.metadata.code = ['testing'];
+        expect(
+          await FrontendServices.putMetadata(
+            'code-snippets',
+            'tester',
+            JSON.stringify(codeSnippetMetadata)
+          )
+        ).toHaveProperty('metadata.code', ['testing']);
+      });
+
+      it('should delete the metadata instance', async () => {
+        await FrontendServices.deleteMetadata('code-snippets', 'tester');
+        const snippets = await FrontendServices.getMetadata('code-snippets');
+        expect(snippets).not.toContain(codeSnippetMetadata);
+      });
+    });
+  });
+});

--- a/packages/metadata-common/tsconfig.json
+++ b/packages/metadata-common/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig-base",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": ["node", "jest"]
   },
   "include": ["src/*"],
   "references": [

--- a/packages/metadata-common/tsconfig.test.json
+++ b/packages/metadata-common/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfigbase.test",
+  "include": ["src/*", "test/*"],
+  "references": []
+}

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 import {
-  FrontendServices,
+  MetadataService,
   MetadataWidget,
   MetadataEditor
 } from '@elyra/metadata-common';
@@ -190,7 +190,7 @@ const extension: JupyterFrontEndPlugin<void> = {
       command: closeTabCommand
     });
 
-    const schemas = await FrontendServices.getAllSchema();
+    const schemas = await MetadataService.getAllSchema();
     for (const schema of schemas) {
       let icon = 'ui-components:text-editor';
       let title = schema.title;

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-import { FrontendServices } from '@elyra/application';
-import { MetadataWidget, MetadataEditor } from '@elyra/metadata-common';
+import {
+  FrontendServices,
+  MetadataWidget,
+  MetadataEditor
+} from '@elyra/metadata-common';
 
 import {
   JupyterFrontEnd,

--- a/packages/pipeline-editor/src/PipelineService.tsx
+++ b/packages/pipeline-editor/src/PipelineService.tsx
@@ -16,11 +16,8 @@
 
 import * as path from 'path';
 
-import {
-  FrontendServices,
-  IDictionary,
-  RequestHandler
-} from '@elyra/application';
+import { IDictionary, RequestHandler } from '@elyra/application';
+import { FrontendServices } from '@elyra/metadata-common';
 
 import { showDialog, Dialog } from '@jupyterlab/apputils';
 import * as React from 'react';

--- a/packages/pipeline-editor/src/PipelineService.tsx
+++ b/packages/pipeline-editor/src/PipelineService.tsx
@@ -17,7 +17,7 @@
 import * as path from 'path';
 
 import { IDictionary, RequestHandler } from '@elyra/application';
-import { FrontendServices } from '@elyra/metadata-common';
+import { MetadataService } from '@elyra/metadata-common';
 
 import { showDialog, Dialog } from '@jupyterlab/apputils';
 import * as React from 'react';
@@ -41,10 +41,10 @@ export class PipelineService {
    * executed on these runtimes.
    */
   static async getRuntimes(showError = true): Promise<any> {
-    const runtimes = await FrontendServices.getMetadata('runtimes');
+    const runtimes = await MetadataService.getMetadata('runtimes');
 
     if (showError && Object.keys(runtimes).length === 0) {
-      return FrontendServices.noMetadataError('runtimes');
+      return MetadataService.noMetadataError('runtimes');
     }
 
     return runtimes;
@@ -55,14 +55,14 @@ export class PipelineService {
    * to run the pipeline nodes.
    */
   static async getRuntimeImages(): Promise<any> {
-    let runtimeImages = await FrontendServices.getMetadata('runtime-images');
+    let runtimeImages = await MetadataService.getMetadata('runtime-images');
 
     runtimeImages = runtimeImages.sort(
       (a: any, b: any) => 0 - (a.name > b.name ? -1 : 1)
     );
 
     if (Object.keys(runtimeImages).length === 0) {
-      return FrontendServices.noMetadataError('runtime-images');
+      return MetadataService.noMetadataError('runtime-images');
     }
 
     const images: IDictionary<string> = {};

--- a/packages/pipeline-editor/src/PipelineService.tsx
+++ b/packages/pipeline-editor/src/PipelineService.tsx
@@ -18,7 +18,7 @@ import * as path from 'path';
 
 import { IDictionary, RequestHandler } from '@elyra/application';
 import { MetadataService } from '@elyra/metadata-common';
-
+import { RequestErrors } from '@elyra/ui-components';
 import { showDialog, Dialog } from '@jupyterlab/apputils';
 import * as React from 'react';
 
@@ -96,55 +96,59 @@ export class PipelineService {
     pipeline: any,
     runtimeName: string
   ): Promise<any> {
-    const response = await RequestHandler.makePostRequest(
-      'elyra/pipeline/schedule',
-      JSON.stringify(pipeline),
-      true
-    );
+    try {
+      const response = await RequestHandler.makePostRequest(
+        'elyra/pipeline/schedule',
+        JSON.stringify(pipeline),
+        true
+      );
 
-    let dialogTitle;
-    let dialogBody;
-    if (response['run_url']) {
-      // pipeline executed remotely in a runtime of choice
-      dialogTitle = 'Job submission to ' + runtimeName + ' succeeded';
-      dialogBody = (
-        <p>
-          Check the status of your job at{' '}
-          <a
-            href={response['run_url']}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Run Details.
-          </a>
-          <br />
-          The results and outputs are in the {
-            response['object_storage_path']
-          }{' '}
-          working directory in{' '}
-          <a
-            href={response['object_storage_url']}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            object storage
-          </a>
-          .
-        </p>
-      );
-    } else {
-      // pipeline executed in-place locally
-      dialogTitle = 'Job execution succeeded';
-      dialogBody = (
-        <p>Your job has been executed in-place in your local environment.</p>
-      );
+      let dialogTitle;
+      let dialogBody;
+      if (response['run_url']) {
+        // pipeline executed remotely in a runtime of choice
+        dialogTitle = 'Job submission to ' + runtimeName + ' succeeded';
+        dialogBody = (
+          <p>
+            Check the status of your job at{' '}
+            <a
+              href={response['run_url']}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Run Details.
+            </a>
+            <br />
+            The results and outputs are in the {
+              response['object_storage_path']
+            }{' '}
+            working directory in{' '}
+            <a
+              href={response['object_storage_url']}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              object storage
+            </a>
+            .
+          </p>
+        );
+      } else {
+        // pipeline executed in-place locally
+        dialogTitle = 'Job execution succeeded';
+        dialogBody = (
+          <p>Your job has been executed in-place in your local environment.</p>
+        );
+      }
+
+      return showDialog({
+        title: dialogTitle,
+        body: dialogBody,
+        buttons: [Dialog.okButton()]
+      });
+    } catch (error) {
+      return RequestErrors.serverError(error);
     }
-
-    return showDialog({
-      title: dialogTitle,
-      body: dialogBody,
-      buttons: [Dialog.okButton()]
-    });
   }
 
   /**
@@ -175,17 +179,21 @@ export class PipelineService {
       overwrite: overwrite
     };
 
-    const response = await RequestHandler.makePostRequest(
-      'elyra/pipeline/export',
-      JSON.stringify(body),
-      true
-    );
+    try {
+      const response = await RequestHandler.makePostRequest(
+        'elyra/pipeline/export',
+        JSON.stringify(body),
+        true
+      );
 
-    return showDialog({
-      title: 'Pipeline export succeeded',
-      body: <p>Exported file: {response['export_path']} </p>,
-      buttons: [Dialog.okButton()]
-    });
+      return showDialog({
+        title: 'Pipeline export succeeded',
+        body: <p>Exported file: {response['export_path']} </p>,
+        buttons: [Dialog.okButton()]
+      });
+    } catch (error) {
+      return RequestErrors.serverError(error);
+    }
   }
 
   /**

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@blueprintjs/core": "^3.22.2",
     "@blueprintjs/select": "^3.11.2",
+    "@jupyterlab/apputils": "^2.0.2",
     "@jupyterlab/ui-components": "^2.0.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/packages/ui-components/src/RequestErrors.tsx
+++ b/packages/ui-components/src/RequestErrors.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018-2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { showDialog, Dialog } from '@jupyterlab/apputils';
+
+import * as React from 'react';
+
+import { ExpandableErrorDialog } from './ExpandableErrorDialog';
+
+/**
+ * A class for handling errors when making requests to the jupyter lab server.
+ */
+export class RequestErrors {
+  /**
+   * Displays an error dialog showing error data and stacktrace, if available.
+   *
+   * @param response - The server response containing the error data
+   *
+   * @returns A promise that resolves with whether the dialog was accepted.
+   */
+  static serverError(response: any): Promise<Dialog.IResult<any>> {
+    const reason = response.reason ? response.reason : '';
+    const message = response.message ? response.message : '';
+    const timestamp = response.timestamp ? response.timestamp : '';
+    const traceback = response.traceback ? response.traceback : '';
+    const default_body = response.timestamp
+      ? 'Check the JupyterLab log for more details at ' + response.timestamp
+      : 'Check the JupyterLab log for more details';
+
+    return showDialog({
+      title: 'Error making request',
+      body:
+        reason || message ? (
+          <ExpandableErrorDialog
+            reason={reason}
+            message={message}
+            timestamp={timestamp}
+            traceback={traceback}
+            default_msg={default_body}
+          />
+        ) : (
+          <p>{default_body}</p>
+        ),
+      buttons: [Dialog.okButton()]
+    });
+  }
+}

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -21,3 +21,4 @@ export * from './icons';
 export * from './DropDown';
 export * from './JSONComponent';
 export * from './Dropzone';
+export * from './RequestErrors';


### PR DESCRIPTION
This addresses point 3 in https://github.com/elyra-ai/elyra/issues/785#issuecomment-664719618

This moves the error handling code in `requests.tsx` that depends on `ui-components` into `ui-components` and replaces them with a Promise reject

Then it wraps all the calls to `requests.tsx` in try catch blocks that call the error handling that was moved to `ui-components`

This PR is built on top of https://github.com/elyra-ai/elyra/issues/785#issuecomment-664719618 and thus also includes all it's changes

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

