### PR TITLE
Use pytest-plugins array to declare fixtures since entry points have been removed

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,19 @@
+#
+# Copyright 2018-2020 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+
+pytest_plugins = ["pytest_jupyter.jupyter_server"]
+

--- a/elyra/metadata/tests/conftest.py
+++ b/elyra/metadata/tests/conftest.py
@@ -20,7 +20,6 @@ from elyra.metadata import MetadataManager, SchemaManager, METADATA_TEST_NAMESPA
 from .test_utils import valid_metadata_json, invalid_metadata_json, another_metadata_json, byo_metadata_json, \
     invalid_json, invalid_schema_name_json, create_json_file, create_instance
 
-pytest_plugins = ["pytest_jupyter.jupyter_server"]
 
 def mkdir(tmp_path, *parts):
     path = tmp_path.joinpath(*parts)

--- a/elyra/metadata/tests/conftest.py
+++ b/elyra/metadata/tests/conftest.py
@@ -20,6 +20,7 @@ from elyra.metadata import MetadataManager, SchemaManager, METADATA_TEST_NAMESPA
 from .test_utils import valid_metadata_json, invalid_metadata_json, another_metadata_json, byo_metadata_json, \
     invalid_json, invalid_schema_name_json, create_json_file, create_instance
 
+pytest_plugins = ["pytest_jupyter.jupyter_server"]
 
 def mkdir(tmp_path, *parts):
     path = tmp_path.joinpath(*parts)

--- a/elyra/metadata/tests/test_handlers.py
+++ b/elyra/metadata/tests/test_handlers.py
@@ -126,7 +126,8 @@ async def test_create_instance(jp_base_url, jp_fetch):
 
     r = await jp_fetch('elyra', 'metadata', METADATA_TEST_NAMESPACE, body=body, method='POST')
     assert r.code == 201
-    assert r.headers.get('Location') == url_path_join(jp_base_url, '/elyra', 'metadata', METADATA_TEST_NAMESPACE, 'valid')
+    assert r.headers.get('Location') == url_path_join(jp_base_url, '/elyra', 'metadata',
+                                                      METADATA_TEST_NAMESPACE, 'valid')
     metadata = json.loads(r.body.decode())
     # Add expected "extra" fields to 'valid' so whole-object comparison is satisfied.
     # These are added during the pre_save() hook on the MockMetadataTest class instance.

--- a/elyra/metadata/tests/test_handlers.py
+++ b/elyra/metadata/tests/test_handlers.py
@@ -117,7 +117,7 @@ async def test_get_hierarchy_instances(jp_fetch, setup_hierarchy):
     assert byo_3['display_name'] == 'factory'
 
 
-async def test_create_instance(jp_fetch):
+async def test_create_instance(jp_base_url, jp_fetch):
     """Create a simple instance - not conflicting with factory instances. """
 
     valid = copy.deepcopy(valid_metadata_json)
@@ -126,7 +126,7 @@ async def test_create_instance(jp_fetch):
 
     r = await jp_fetch('elyra', 'metadata', METADATA_TEST_NAMESPACE, body=body, method='POST')
     assert r.code == 201
-    assert r.headers.get('Location') == url_path_join('/elyra', 'metadata', METADATA_TEST_NAMESPACE, 'valid')
+    assert r.headers.get('Location') == url_path_join(jp_base_url, '/elyra', 'metadata', METADATA_TEST_NAMESPACE, 'valid')
     metadata = json.loads(r.body.decode())
     # Add expected "extra" fields to 'valid' so whole-object comparison is satisfied.
     # These are added during the pre_save() hook on the MockMetadataTest class instance.


### PR DESCRIPTION
The `pytest-jupyter` package has removed its use of entry points to register its fixtures since this approach would require that `jupyter_server` be installed for **any** packages being tested in environments in which `pytest-jupyter` has been installed, even though those tests have nothing to do with Jupyter Server.  As a result, it is now necessary to use the `pytest-plugins=['plugin-name']` approach to letting pytest know which fixtures are needed. 

This PR adds that declaration and addresses a test failure introduced by another recent fixture change relative to the base URL fixture `jp_base_url`.

**Note: All metadata-handler tests will fail until this PR is merged.**
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

