### PR TITLE
Handle default field on metadata editor

### DIFF
--- a/elyra/metadata/schemas/airflow.json
+++ b/elyra/metadata/schemas/airflow.json
@@ -32,10 +32,20 @@
           "type": "string"
         },
         "api_endpoint": {
-          "title": "Apache  Airflow UI Endpoint",
+          "title": "Apache Airflow UI Endpoint",
           "description": "The Apache Airflow UI endpoint",
           "type": "string",
           "format": "uri",
+          "uihints": {
+            "category": "Apache Airflow"
+          }
+        },
+        "github_api_endpoint": {
+          "title": "Github API Endpoint",
+          "description": "The Github Server URL / API endpoint - Public or Enterprise",
+          "type": "string",
+          "format": "uri",
+          "default": "https://api.github.com",
           "uihints": {
             "category": "Apache Airflow"
           }
@@ -118,6 +128,7 @@
         "cos_password",
         "cos_bucket",
         "github_branch",
+        "github_api_endpoint",
         "github_repo_token",
         "github_repo",
         "api_endpoint"

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -183,9 +183,11 @@ export class MetadataEditor extends ReactWidget {
       this.invalidForm = true;
     }
     for (const schemaField in this.schema) {
+      const value =
+        this.metadata[schemaField] || this.schema[schemaField].default;
       if (
         this.requiredFields.includes(schemaField) &&
-        this.isValueEmpty(this.metadata[schemaField])
+        this.isValueEmpty(value)
       ) {
         this.invalidForm = true;
         this.schema[schemaField].uihints.intent = Intent.DANGER;
@@ -429,6 +431,7 @@ export class MetadataEditor extends ReactWidget {
 
   renderField(fieldName: string): React.ReactElement {
     let uihints = this.schema[fieldName].uihints;
+    const defaultValue = this.schema[fieldName].default || '';
     let required = '(optional)';
     if (this.requiredFields && this.requiredFields.includes(fieldName)) {
       required = '(required)';
@@ -445,7 +448,7 @@ export class MetadataEditor extends ReactWidget {
         this.schema[fieldName].title,
         uihints.description,
         fieldName,
-        this.metadata[fieldName],
+        this.metadata[fieldName] || defaultValue,
         required,
         uihints.secure,
         uihints.intent

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -403,6 +403,11 @@ const createRuntimeConfig = (): any => {
   cy.get('.elyra-metadataEditor-form-cos_username').type('minioadmin');
   cy.get('.elyra-metadataEditor-form-cos_password').type('minioadmin');
   cy.get('.elyra-metadataEditor-form-cos_bucket').type('test-bucket');
+  // Check the default value is displayed on github api endpoint field
+  cy.get('.elyra-metadataEditor-form-github_api_endpoint > input').should(
+    'have.value',
+    'https://api.github.com'
+  );
   // save it
   cy.get('.elyra-metadataEditor-saveButton > .bp3-form-content > button')
     .click()


### PR DESCRIPTION
When a metadata schema has a default property for a certain field, the metadata editor can now consume it in case no other value is set.

- [X] Update Metadata Editor
- [x] Add test

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

