### PR TITLE
Fix kfp template resource rendering when exporting

### DIFF
--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -155,7 +155,7 @@ class KfpPipelineProcessor(PipelineProcessor):
             # Load template from installed elyra package
             t0 = time.time()
             loader = PackageLoader('elyra', 'templates')
-            template_env = Environment(loader=loader)
+            template_env = Environment(loader=loader, trim_blocks=True)
 
             template_env.filters['to_basename'] = lambda path: os.path.basename(path)
 

--- a/elyra/templates/kfp_template.jinja2
+++ b/elyra/templates/kfp_template.jinja2
@@ -28,7 +28,7 @@ def create_pipeline():
         {% if operation.mem_request %}
                                                       mem_request='{{ operation.mem_request }}',
         {% endif %}
-        {% if operation.gpu_request %}
+        {% if operation.gpu_limit %}
                                                       gpu_limit='{{ operation.gpu_limit }}',
         {% endif %}
                                                       image='{{ operation.image }}',

--- a/elyra/templates/kfp_template.jinja2
+++ b/elyra/templates/kfp_template.jinja2
@@ -22,9 +22,15 @@ def create_pipeline():
                                                       cos_dependencies_archive='{{ operation.cos_dependencies_archive }}',
                                                       pipeline_inputs={{ operation.pipeline_inputs }},
                                                       pipeline_outputs={{ operation.pipeline_outputs }},
+        {% if operation.cpu_request %}
                                                       cpu_request='{{ operation.cpu_request }}',
-                                                      mem_request='{{ operation.mem_request }}G',
+        {% endif %}
+        {% if operation.mem_request %}
+                                                      mem_request='{{ operation.mem_request }}',
+        {% endif %}
+        {% if operation.gpu_request %}
                                                       gpu_limit='{{ operation.gpu_limit }}',
+        {% endif %}
                                                       image='{{ operation.image }}',
                                                       file_outputs={
                                                         'mlpipeline-metrics': '{{ metrics_file }}',


### PR DESCRIPTION
- Render resource requests in kfp template only when values exist
- Remove 'G' memory unit from template since notebook operation
will handle



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

