### PR TITLE
Add details on how to determine workflow engine type

### DIFF
--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -186,7 +186,15 @@ Password used to access your KubeFlow Pipelines API endpoint. This setting is re
 Example: `mypassword`
 
 ##### engine
-The engine being used by Kubeflow Pipelines: `Argo` or `Tekton` (default is `Argo`).
+The engine being used by Kubeflow Pipelines: `Argo` or `Tekton` (default is `Argo`). If you have access to the Kubernetes cluster where Kubeflow Pipelines is deployed, run these commands in a terminal window to determine the engine type.
+
+```
+# If this command completes successfully, the engine type is Argo.
+kubectl describe configmap -n kubeflow workflow-controller-configmap
+
+# If this command completes successfully, the engine type is Tekton.
+kubectl describe configmap -n kubeflow kfp-tekton-config
+```
 
 Example: `Argo`
 


### PR DESCRIPTION
This PR updates the https://elyra.readthedocs.io/en/latest/user_guide/runtime-conf.html topic, adding instructions on how to determine which workflow engine type is used by a Kubeflow deployment:

![image](https://user-images.githubusercontent.com/13068832/106789086-a6d8e000-6606-11eb-8947-af6876aeedac.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

