### PR TITLE
Add reference to Apache Airflow tutorial to documentation

### DIFF
--- a/docs/source/getting_started/tutorials.md
+++ b/docs/source/getting_started/tutorials.md
@@ -31,6 +31,10 @@ Learn how to [create a notebook pipeline and run it in your local JupyterLab env
 
 Learn how to [create a notebook pipeline and run it on Kubeflow Pipelines](https://github.com/elyra-ai/examples/tree/master/pipelines/hello_world_kubeflow_pipelines). This tutorial requires a Kubeflow Pipelines deployment in a local environment or on the cloud.
 
+#### Running notebook pipelines on Apache Airflow
+
+Learn how to [create a notebook pipeline and run it on Apache Airflow](https://github.com/elyra-ai/examples/tree/master/pipelines/hello_world_apache_airflow). This tutorial requires an Apache Airflow deployment in a local environment or on the cloud.
+
 #### Examples
 
 The [https://github.com/elyra-ai/examples](https://github.com/elyra-ai/examples) repository contains examples you can use to explore Elyra features.


### PR DESCRIPTION
This PR
 - Adds a reference to the new Apache Airflow tutorial to the "Getting Started" > "Tutorials and examples" topic
 - requires https://github.com/elyra-ai/examples/pull/36 (resolved)
 
![image](https://user-images.githubusercontent.com/13068832/110557275-23267d80-80f5-11eb-9dfb-595961e22f67.png)


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

