### PR TITLE
Fix enum / undefined dropdown bug

### DIFF
--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -335,20 +335,22 @@ export class MetadataEditor extends ReactWidget {
   }
 
   getDefaultChoices(fieldName: string): any[] {
-    let defaultChoices = this.schema[fieldName].uihints.default_choices;
-    if (defaultChoices === undefined) {
-      defaultChoices = [];
-    }
-    for (const otherMetadata of this.allMetadata) {
-      if (
-        !find(defaultChoices, (choice: string) => {
-          return (
-            choice.toLowerCase() ===
-            otherMetadata.metadata[fieldName].toLowerCase()
-          );
-        })
-      ) {
-        defaultChoices.push(otherMetadata.metadata[fieldName]);
+    let defaultChoices = this.schema[fieldName].enum;
+    if (!defaultChoices) {
+      defaultChoices = this.schema[fieldName].uihints.default_choices || [];
+      for (const otherMetadata of this.allMetadata) {
+        if (
+          // Don't add if otherMetadata hasn't defined field
+          otherMetadata.metadata[fieldName] &&
+          !find(defaultChoices, (choice: string) => {
+            return (
+              choice.toLowerCase() ===
+              otherMetadata.metadata[fieldName].toLowerCase()
+            );
+          })
+        ) {
+          defaultChoices.push(otherMetadata.metadata[fieldName]);
+        }
       }
     }
     return defaultChoices;
@@ -459,6 +461,7 @@ export class MetadataEditor extends ReactWidget {
           choice={this.metadata[fieldName]}
           defaultChoices={this.getDefaultChoices(fieldName)}
           handleDropdownChange={this.handleDropdownChange}
+          allowCreate={!this.schema[fieldName].enum}
         ></DropDown>
       );
     } else if (uihints.field_type === 'code') {

--- a/packages/pipeline-editor/style/canvas.css
+++ b/packages/pipeline-editor/style/canvas.css
@@ -466,10 +466,6 @@ img.toolbar-icons[disabled] {
     inset 0 -1px 0 rgba(16, 22, 26, 0.1);
 }
 
-.bp3-input {
-  background: #000000;
-}
-
 .bp3-input[readonly] {
   color: rgba(92, 112, 128, 0.6);
   cursor: not-allowed;

--- a/packages/ui-components/src/DropDown.tsx
+++ b/packages/ui-components/src/DropDown.tsx
@@ -30,6 +30,7 @@ export interface IDropDownProps {
   defaultChoices?: string[];
   handleDropdownChange: any;
   intent: Intent;
+  allowCreate: boolean;
 }
 
 export class DropDown extends React.Component<IDropDownProps> {
@@ -91,10 +92,16 @@ export class DropDown extends React.Component<IDropDownProps> {
         <Select
           items={this.props.defaultChoices}
           itemPredicate={this.filterDropdown}
-          createNewItemFromQuery={(newValue: any): void => {
-            return newValue;
-          }}
-          createNewItemRenderer={this.renderCreateOption}
+          createNewItemFromQuery={
+            this.props.allowCreate
+              ? (newValue: any): void => {
+                  return newValue;
+                }
+              : undefined
+          }
+          createNewItemRenderer={
+            this.props.allowCreate ? this.renderCreateOption : undefined
+          }
           onItemSelect={(value: string): void => {
             this.props.handleDropdownChange(this.props.schemaField, value);
           }}


### PR DESCRIPTION
Fixes #1240. Two bug fixes:
* Enum support - checks for `enum` before using `uihints.default_choices` and removes ability to add options if `enum` is defined
* When appending all values of a given field to the default options, checks to make sure the value is defined to avoid errors
 
Also - I noticed that the style was changed to have a black background for the dropdown because of a line in the pipeline editor stylesheet. Removed the line from the pipeline editor stylesheet because it wasn't necessary anyway. 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

