### PR TITLE
Tweak runtime metadata definitions for Airflow and Kubeflow

### DIFF
--- a/elyra/metadata/schemas/airflow.json
+++ b/elyra/metadata/schemas/airflow.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Pipeline runtime configuration",
+  "title": "Apache Airflow runtime configuration",
   "name": "airflow",
   "display_name": "Apache Airflow runtime",
   "namespace": "runtimes",
@@ -32,12 +32,12 @@
           "type": "string"
         },
         "api_endpoint": {
-          "title": "Airflow UI Endpoint",
+          "title": "Apache  Airflow UI Endpoint",
           "description": "The Apache Airflow UI endpoint",
           "type": "string",
           "format": "uri",
           "uihints": {
-            "category": "Airflow Pipelines"
+            "category": "Apache Airflow"
           }
         },
         "github_repo": {
@@ -45,7 +45,7 @@
           "description": "The git repository for Airflow DAGs",
           "type": "string",
           "uihints": {
-            "category": "Airflow Pipelines"
+            "category": "Apache Airflow"
           }
         },
         "github_branch": {
@@ -53,7 +53,7 @@
           "description": "The git branch to use for Airflow DAGs",
           "type": "string",
           "uihints": {
-            "category": "Airflow Pipelines"
+            "category": "Apache Airflow"
           }
         },
         "github_repo_token": {
@@ -62,7 +62,7 @@
           "type": "string",
           "uihints": {
             "secure": true,
-            "category": "Airflow Pipelines"
+            "category": "Apache Airflow"
           }
         },
         "cos_endpoint": {
@@ -119,7 +119,8 @@
         "cos_bucket",
         "github_branch",
         "github_repo_token",
-        "github_repo"
+        "github_repo",
+        "api_endpoint"
       ]
     }
   },

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Pipeline runtime configuration",
+  "title": "Kubeflow Pipelines runtime configuration",
   "name": "kfp",
   "display_name": "Kubeflow Pipelines runtime",
   "namespace": "runtimes",

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -390,7 +390,7 @@ const createRuntimeConfig = (): any => {
   cy.get('.elyra-metadata .elyra-metadataHeader').contains('Runtimes');
   // Add a runtime config
   cy.get(
-    'button.elyra-metadataHeader-button[title="Create new Pipeline runtime configuration"]'
+    'button.elyra-metadataHeader-button[title="Create new Apache Airflow runtime configuration"]'
   ).click();
   cy.get('.elyra-metadataEditor-form-display_name').type('Test Runtime');
   cy.get('.elyra-metadataEditor-form-api_endpoint').type(


### PR DESCRIPTION
This PR updated the metadata definitions for the KFP and AA runtimes:
- the title now includes the runtime type
- replaced the category name with the official AA name
- made AA UI endpoint property required (the UI fails if one does not enter a URL => https://github.com/elyra-ai/elyra/issues/1307)

![image](https://user-images.githubusercontent.com/13068832/108245906-ad3a8200-7105-11eb-85b5-88e7407008a8.png)

If AA UI endpoint property is not required this would be broken and a user would not have access to the AA UI from Elyra.

![image](https://user-images.githubusercontent.com/13068832/108246465-4ff30080-7106-11eb-92e8-44dbd44cbcd3.png)


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

