### PR TITLE
Set the release script to explicitly checkout v1.x branch

### DIFF
--- a/create-release.py
+++ b/create-release.py
@@ -246,6 +246,8 @@ def checkout_code() -> None:
     check_run(['git', 'config', 'user.name', config.git_user_name], cwd=config.source_dir)
     check_run(['git', 'config', 'user.email', config.git_user_email], cwd=config.source_dir)
 
+    check_run(['git', 'checkout', 'v1.x'], cwd=config.source_dir)
+    check_run(['git', 'status'], cwd=config.source_dir)
     print('')
 
 


### PR DESCRIPTION
Set the release script to explicitly checkout v1.x branch
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

