### PR TITLE
Update NBFormat to release 5.1.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup_args = dict(
         'nbclient>=0.5.1',
         'nbconvert>=5.6.1,<6.0',
         'nbdime>=3.0.0.b1',
+        'nbformat>=5.1.2',
         'papermill>=2.1.3',
         'python-language-server[all]>=0.36.2',
         'requests>=2.9.1,<3.0',


### PR DESCRIPTION
Papermill 2.3.1 requires nbformat>=5.1.2

Related to #1251
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

