### PR TITLE
Properly handle references to missing schema files

### DIFF
--- a/elyra/metadata/error.py
+++ b/elyra/metadata/error.py
@@ -16,7 +16,7 @@
 """This module includes custom error classes pertaining to the metadata service."""
 
 
-class MetadataNotFoundError(BaseException):
+class MetadataNotFoundError(Exception):
     """Raised when a metadata instance is not found.
 
        Overrides FileNotFoundError to set contextual message text
@@ -26,7 +26,7 @@ class MetadataNotFoundError(BaseException):
         super().__init__("No such instance named '{}' was found in the {} namespace.".format(name, namespace))
 
 
-class MetadataExistsError(BaseException):
+class MetadataExistsError(Exception):
     """Raised when a metadata instance unexpectedly exists.
 
        Overrides FileExistsError to set contextual message text
@@ -36,7 +36,7 @@ class MetadataExistsError(BaseException):
         super().__init__("An instance named '{}' already exists in the {} namespace.".format(name, namespace))
 
 
-class SchemaNotFoundError(BaseException):
+class SchemaNotFoundError(Exception):
     """Raised when a schema instance is not found.
 
        Overrides FileNotFoundError to set contextual message text

--- a/elyra/metadata/manager.py
+++ b/elyra/metadata/manager.py
@@ -68,9 +68,9 @@ class MetadataManager(LoggingConfigurable):
         instance_list = self.metadata_store.fetch_instances(include_invalid=include_invalid)
         for metadata_dict in instance_list:
             # validate the instance prior to return, include invalid instances as appropriate
-            metadata = Metadata.from_dict(self.namespace, metadata_dict)
-            metadata.post_load()  # Allow class instances to handle loads
             try:
+                metadata = Metadata.from_dict(self.namespace, metadata_dict)
+                metadata.post_load()  # Allow class instances to handle loads
                 # if we're including invalid and there was an issue on retrieval, add it to the list
                 if include_invalid and metadata.reason:
                     # If no schema-name is present, set to '{unknown}' since we can't make that determination.
@@ -80,11 +80,14 @@ class MetadataManager(LoggingConfigurable):
                     self.validate(metadata.name, metadata)
                 instances.append(metadata)
             except Exception as ex:  # Ignore ValidationError and others when fetching all instances
+                # Since we may not have a metadata instance due to a failure during `from_dict()`,
+                # instantiate a bad instance directly to use in the message and invalid result.
+                invalid_instance = Metadata(**metadata_dict)
                 self.log.debug("Fetch of instance '{}' of namespace '{}' encountered an exception: {}".
-                               format(metadata.name, self.namespace, ex))
+                               format(invalid_instance.name, self.namespace, ex))
                 if include_invalid:
-                    metadata.reason = ex.__class__.__name__
-                    instances.append(metadata)
+                    invalid_instance.reason = ex.__class__.__name__
+                    instances.append(invalid_instance)
         return instances
 
     def get(self, name: str) -> Metadata:

--- a/elyra/metadata/metadata.py
+++ b/elyra/metadata/metadata.py
@@ -73,11 +73,8 @@ class Metadata(object):
         metadata_class_name = 'elyra.metadata.Metadata'
         schema_name = metadata_dict.get('schema_name')
         if schema_name:
-            try:
-                schema = SchemaManager.instance().get_schema(namespace, schema_name)
-                metadata_class_name = schema.get('metadata_class_name', metadata_class_name)
-            except Exception:  # just use the default
-                pass
+            schema = SchemaManager.instance().get_schema(namespace, schema_name)
+            metadata_class_name = schema.get('metadata_class_name', metadata_class_name)
         metadata_class = import_item(metadata_class_name)
         try:
             instance = metadata_class(**metadata_dict)

--- a/elyra/metadata/tests/conftest.py
+++ b/elyra/metadata/tests/conftest.py
@@ -24,7 +24,7 @@ from tornado.escape import url_escape
 from elyra.metadata import MetadataManager, SchemaManager, METADATA_TEST_NAMESPACE  # noqa: F401
 
 from .test_utils import valid_metadata_json, invalid_metadata_json, another_metadata_json, byo_metadata_json, \
-    invalid_json, create_json_file, create_instance
+    invalid_json, invalid_schema_name_json, create_json_file, create_instance
 
 
 # BEGIN - Remove once transition to jupyter_server occurs
@@ -134,6 +134,7 @@ def tests_manager(environ, namespace_location, request):
     create_instance(store_mgr, namespace_location, 'another', another_metadata_json)
     create_instance(store_mgr, namespace_location, 'invalid', invalid_metadata_json)
     create_instance(store_mgr, namespace_location, 'bad', invalid_json)
+    create_instance(store_mgr, namespace_location, 'invalid_schema_name', invalid_schema_name_json)
     return metadata_mgr
 
 

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -175,7 +175,7 @@ def test_manager_get_include_invalid(tests_manager):
     metadata_list = tests_manager.get_all(include_invalid=False)
     assert len(metadata_list) == 2
     metadata_list = tests_manager.get_all(include_invalid=True)
-    assert len(metadata_list) == 4
+    assert len(metadata_list) == 5
 
 
 def test_manager_get_bad_json(tests_manager):
@@ -579,7 +579,7 @@ def test_store_namespace(store_manager, namespace_location):
 
 def test_store_fetch_instances(store_manager):
     instances_list = store_manager.fetch_instances()
-    assert len(instances_list) == 3
+    assert len(instances_list) == 4
 
 
 def test_store_fetch_no_namespace(store_manager, namespace_location):

--- a/elyra/metadata/tests/test_metadata_app.py
+++ b/elyra/metadata/tests/test_metadata_app.py
@@ -22,7 +22,8 @@ import shutil
 from tempfile import mkdtemp
 from elyra.metadata import Metadata, MetadataManager, METADATA_TEST_NAMESPACE
 from .test_utils import PropertyTester, create_json_file, valid_metadata_json, \
-    another_metadata_json, invalid_metadata_json, invalid_no_display_name_json
+    another_metadata_json, invalid_metadata_json, invalid_no_display_name_json, \
+    invalid_schema_name_json
 
 os.environ["METADATA_TESTING"] = "1"  # Enable metadata-tests namespace
 
@@ -178,7 +179,6 @@ def test_install_and_replace(script_runner, mock_data_dir):
                             '--name=test-metadata_42_valid-name', '--display_name=display_name',
                             '--required_test=required_value')
     assert ret.success is False
-    assert ret.stdout == ''
     assert "An instance named 'test-metadata_42_valid-name' already exists in the metadata-tests " \
            "namespace" in ret.stderr
 
@@ -263,13 +263,14 @@ def test_list_instances(script_runner, mock_data_dir):
     metadata_dir = os.path.join(mock_data_dir, 'metadata', METADATA_TEST_NAMESPACE)
     create_json_file(metadata_dir, 'invalid.json', invalid_metadata_json)
     create_json_file(metadata_dir, 'no_display_name.json', invalid_no_display_name_json)
+    create_json_file(metadata_dir, 'invalid_schema_name.json', invalid_schema_name_json)
 
     ret = script_runner.run('elyra-metadata', 'list', METADATA_TEST_NAMESPACE)
     assert ret.success
     lines = ret.stdout.split('\n')
-    assert len(lines) == 9  # always 5 more than the actual runtime count
+    assert len(lines) == 10  # always 5 more than the actual runtime count
     assert lines[0] == "Available metadata instances for {} (includes invalid):".format(METADATA_TEST_NAMESPACE)
-    line_elements = [line.split() for line in lines[4:8]]
+    line_elements = [line.split() for line in lines[4:9]]
     assert line_elements[0][1] == "another"
     assert line_elements[1][1] == "invalid"
     assert line_elements[1][3] == "**INVALID**"
@@ -277,6 +278,8 @@ def test_list_instances(script_runner, mock_data_dir):
     assert line_elements[2][3] == "**INVALID**"
     assert line_elements[2][4] == "(ValidationError)"
     assert line_elements[3][1] == "valid"
+    assert line_elements[4][3] == "**INVALID**"
+    assert line_elements[4][4] == "(SchemaNotFoundError)"
 
     ret = script_runner.run('elyra-metadata', 'list', METADATA_TEST_NAMESPACE, '--valid-only')
     assert ret.success

--- a/elyra/metadata/tests/test_utils.py
+++ b/elyra/metadata/tests/test_utils.py
@@ -78,6 +78,18 @@ valid_display_name_json = {
     }
 }
 
+
+invalid_schema_name_json = {
+    'schema_name': 'metadata-testxxx',
+    'display_name': 'invalid schema name',
+    'metadata': {
+        'uri_test': 'http://localhost:31823/v1/models?version=2017-02-13',
+        'number_range_test': 8,
+        'required_test': "required_value"
+    }
+}
+
+
 # Contains all values corresponding to test schema...
 complete_metadata_json = {
     "schema_name": "metadata-test",


### PR DESCRIPTION
References to "missing" schema (which can include typos in the `schema_name` value) were not handled correctly, leading to an unhandled exception.  These changes include such occurrences as invalid metadata and will include such results upon request (and not be unhandled).  The custom-defined errors now derive from `Exception` rather than `BaseException` to accommodate this change - which is probably better anyway.

Note since issue #1093 was not marked for elyra 2.x, I'm including it in master for now.  These changes should easily migrate to the elyra 2.x branch when that is officially built.
 
Fixes #1093 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

