### PR TITLE
Save as code snippet from editor selection

### DIFF
--- a/packages/code-snippet/package.json
+++ b/packages/code-snippet/package.json
@@ -43,6 +43,7 @@
     "@jupyterlab/docregistry": "^3.0.0",
     "@jupyterlab/fileeditor": "^3.0.0",
     "@jupyterlab/mainmenu": "^3.0.0",
+    "@jupyterlab/markdownviewer": "^3.0.0",
     "@jupyterlab/notebook": "^3.0.0",
     "@jupyterlab/ui-components": "^3.0.0",
     "@lumino/algorithm": "^1.3.3",

--- a/packages/code-snippet/src/index.ts
+++ b/packages/code-snippet/src/index.ts
@@ -36,6 +36,10 @@ import { CodeSnippetWidget } from './CodeSnippetWidget';
 
 const CODE_SNIPPET_EXTENSION_ID = 'elyra-code-snippet-extension';
 
+const commandIDs = {
+  saveAsSnippet: 'codesnippet:save-as-snippet'
+};
+
 /**
  * Initialization data for the code-snippet extension.
  */
@@ -74,6 +78,28 @@ export const code_snippet_extension: JupyterFrontEndPlugin<void> = {
     // Rank has been chosen somewhat arbitrarily to give priority to the running
     // sessions widget in the sidebar.
     app.shell.add(codeSnippetWidget, 'left', { rank: 900 });
+
+    app.commands.addCommand(commandIDs.saveAsSnippet, {
+      label: 'Save As Code Snippet',
+      isEnabled: () => true,
+      isVisible: () => true,
+      execute: () => {
+        const selection = document.getSelection().toString();
+
+        console.log('SAVING AS CODE SNIPPET...');
+        console.log(selection);
+      }
+    });
+
+    app.contextMenu.addItem({
+      command: commandIDs.saveAsSnippet,
+      selector: '.jp-Cell'
+    });
+
+    app.contextMenu.addItem({
+      command: commandIDs.saveAsSnippet,
+      selector: '.jp-FileEditor'
+    });
   }
 };
 

--- a/packages/code-snippet/src/index.ts
+++ b/packages/code-snippet/src/index.ts
@@ -107,7 +107,8 @@ export const code_snippet_extension: JupyterFrontEndPlugin<void> = {
             codeSnippetWidget.openMetadataEditor({
               namespace: CODE_SNIPPET_NAMESPACE,
               schema: CODE_SNIPPET_SCHEMA,
-              code: selection.split('\n')
+              code: selection.split('\n'),
+              onSave: codeSnippetWidget.updateMetadata
             });
           }
         }

--- a/packages/code-snippet/src/index.ts
+++ b/packages/code-snippet/src/index.ts
@@ -103,9 +103,13 @@ export const code_snippet_extension: JupyterFrontEndPlugin<void> = {
         const editor = getEditor(currentWidget);
         if (editor) {
           const selection = getTextSelection(editor);
-
-          console.log('SAVING AS CODE SNIPPET...');
-          console.log('SELECTION: ' + selection);
+          if (selection) {
+            codeSnippetWidget.openMetadataEditor({
+              namespace: CODE_SNIPPET_NAMESPACE,
+              schema: CODE_SNIPPET_SCHEMA,
+              code: selection.split('\n')
+            });
+          }
         }
       }
     });

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -311,6 +311,7 @@ export class MetadataEditor extends ReactWidget {
         initialCodeValue = this.metadata['code'].join('\n');
       } else {
         if (this.code) {
+          this.metadata['code'] = this.code;
           initialCodeValue = this.code.join('\n');
         } else {
           initialCodeValue = '';

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -39,6 +39,7 @@ interface IMetadataEditorProps {
   schema: string;
   namespace: string;
   name?: string;
+  code?: string[];
   onSave: () => void;
   editorServices: IEditorServices | null;
   status: ILabStatus;
@@ -57,6 +58,7 @@ export class MetadataEditor extends ReactWidget {
   schemaDisplayName: string;
   namespace: string;
   name: string;
+  code: string[];
   dirty: boolean;
   allTags: string[];
   clearDirty: IDisposable;
@@ -80,6 +82,7 @@ export class MetadataEditor extends ReactWidget {
     this.allTags = [];
     this.onSave = props.onSave;
     this.name = props.name;
+    this.code = props.code;
 
     this.widgetClass = `elyra-metadataEditor-${this.name ? this.name : 'new'}`;
     this.addClass(this.widgetClass);
@@ -307,7 +310,11 @@ export class MetadataEditor extends ReactWidget {
       if (this.name) {
         initialCodeValue = this.metadata['code'].join('\n');
       } else {
-        initialCodeValue = '';
+        if (this.code) {
+          initialCodeValue = this.code.join('\n');
+        } else {
+          initialCodeValue = '';
+        }
       }
       this.editor = this.editorServices.factoryService.newInlineEditor({
         host: document.getElementById('code:' + this.id),


### PR DESCRIPTION
Resolves #1005

This PR implements the 'Save as Code Snippet' command.

1. Select text from notebook or file editor
2. Right click to open the context menu
3. Select 'Save as Code Snippet'
4. Metadata editor opens, code field is pre-populated with selection
5. User fills out remaining form fields

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

