### PR TITLE
Honor default values for missing metadata properties

### DIFF
--- a/elyra/metadata/manager.py
+++ b/elyra/metadata/manager.py
@@ -219,8 +219,9 @@ class MetadataManager(LoggingConfigurable):
 
         # Get the schema and build a dict consisting of properties and their default values (for those
         # properties that have defaults).  Then walk the metadata instance looking for missing properties
-        # and assign the corresponding default value.  Note that we do not consider exiting properties with
-        # values of None for default replacement since that may be intentional.
+        # and assign the corresponding default value.  Note that we do not consider existing properties with
+        # values of None for default replacement since that may be intentional (although those values will
+        # likely fail subsequent validation).
 
         schema = self.schema_mgr.get_schema(self.namespace, metadata.schema_name)
 

--- a/elyra/metadata/manager.py
+++ b/elyra/metadata/manager.py
@@ -95,10 +95,13 @@ class MetadataManager(LoggingConfigurable):
         instance_list = self.metadata_store.fetch_instances(name=name)
         metadata_dict = instance_list[0]
         metadata = Metadata.from_dict(self.namespace, metadata_dict)
-        metadata.post_load()  # Allow class instances to handle loads
 
-        # validate the instance prior to return...
+        # Validate the instance on load
         self.validate(name, metadata)
+
+        # Allow class instances to alter instance
+        metadata.post_load()
+
         return metadata
 
     def create(self, name: str, metadata: Metadata) -> Metadata:
@@ -196,12 +199,39 @@ class MetadataManager(LoggingConfigurable):
             raise ValueError("Name of metadata must be lowercase alphanumeric, beginning with alpha and can include "
                              "embedded hyphens ('-') and underscores ('_').")
 
-        # Validate the metadata prior to storage then store the instance.
-        self.validate(name, metadata)
-
         # Allow class instances to handle saves
         metadata.pre_save(for_update=for_update)
+
+        self._apply_defaults(metadata)
+
+        # Validate the metadata prior to storage then store the instance.
+        self.validate(name, metadata)
 
         metadata_dict = self.metadata_store.store_instance(name, metadata.prepare_write(), for_update=for_update)
 
         return Metadata.from_dict(self.namespace, metadata_dict)
+
+    def _apply_defaults(self, metadata: Metadata) -> None:
+        """If a given property has a default value defined, and that property is not currently represented,
+
+        assign it the default value.
+        """
+
+        # Get the schema and build a dict consisting of properties and their default values (for those
+        # properties that have defaults).  Then walk the metadata instance looking for missing properties
+        # and assign the corresponding default value.  Note that we do not consider exiting properties with
+        # values of None for default replacement since that may be intentional.
+
+        schema = self.schema_mgr.get_schema(self.namespace, metadata.schema_name)
+
+        meta_properties = schema['properties']['metadata']['properties']
+        property_defaults = {}
+        for name, property in meta_properties.items():
+            if 'default' in property:
+                property_defaults[name] = property['default']
+
+        if property_defaults:  # schema defines defaulted properties
+            instance_properties = metadata.metadata
+            for name, default in property_defaults.items():
+                if name not in instance_properties:
+                    instance_properties[name] = default

--- a/elyra/metadata/tests/test_handlers.py
+++ b/elyra/metadata/tests/test_handlers.py
@@ -130,9 +130,11 @@ async def test_create_instance(jp_base_url, jp_fetch):
                                                       METADATA_TEST_NAMESPACE, 'valid')
     metadata = json.loads(r.body.decode())
     # Add expected "extra" fields to 'valid' so whole-object comparison is satisfied.
-    # These are added during the pre_save() hook on the MockMetadataTest class instance.
+    # These are added during the pre_save() hook on the MockMetadataTest class instance
+    # or when default values for missing properties are applied.
     valid['for_update'] = False
     valid['special_property'] = valid['metadata']['required_test']
+    valid['metadata']['number_default_test'] = 42
     assert metadata == valid
 
 

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -480,6 +480,33 @@ def test_manager_update(tests_hierarchy_manager, namespace_location):
     assert instance2.metadata['number_range_test'] == 7
 
 
+def test_manager_default_value(tests_hierarchy_manager, namespace_location):
+
+    # Create some metadata, then attempt to update it with a known schema violation
+    # and ensure the previous copy still exists...
+
+    # Create a user instance...
+    metadata = Metadata.from_dict(METADATA_TEST_NAMESPACE, {**byo_metadata_json})
+    metadata.display_name = 'user1'
+    instance = tests_hierarchy_manager.create('default_value', metadata)
+    assert instance.metadata['number_default_test'] == 42  # Ensure default value was applied when not present
+
+    instance2 = tests_hierarchy_manager.get('default_value')
+    instance2.metadata['number_default_test'] = 37
+    tests_hierarchy_manager.update('default_value', instance2)
+
+    instance3 = tests_hierarchy_manager.get('default_value')
+    assert instance3.metadata['number_default_test'] == 37
+
+    # Now remove the updated value and ensure it comes back with the default
+    instance3.metadata.pop('number_default_test')
+    assert 'number_default_test' not in instance3.metadata
+    tests_hierarchy_manager.update('default_value', instance3)
+
+    instance4 = tests_hierarchy_manager.get('default_value')
+    assert instance4.metadata['number_default_test'] == 42
+
+
 def test_manager_bad_update(tests_hierarchy_manager, namespace_location):
 
     # Create some metadata, then attempt to update it with a known schema violation


### PR DESCRIPTION
Prior to validation and persistence, the metadata framework will now apply default values to missing properties if the schema for said properties defines a default.  Note that the application of default values occurs _after_ custom class overrides have had a shot at the to-be-persisted instance.

Fixes: #1333
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

