### PR TITLE
update container-image targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,11 +146,16 @@ dist-ui: build-ui
 
 release: dist-ui build-server ## Build wheel file for release
 
-docker-image: ## Build docker image
+container-image: ## Build container image
 	@mkdir -p build/docker
 	cp etc/docker/elyra/Dockerfile build/docker/Dockerfile
 	cp etc/docker/elyra/start-elyra.sh build/docker/start-elyra.sh
 	DOCKER_BUILDKIT=1 docker build -t docker.io/$(IMAGE) -t quay.io/$(IMAGE) build/docker/ --progress plain
+
+publish-container-image: container-image ## Publish container image
+    # this is a privileged operation; a `docker login` might be required
+	docker push docker.io/$(IMAGE)
+	docker push quay.io/$(IMAGE)
 
 validate-runtime-images: ## Validates delivered runtime-images meet minimum criteria
 	@required_commands=$(REQUIRED_RUNTIME_IMAGE_COMMANDS) ; \


### PR DESCRIPTION
This PR:
 - renames the existing [Elyra] `docker-image` target to `container-image` (so we start using more general terminology)
 - adds a `publish-container-image` target, which  pushes the Elyra container image to Docker Hub and quay.io. This is a privileged task and only users with the appropriate access to the target project on hub.docker.com and quay.io can perform it by default, after they've logged in to the registries. 

The main goal of this PR is to assure that each task in the Elyra lifecycle is "documented", which is not yet the case for the container image publication process is not, as far as I can tell scanning at the documentation. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

