### PR TITLE
Remove divider between runtime and usage in properties

### DIFF
--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -203,6 +203,11 @@ td {
 }
 .properties-editor-form
   .properties-control-panel
+  .properties-control-panel[data-id='properties-nodeRuntimeImageControl'] {
+  border-bottom: none;
+}
+.properties-editor-form
+  .properties-control-panel
   .properties-control-panel[data-id='properties-nodeListDependenciesControl'] {
   border-bottom: none;
   padding-left: 0;


### PR DESCRIPTION
Fixes part of #1253 - because cpu/ram/gpu only apply to runtime image, they shouldn't be separated by a divider in the properties editor. See change below:
![image](https://user-images.githubusercontent.com/6673460/106636079-2a32fc80-6547-11eb-8d85-e542375b199b.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

