### PR TITLE
Re-order  kfp.json metadata schema

### DIFF
--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -40,6 +40,16 @@
             "category": "Kubeflow Pipelines"
           }
         },
+        "user_namespace": {
+          "title": "Kubeflow Pipelines User Namespace",
+          "description": "The Kubeflow Pipelines user namespace used to create experiments",
+          "type": "string",
+          "pattern": "^[a-z0-9][-a-z0-9]*[a-z0-9]$",
+          "maxLength": 63,
+          "uihints": {
+            "category": "Kubeflow Pipelines"
+          }
+        },
         "api_username": {
           "title": "Kubeflow Pipelines API Endpoint Username",
           "description": "The Kubeflow Pipelines API endpoint username",
@@ -54,16 +64,6 @@
           "type": "string",
           "uihints": {
             "secure": true,
-            "category": "Kubeflow Pipelines"
-          }
-        },
-        "user_namespace": {
-          "title": "Kubeflow Pipelines User Namespace",
-          "description": "The Kubeflow Pipelines user namespace used to create experiments",
-          "type": "string",
-          "pattern": "^[a-z0-9][-a-z0-9]*[a-z0-9]$",
-          "maxLength": 63,
-          "uihints": {
             "category": "Kubeflow Pipelines"
           }
         },


### PR DESCRIPTION
This PR changes the  order from "API Endpoint URL" "user name" "password" "namespace"
to "API Endpoint URL" "namespace" "user name" "password" to improve
usability in the Runtime configuration UI by grouping semantically related properties:
 - API endpoint and namespace are now displayed side-by-side 
 - user name and password fields are now displayed side-by-side
![image](https://user-images.githubusercontent.com/13068832/105762836-ce92be80-5f09-11eb-9c1d-ff1c3af9b3e3.png)




 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

