### PR TITLE
Fix namespace bug in DSL Python template

### DIFF
--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -144,6 +144,7 @@ class KfpPipelineProcessor(PipelineProcessor):
 
         runtime_configuration = self._get_runtime_configuration(pipeline.runtime_config)
         api_endpoint = runtime_configuration.metadata['api_endpoint']
+        namespace = runtime_configuration.metadata.get('user_namespace')
         engine = runtime_configuration.metadata.get('engine')
 
         if os.path.exists(absolute_pipeline_export_path) and not overwrite:
@@ -189,6 +190,7 @@ class KfpPipelineProcessor(PipelineProcessor):
             python_output = template.render(operations_list=defined_pipeline,
                                             pipeline_name=pipeline_name,
                                             engine=engine,
+                                            namespace=namespace,
                                             api_endpoint=api_endpoint,
                                             pipeline_description=description,
                                             writable_container_dir=self.WCD)

--- a/elyra/templates/kfp_template.jinja2
+++ b/elyra/templates/kfp_template.jinja2
@@ -59,7 +59,12 @@ if __name__ == "__main__":
     client = kfp.Client(host='{{ api_endpoint }}')
 {% endif %}
     name = '{{ pipeline_name }}'
-    exp = client.create_experiment('{{ pipeline_name }}')
+    exp = client.create_experiment('{{ pipeline_name }}',
+    {% if namespace is none  %}
+                                namespace=None)
+    {% else %}
+                                namespace='{{ namespace }}')
+    {% endif %}
     run_result = client.run_pipeline(exp.id, name, pipeline_filename, {})
 
     print("Pipeline Submitted: {{ api_endpoint }}/#/runs/details/" + run_result.id)


### PR DESCRIPTION
This PR
 - adds support for user namespaces in the exported Python DSL template
 - closes #1273 

Tested the following scenarios:
 - export & run pipeline in environment where no namespace is defined 
 - export & run pipeline in environment where namespace is defined
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

