### PR TITLE
Upgrade canvas to 9.2.9

### DIFF
--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@elyra/canvas": "9.2.1",
+    "@elyra/canvas": "9.2.8",
     "@elyra/metadata-common": "^2.1.0-dev",
     "@elyra/services": "^2.1.0-dev",
     "@elyra/ui-components": "^2.1.0-dev",

--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -33,7 +33,7 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@elyra/canvas": "9.2.8",
+    "@elyra/canvas": "9.2.9",
     "@elyra/metadata-common": "^2.1.0-dev",
     "@elyra/services": "^2.1.0-dev",
     "@elyra/ui-components": "^2.1.0-dev",

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -531,11 +531,13 @@ export class PipelineEditor extends React.Component<
     const app_data = node.app_data;
 
     if (additionalData.title) {
-      node.label = additionalData.title;
+      this.canvasController.setNodeLabel(additionalData.title);
     }
     if (app_data.filename !== propertySet.filename) {
       app_data.filename = propertySet.filename;
-      node.label = PathExt.basename(propertySet.filename);
+      this.canvasController.setNodeLabel(
+        PathExt.basename(propertySet.filename)
+      );
     }
 
     app_data.runtime_image = propertySet.runtime_image;
@@ -546,6 +548,11 @@ export class PipelineEditor extends React.Component<
     app_data.cpu = propertySet.cpu;
     app_data.memory = propertySet.memory;
     app_data.gpu = propertySet.gpu;
+    this.canvasController.setNodeProperties(
+      appData.id,
+      { app_data },
+      pipelineId
+    );
     this.validateAllNodes();
     this.updateModel();
   }

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -531,11 +531,12 @@ export class PipelineEditor extends React.Component<
     const app_data = node.app_data;
 
     if (additionalData.title) {
-      this.canvasController.setNodeLabel(additionalData.title);
+      this.canvasController.setNodeLabel(appData.id, additionalData.title);
     }
     if (app_data.filename !== propertySet.filename) {
       app_data.filename = propertySet.filename;
       this.canvasController.setNodeLabel(
+        appData.id,
         PathExt.basename(propertySet.filename)
       );
     }

--- a/packages/pipeline-editor/src/properties.json
+++ b/packages/pipeline-editor/src/properties.json
@@ -62,11 +62,12 @@
         "control": "readonly",
         "label": {
           "default": "Filename"
-        }
+        },
+        "orientation": "horizontal",
+        "separator": "after"
       },
       {
         "parameter_ref": "runtime_image",
-        "control": "oneofselect",
         "label": {
           "default": "Runtime Image"
         },
@@ -99,7 +100,9 @@
         },
         "description": {
           "default": "The total amount of RAM specified."
-        }
+        },
+        "orientation": "horizontal",
+        "separator": "after"
       },
       {
         "parameter_ref": "dependencies",
@@ -111,6 +114,8 @@
         "description": {
           "default": "Local file dependencies that need to be copied to remote execution environment.\nOne filename or expression (e.g. *.py) per line. Supported patterns: ? and *."
         },
+        "orientation": "horizontal",
+        "separator": "after",
         "data": {
           "single_item_label": "Dependency",
           "placeholder": "*.py",
@@ -124,7 +129,9 @@
         },
         "description": {
           "default": "May increase submission time"
-        }
+        },
+        "orientation": "horizontal",
+        "separator": "after"
       },
       {
         "parameter_ref": "env_vars",
@@ -136,6 +143,8 @@
         "description": {
           "default": "Environment variables to be set on the execution environment.\nOne variable per line in the format ENV_VAR=value."
         },
+        "orientation": "horizontal",
+        "separator": "after",
         "data": {
           "placeholder": "env_var=VALUE",
           "single_item_label": "Environment Variable"

--- a/packages/pipeline-editor/style/canvas.css
+++ b/packages/pipeline-editor/style/canvas.css
@@ -313,8 +313,35 @@ body[data-jp-theme-light='false'] .bx--modal.is-visible {
   border-radius: 3px 0 0 3px;
   width: 100%;
 }
+.properties-title-editor {
+  padding: 0;
+  height: auto;
+}
+.properties-control-panel[data-id='properties-nodeFileControl']
+  .properties-h-separator {
+  position: absolute;
+  top: 80px;
+  left: 9px;
+  width: calc(100% - 9px);
+}
+.properties-h-separator {
+  width: 100%;
+}
+.properties-category {
+  padding-top: 0;
+}
+.bx--list-box--expanded:hover.bx--list-box--light:hover {
+  background-color: transparent;
+}
 .bx--dropdown {
   border-bottom: none;
+  background-color: transparent;
+}
+.bx--dropdown:hover {
+  background-color: transparent;
+}
+.bx--list-box__field {
+  padding: 0 3em 0 1em;
 }
 .bx--list-box__field:focus {
   outline: none;

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -50,13 +50,6 @@
 .properties-add-fields-button {
   display: none;
 }
-
-.properties-editor-form .properties-control-panel .properties-control-panel {
-  padding: 0;
-  margin-bottom: 14px;
-  margin-top: 14px;
-  border-bottom: 1px solid #cfd1d4;
-}
 .properties-control-item {
   padding: 5px 0 5px 0;
 }
@@ -68,8 +61,10 @@
 .bx--text-input__field-outer-wrapper {
   width: 100%;
 }
-
-.properties-dropdown .bx--list-box__field {
+.properties-dropdown .bx--list-box__wrapper:hover {
+  background-color: #e5e5e5;
+}
+.properties-dropdown .bx--list-box__wrapper {
   background-color: #f5f8fa;
   border-radius: 3px;
   border-bottom: 0px;
@@ -102,11 +97,11 @@
   cursor: pointer;
   font-size: 14px;
   -ms-flex-pack: center;
-  padding: 5px 10px;
   text-align: left;
   vertical-align: middle;
   min-height: 30px;
   min-width: 30px;
+  width: -webkit-fill-available;
 }
 
 .common-canvas-tooltip[data-id^='node_tip'] {
@@ -208,6 +203,12 @@ td {
   padding-left: 0;
   padding-bottom: 0;
 }
+.properties-editor-form
+  .properties-control-panel
+  .properties-control-panel[data-id='properties-nodeListDependenciesControl']
+  .bx--list-box__selection {
+  display: none;
+}
 .properties-control-item[data-id='properties-ci-dependencies'] {
   padding: 0;
 }
@@ -227,7 +228,7 @@ td {
 .properties-action-panel[data-id='properties-nodeBrowseFileAction'] {
   position: absolute;
   right: 0px;
-  top: 22px;
+  top: 34px;
 }
 .properties-control-panel[data-id='properties-nodeFileControl'] {
   display: flex;
@@ -240,26 +241,27 @@ td {
 }
 .properties-editor-form
   .properties-control-panel[data-id='properties-nodeUsageControls']
-  .properties-control-item {
+  .properties-ctrl-wrapper {
   margin: 0;
   padding: 0px 3px 14px 3px;
   max-width: 32%;
   border-bottom: none;
 }
-.properties-control-panel[data-id='properties-nodeFileControl']
+.properties-editor-form
+  .properties-control-panel[data-id='properties-nodePropertiesControls']
+  .properties-ctrl-wrapper {
+  padding: 0;
+}
+.properties-editor-form
+  .properties-control-panel[data-id='properties-nodeUsageControls']
   .properties-control-item {
+  padding: 0 0 3px 0;
+}
+.properties-control-panel[data-id='properties-nodeFileControl']
+  .properties-ctrl-wrapper {
   width: calc(100% - 67px);
+  padding-bottom: 30px;
 }
-.properties-control-panel[data-id='properties-nodePropertiesControls']
-  .properties-control-item[data-id='properties-ci-include_subdirectories'] {
-  border-bottom: 1px solid #cfd1d4;
-  padding: 0 0 10px 0;
-}
-.properties-control-panel[data-id='properties-nodePropertiesControls']
-  .properties-control-item[data-id='properties-ci-env_vars'] {
-  border-bottom: 1px solid #cfd1d4;
-}
-
 .properties-control-panel > .properties-control-panel {
   padding: 0;
 }
@@ -284,7 +286,7 @@ td {
 }
 
 .elyra-Tooltip {
-  top: 84px;
+  top: 92px;
   visibility: hidden;
   opacity: 100%;
 }
@@ -298,7 +300,7 @@ td {
   position: absolute;
   visibility: hidden;
   width: 0;
-  top: 51px;
+  top: 56px;
   left: 94px;
   z-index: 1000000;
   border: 8px solid transparent;
@@ -307,7 +309,7 @@ td {
   transform: rotate(90deg);
 }
 .elyra-Tooltip-arrow-outline {
-  top: 50px;
+  top: 55px;
   z-index: 999999;
   border-right-color: var(--ui-03);
 }

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -215,6 +215,7 @@ td {
 .properties-control-panel[data-id='properties-nodePropertiesControls']
   .properties-control-item {
   margin-top: 10px;
+  padding: 0;
 }
 .properties-action-panel[data-id='properties-nodeBrowseFileAction']
   .properties-action-button {

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -287,7 +287,7 @@ td {
 }
 
 .elyra-Tooltip {
-  top: 92px;
+  top: 90px;
   visibility: hidden;
   opacity: 100%;
 }


### PR DESCRIPTION
Upgrades canvas version and adds css to adjust for class names changing. Also changes code to use separators defined in the properties.json rather than css separators. This also handles the issue in #1264 because of the changes in separators, so #1264 can be closed. 
![image](https://user-images.githubusercontent.com/6673460/106790553-59b23980-6619-11eb-8873-67e1e77fab2d.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

