### PR TITLE
Enables removal of optional metadata fields

### DIFF
--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -245,6 +245,11 @@ export class MetadataEditor extends ReactWidget {
     // Special case because all metadata has a display name
     if (schemaField === 'display_name') {
       this.displayName = event.nativeEvent.target.value;
+    } else if (
+      !event.nativeEvent.target.value &&
+      !this.requiredFields.includes(schemaField)
+    ) {
+      delete this.metadata[schemaField];
     } else {
       this.metadata[schemaField] = event.nativeEvent.target.value;
     }


### PR DESCRIPTION
Currently once you add value for an optional field in the
MetadataEditor you are unable to remove a value entirely.

This only enables removing an optional value for text fields

Fixes #1087



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

