### PR TITLE
Fix test failure due to jest timeout

### DIFF
--- a/packages/application/src/test/application.spec.ts
+++ b/packages/application/src/test/application.spec.ts
@@ -21,6 +21,7 @@ import { JupyterServer, NBTestUtils } from '@jupyterlab/testutils';
 import { MetadataService } from '../metadata';
 import { NotebookParser } from '../parsing';
 import { RequestHandler } from '../requests';
+jest.setTimeout(3 * 60 * 1000);
 
 const server = new JupyterServer();
 const notebookWithEnvVars: any = {


### PR DESCRIPTION
Jest tests started running tests before the Jupyter Server started because the `await` timed out. This fixes the issue by increasing the timeout time. Not sure if we should look into the longer start time for server? 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

