### PR TITLE
Update xeus-python version to 0.9.3

### DIFF
--- a/etc/scripts/clean-jupyterlab.sh
+++ b/etc/scripts/clean-jupyterlab.sh
@@ -52,12 +52,12 @@ pip install --upgrade --pre "jupyterlab$LAB_VERSION"
 echo " "
 
 echo "Installing Xeus kernel"
-XPYTHON_VERSION="$(python --version)"
-if [[ "$XPYTHON_VERSION" == *"Python 3.7"* ]]
+XPYTHON_VERSION="$(python --version 2>&1)"
+if [[ "$XPYTHON_VERSION" == *"Python 3.6"* ]]
 then
     conda install -y xeus-python">=0.8.0,<0.9.0" -c conda-forge
 else
-    conda install -y xeus-python=0.9.0 -c conda-forge
+    conda install -y xeus-python">=0.9.3" -c conda-forge
 fi
 echo " "
 


### PR DESCRIPTION
As a follow up to #1125 , the release of xeus-python 0.9.3 is now compatible with Python 3.7.
The `clean-jupyterlab` script is being updated to install the earliest version.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

