### PR TITLE
add examples section to documentation

### DIFF
--- a/docs/source/getting_started/tutorials.md
+++ b/docs/source/getting_started/tutorials.md
@@ -39,3 +39,10 @@ If you have JupyterLab with the Elyra extensions installed, clone the repository
  - From the main menu select `git` > `Clone a repository`. (The label texts might vary depending which version of the `jupyter-git` extension is installed.)
  - Enter `https://github.com/elyra-ai/examples.git` as repository URL.
  - In the JupyterLab File Browser navigate to the `examples` directory and open `README.md`.
+
+ #### Sample pipelines
+
+The following pipelines were created by members of the extended Elyra community and should run as-is in JupyterLab and on Kubeflow Pipelines.
+
+- [Analyzing COVID-19 time series data](https://github.com/CODAIT/covid-notebooks)
+- [Analyzing flight delays](https://github.com/CODAIT/flight-delay-notebooks)

--- a/docs/source/getting_started/tutorials.md
+++ b/docs/source/getting_started/tutorials.md
@@ -15,14 +15,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 {% endcomment %}
 -->
-## Tutorials
+## Tutorials and examples
+
+The community maintains a set of official tutorials and examples for many Elyra features.
+
+### Tutorials
 
 The following tutorials highlight key features of Elyra.
 
-### Running notebook pipelines in JupyterLab
+#### Running notebook pipelines in JupyterLab
 
 Learn how to [create a notebook pipeline and run it in your local JupyterLab environment](https://github.com/elyra-ai/examples/tree/master/pipelines/hello_world).
 
-### Running notebook pipelines on Kubeflow Pipelines
+#### Running notebook pipelines on Kubeflow Pipelines
 
 Learn how to [create a notebook pipeline and run it on Kubeflow Pipelines](https://github.com/elyra-ai/examples/tree/master/pipelines/hello_world_kubeflow_pipelines). This tutorial requires a Kubeflow Pipelines deployment in a local environment or on the cloud.
+
+### Examples
+
+The [https://github.com/elyra-ai/examples](https://github.com/elyra-ai/examples) repository contains examples you can use to explore Elyra features.
+
+If you have JupyterLab with the Elyra extensions installed, clone the repository using the included [jupyter-git extension](https://github.com/jupyterlab/jupyterlab-git):
+ - From the main menu select `git` > `Clone a repository`. (The label texts might vary depending which version of the `jupyter-git` extension is installed.)
+ - Enter `https://github.com/elyra-ai/examples.git` as repository URL.
+ - In the JupyterLab File Browser navigate to the `examples` directory and open `README.md`.


### PR DESCRIPTION
Currently the official Elyra examples repository (https://github.com/elyra-ai/examples) isn't prominently mentioned in the Elyra documentation.

This PR
 - renames the `tutorials` section in `Getting started` to `tutorials and examples` 
 - adds an  `examples` section, which links to the Elyra examples repository and provides instructions how to clone the repository into the JupyterLab working directory.

![image](https://user-images.githubusercontent.com/13068832/100783357-84d29f80-33c2-11eb-9b51-ca1d577a7989.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

