### PR TITLE
Fix Airflow/github error handling

### DIFF
--- a/elyra/pipeline/processor_airflow.py
+++ b/elyra/pipeline/processor_airflow.py
@@ -90,7 +90,7 @@ class AirflowPipelineProcessor(RuntimePipelineProcess):
                 self.log.info('Waiting for Airflow Scheduler to process and start the pipeline')
 
             except GithubException as e:
-                self.log.debug('Error adding pipeline to Airflow git queue: ' + e)
+                self.log.error('Error adding pipeline to Airflow git queue: ' + str(e))
                 raise RuntimeError('Error adding pipeline to Airflow git queue: ', e)
 
             self.log_pipeline_info(pipeline_name,


### PR DESCRIPTION
This PR resolves an error handling issue that masks the underlying issue.


![image](https://user-images.githubusercontent.com/13068832/108564901-b28bfe00-72b8-11eb-8dd2-86cc90f93675.png)


Previously the error details listed

```
      ...
      File "/opt/anaconda3/envs/elyra_dev/lib/python3.7/site-packages/elyra/pipeline/processor_airflow.py", line 93, in process
        self.log.debug('Error adding pipeline to Airflow git queue: ' + e)
    TypeError: can only concatenate str (not "UnknownObjectException") to str
```
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

