### PR TITLE
Add link to GitHub discussion forum to "Getting help" documentation

### DIFF
--- a/docs/source/getting_started/getting-help.md
+++ b/docs/source/getting_started/getting-help.md
@@ -19,6 +19,10 @@ limitations under the License.
 
 Thank you for your interest in Elyra!
 
+### General questions
+
+Share your questions and ideas with the community in the [GitHub discussion forum](https://github.com/elyra-ai/elyra/discussions). 
+
 ### Create an issue or feature request
 
 If you encounter a problem or have suggestions for improvements please [open an issue on GitHub](https://github.com/elyra-ai/elyra/issues).


### PR DESCRIPTION
This PR adds a link to the new discussion forum to the `Getting help` topic in the Elyra documentation at https://elyra.readthedocs.io/en/latest/getting_started/getting-help.html. This provides users with another venue to ask questions, hopefully reducing the need to create an issue.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

