### PR TITLE
Update to Jupyter Server 1.2.0

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,5 +15,5 @@
 #
 import pytest
 
-pytest_plugins = ["pytest_jupyter.jupyter_server"]
+pytest_plugins = ["jupyter_server.pytest_plugin"]
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup_args = dict(
         'jsonschema>=3.2.0',
         'jupyter_core>=4.0,<5.0',
         'jupyter_client>=6.1.7',
-        'jupyter_server>=1.0.5',
+        'jupyter_server>=1.2.0',
         'jupyterlab>==3.0.0rc10',
         # 'jupyterlab-git==0.21.1',
         'kfp-notebook>=0.17.0,<0.18.0',
@@ -72,7 +72,7 @@ setup_args = dict(
         'websocket-client',
     ],
     extras_require={
-        'test': ['pytest', 'pytest-tornasync', 'pytest-jupyter'],
+        'test': ['pytest', 'pytest-tornasync'],
     },
     include_package_data=True,
     classifiers=(

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,4 @@
 pytest>=5.4.1
-pytest-jupyter
 pytest-tornasync
 pytest-console-scripts
 flake8


### PR DESCRIPTION
After the removal of pytest-jupter from PyPi we need to
update to latest Jupyter Server release to re-enable our
CI



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

