### PR TITLE
Update docs for clarity around creating KfDef YAML

### DIFF
--- a/docs/source/recipes/deploying-elyra-with-opendatahub.md
+++ b/docs/source/recipes/deploying-elyra-with-opendatahub.md
@@ -53,7 +53,7 @@ OpenShift Cluster.
 - Once the Operator has finished installing, navigate to the `Installed Operators` page under  the `Operators` dropdown
  and click on 'Open Data Hub'
 ![Elyra](../images/odh-deploy-create-kfdef.png) 
-- Click on `Create KfDef`, you should see a default configuration. Replace it with the following:  
+- Click on `Create KfDef`, then select 'YAML View'. You should now see a default configuration. Replace it with the following:  
 NOTE: Make sure to fill in the namespace field with the `Project` name you created earlier
 ```yaml
 apiVersion: kfdef.apps.kubeflow.org/v1


### PR DESCRIPTION
In the documentation, after clicking 'Create KfDef' the user is taken to a screen where they're shown the form view and given the option for YAML. This change adds clarity, as on a quick glance it would appear the YAML view is not there. Language was added to make this more obvious.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

