### PR TITLE
Fix console warning on properties flyout

### DIFF
--- a/packages/pipeline-editor/src/StringArrayInput.tsx
+++ b/packages/pipeline-editor/src/StringArrayInput.tsx
@@ -71,7 +71,7 @@ export class StringArrayInput extends React.Component {
     this.controller.updatePropertyValue({ name: this.parameter }, this.values);
   };
 
-  renderControl() {
+  renderControl(): any {
     this.values = this.controller.getPropertyValue(this.parameter);
     return (
       <div>

--- a/packages/pipeline-editor/src/StringArrayInput.tsx
+++ b/packages/pipeline-editor/src/StringArrayInput.tsx
@@ -36,28 +36,59 @@ export class StringArrayInput extends React.Component {
     this.fileBrowser = data.filebrowser;
     this.parameter = parameters['name'];
     this.controller = controller;
+
+    this.deleteHandler = this.deleteHandler.bind(this);
+    this.onTextAreaChange = this.onTextAreaChange.bind(this);
+    this.onInputChange = this.onInputChange.bind(this);
+    this.addHandler = this.addHandler.bind(this);
   }
 
+  deleteHandler = (index: number): void => {
+    delete this.values[index];
+    this.controller.updatePropertyValue({ name: this.parameter }, this.values);
+  };
+
+  onTextAreaChange = (props: any): void => {
+    this.values = props.value.split('\n');
+  };
+
+  onInputChange = (event: any, index: number): void => {
+    event.target.value
+      .split('\n')
+      .forEach((element: string, valueIndex: number): void => {
+        if (valueIndex === 0) {
+          this.values[index] = element;
+        } else {
+          this.values.splice(index, 0, element);
+        }
+      });
+    this.values[index] = event.target.value;
+    this.controller.updatePropertyValue({ name: this.parameter }, this.values);
+  };
+
+  addHandler = (): void => {
+    this.values.push('');
+    this.controller.updatePropertyValue({ name: this.parameter }, this.values);
+  };
+
   renderControl() {
-    const parameter = this.parameter;
-    this.values = this.controller.getPropertyValue(parameter);
+    this.values = this.controller.getPropertyValue(this.parameter);
     return (
       <div>
         <div id={this.parameter}>
           {this.values.map((value: any, index: number) => (
             <ControlGroup
-              key={parameter + index + 'ControlGroup'}
+              key={this.parameter + index + 'ControlGroup'}
               style={{ marginBottom: 4 }}
             >
               <InputGroup
                 fill
-                key={parameter + index + 'InputGroup'}
+                key={this.parameter + index + 'InputGroup'}
                 className="jp-InputGroup"
                 defaultValue={value}
                 placeholder={this.placeholder}
                 onChange={(event: any): void => {
-                  this.values[index] = event.target.value;
-                  this.controller.updatePropertyValue(parameter, this.values);
+                  this.onInputChange(event, index);
                 }}
               />
               {this.fileBrowser ? (
@@ -83,23 +114,21 @@ export class StringArrayInput extends React.Component {
                 className="jp-Button"
                 icon="cross"
                 onClick={(): void => {
-                  delete this.values[index];
-                  this.controller.updatePropertyValue(parameter, this.values);
+                  this.deleteHandler(index);
                 }}
               />
             </ControlGroup>
           ))}
         </div>
-        <Button
-          className="jp-Button"
-          onClick={(): void => {
-            this.values.push('');
-            this.controller.updatePropertyValue(parameter, this.values);
-          }}
-          style={{ marginTop: 8 }}
-        >
-          Add {this.singleItemLabel ? this.singleItemLabel : 'item'}
-        </Button>
+        <div style={{ display: 'flex' }}>
+          <Button
+            className="jp-Button"
+            onClick={this.addHandler}
+            style={{ marginTop: 8 }}
+          >
+            Add {this.singleItemLabel ? this.singleItemLabel : 'item'}
+          </Button>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
An issue with handlers was causing a warning in the console when interacting with the lists in the properties flyout. This just moves the handlers into functions and binds them to prevent the warning. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

