### PR TITLE
Add UI placeholder metadata to KFP and Apache Airflow configurations

### DIFF
--- a/elyra/metadata/schemas/airflow.json
+++ b/elyra/metadata/schemas/airflow.json
@@ -38,7 +38,7 @@
           "format": "uri",
           "uihints": {
             "category": "Apache Airflow",
-            "placeholder": "http://your-apache-webserver:port"
+            "placeholder": "https://your-airflow-webserver:port"
           }
         },
         "github_api_endpoint": {
@@ -49,7 +49,7 @@
           "default": "https://api.github.com",
           "uihints": {
             "category": "Apache Airflow",
-            "placeholder": "https://api.github.com"
+            "placeholder": "https://your-github-endpoint"
           }
         },
         "github_repo": {

--- a/elyra/metadata/schemas/airflow.json
+++ b/elyra/metadata/schemas/airflow.json
@@ -37,7 +37,8 @@
           "type": "string",
           "format": "uri",
           "uihints": {
-            "category": "Apache Airflow"
+            "category": "Apache Airflow",
+            "placeholder": "http://your-apache-webserver:port"
           }
         },
         "github_api_endpoint": {
@@ -47,7 +48,8 @@
           "format": "uri",
           "default": "https://api.github.com",
           "uihints": {
-            "category": "Apache Airflow"
+            "category": "Apache Airflow",
+            "placeholder": "https://api.github.com"
           }
         },
         "github_repo": {
@@ -55,7 +57,8 @@
           "description": "The git repository for Airflow DAGs",
           "type": "string",
           "uihints": {
-            "category": "Apache Airflow"
+            "category": "Apache Airflow",
+            "placeholder": "user-or-org/dag-repo-name"
           }
         },
         "github_branch": {
@@ -81,7 +84,8 @@
           "type": "string",
           "format": "uri",
           "uihints": {
-            "category": "Cloud Object Storage"
+            "category": "Cloud Object Storage",
+            "placeholder": "https://your-cos-service:port"
           }
         },
         "cos_username": {

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -37,7 +37,8 @@
           "type": "string",
           "format": "uri",
           "uihints": {
-            "category": "Kubeflow Pipelines"
+            "category": "Kubeflow Pipelines",
+            "placeholder": "https://your-kubeflow-service:port/pipeline"
           }
         },
         "user_namespace": {
@@ -84,7 +85,8 @@
           "type": "string",
           "format": "uri",
           "uihints": {
-            "category": "Cloud Object Storage"
+            "category": "Cloud Object Storage",
+            "placeholder": "https://your-cos-service:port"
           }
         },
         "cos_username": {


### PR DESCRIPTION
This PR adds placeholder UI hints to the Apache Airflow and Kubeflow Pipelines metadata. The `placeholder` property is optional. If present, it is rendered by the metadata editor if the input type is "string".

See https://github.com/elyra-ai/elyra/issues/1314 for background information
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

