### PR TITLE
Move NotebookParser from application to pipeline-editor

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -16,6 +16,5 @@
 
 import '../style/index.css';
 
-export * from './parsing';
 export * from './services';
 export * from './requests';

--- a/packages/application/src/requests.tsx
+++ b/packages/application/src/requests.tsx
@@ -22,6 +22,13 @@ import { ServerConnection } from '@jupyterlab/services';
 import * as React from 'react';
 
 /**
+ * An interface for typing json dictionaries in typescript
+ */
+export interface IDictionary<T> {
+  [key: string]: T;
+}
+
+/**
  * A service class for making requests to the jupyter lab server.
  */
 export class RequestHandler {

--- a/packages/application/src/services.tsx
+++ b/packages/application/src/services.tsx
@@ -17,8 +17,7 @@
 import { Dialog, showDialog } from '@jupyterlab/apputils';
 import * as React from 'react';
 
-import { IDictionary } from './parsing';
-import { RequestHandler } from './requests';
+import { IDictionary, RequestHandler } from './requests';
 
 const ELYRA_SCHEMA_API_ENDPOINT = 'elyra/schema/';
 const ELYRA_METADATA_API_ENDPOINT = 'elyra/metadata/';

--- a/packages/application/src/test/application.spec.ts
+++ b/packages/application/src/test/application.spec.ts
@@ -14,55 +14,12 @@
  * limitations under the License.
  */
 
-import * as nbformat from '@jupyterlab/nbformat';
-import { NotebookModel } from '@jupyterlab/notebook';
-import { JupyterServer, NBTestUtils } from '@jupyterlab/testutils';
+import { JupyterServer } from '@jupyterlab/testutils';
 
-import { NotebookParser } from '../parsing';
 import { RequestHandler } from '../requests';
 import { FrontendServices } from '../services';
 
 const server = new JupyterServer();
-const notebookWithEnvVars: any = {
-  cells: [
-    {
-      cell_type: 'code',
-      execution_count: null,
-      metadata: {},
-      outputs: [],
-      source: [
-        'import os\n',
-        "print(os.environ['HOME'])\n",
-        'print(os.getenv("HOME2"))\n',
-        "print(os.getenvb('HOME3'))\n",
-        'print(os.getenvb("HOME4"))\n',
-        "print(os.environb['HOME5'))\n",
-        'print(os.environb["HOME6"])\n'
-      ]
-    }
-  ],
-  metadata: {
-    kernelspec: {
-      display_name: 'Python 3',
-      language: 'python',
-      name: 'python3'
-    },
-    language_info: {
-      codemirror_mode: {
-        name: 'ipython',
-        version: 3
-      },
-      file_extension: '.py',
-      mimetype: 'text/x-python',
-      name: 'python',
-      nbconvert_exporter: 'python',
-      pygments_lexer: 'ipython3',
-      version: '3.7.6'
-    }
-  },
-  nbformat: 4,
-  nbformat_minor: 4
-};
 
 const codeSnippetMetadata = {
   schema_name: 'code-snippet',
@@ -208,34 +165,6 @@ describe('@elyra/application', () => {
             false
           )
         ).toMatchObject({ 'code-snippets': [] });
-      });
-    });
-  });
-
-  describe('NotebookParser', () => {
-    describe('getEnvVars', () => {
-      it('should find no env vars where there are none', () => {
-        const notebook = NBTestUtils.createNotebook();
-        NBTestUtils.populateNotebook(notebook);
-        expect(
-          NotebookParser.getEnvVars(notebook.model.toString())
-        ).toMatchObject([]);
-      });
-
-      it('should find env vars', () => {
-        const notebook = NBTestUtils.createNotebook();
-        const model = new NotebookModel();
-        model.fromJSON(notebookWithEnvVars as nbformat.INotebookContent);
-        notebook.model = model;
-        const foundEnvVars = NotebookParser.getEnvVars(
-          notebook.model.toString()
-        );
-        expect(foundEnvVars).toContain('HOME');
-        expect(foundEnvVars).toContain('HOME2');
-        expect(foundEnvVars).toContain('HOME3');
-        expect(foundEnvVars).toContain('HOME4');
-        expect(foundEnvVars).toContain('HOME5');
-        expect(foundEnvVars).toContain('HOME6');
       });
     });
   });

--- a/packages/pipeline-editor/src/NotebookParser.ts
+++ b/packages/pipeline-editor/src/NotebookParser.ts
@@ -15,13 +15,6 @@
  */
 
 /**
- * An interface for typing json dictionaries in typescript
- */
-export interface IDictionary<T> {
-  [key: string]: T;
-}
-
-/**
  * A utilities class for parsing notebook files.
  */
 export class NotebookParser {

--- a/packages/pipeline-editor/src/SubmitNotebookButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitNotebookButtonExtension.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { NotebookParser } from '@elyra/application';
 import { showFormDialog } from '@elyra/ui-components';
 import { Dialog, ToolbarButton } from '@jupyterlab/apputils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
@@ -24,6 +23,7 @@ import { IDisposable } from '@lumino/disposable';
 import * as React from 'react';
 
 import { formDialogWidget } from './formDialogWidget';
+import { NotebookParser } from './NotebookParser';
 import { NotebookSubmissionDialog } from './NotebookSubmissionDialog';
 import { PipelineService } from './PipelineService';
 import Utils from './utils';

--- a/packages/pipeline-editor/src/canvas.ts
+++ b/packages/pipeline-editor/src/canvas.ts
@@ -16,13 +16,12 @@
 
 import * as path from 'path';
 
-import { NotebookParser } from '@elyra/application';
-
 import { IconUtil } from '@elyra/ui-components';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { Contents } from '@jupyterlab/services';
 import { LabIcon, notebookIcon, pythonIcon } from '@jupyterlab/ui-components';
 
+import { NotebookParser } from './NotebookParser';
 import { PipelineService } from './PipelineService';
 
 enum ContentType {


### PR DESCRIPTION
The utility class NotebookParser is only used in pipeline-editor and so it could be argued that it should belong in that package instead

This addresses point 2 in https://github.com/elyra-ai/elyra/issues/785#issuecomment-664719618 refactoring `application`

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

