### PR TITLE
Group tags with name and description

### DIFF
--- a/elyra/metadata/schemas/code-snippet.json
+++ b/elyra/metadata/schemas/code-snippet.json
@@ -31,13 +31,22 @@
           "description": "Code snippet description",
           "type": "string"
         },
+        "tags": {
+          "title": "Tags",
+          "description": "Tags for categorizing snippets",
+          "type": "array",
+          "uihints": {
+            "field_type": "tags"
+          }
+        },
         "language": {
           "title": "Language",
           "description": "Code snippet implementation language",
           "type": "string",
           "uihints": {
             "field_type": "dropdown",
-            "default_choices": ["Python", "Java", "R", "Scala", "Markdown"]
+            "default_choices": ["Python", "Java", "R", "Scala", "Markdown"],
+            "category": "Source"
           },
           "minLength": 1
         },
@@ -46,15 +55,8 @@
           "description": "Code snippet code lines",
           "type": "array",
           "uihints": {
-            "field_type": "code"
-          }
-        },
-        "tags": {
-          "title": "Tags",
-          "description": "Tags for categorizing snippets",
-          "type": "array",
-          "uihints": {
-            "field_type": "tags"
+            "field_type": "code",
+            "category": "Source"
           }
         }
       },

--- a/elyra/metadata/schemas/runtime-image.json
+++ b/elyra/metadata/schemas/runtime-image.json
@@ -31,11 +31,23 @@
           "description": "The description of this Runtime Image instance",
           "type": "string"
         },
+        "tags": {
+          "title": "Tags",
+          "description": "Tags for categorizing runtime images",
+          "type": "array",
+          "uihints": {
+            "field_type": "tags"
+          }
+        },
         "image_name": {
           "title": "Image Name",
           "description": "The image name (including optional tag)",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "uihints": {
+            "placeholder": "registry/owner/image:tag",
+            "category": "Source"
+          }
         },
         "pull_policy": {
           "title": "Image Pull Policy",
@@ -43,15 +55,8 @@
           "type": "string",
           "enum": ["Always", "IfNotPresent", "Never"],
           "uihints": {
-            "field_type": "dropdown"
-          }
-        },
-        "tags": {
-          "title": "Tags",
-          "description": "Tags for categorizing runtime images",
-          "type": "array",
-          "uihints": {
-            "field_type": "tags"
+            "field_type": "dropdown",
+            "category": "Source"
           }
         }
       },


### PR DESCRIPTION
This PR
 - Enforces that tags are displayed after the display name and description but before all other properties for code snippets and runtime images. See next comment for motivation why a new category `source` was introduced.
 - Closes https://github.com/elyra-ai/elyra/issues/1334
 - Adds a placeholder for the runtime image `image_name` property. For the placeholder to be rendered, https://github.com/elyra-ai/elyra/pull/1293 is required.
 
New arrangements:

![image](https://user-images.githubusercontent.com/13068832/109369182-5002a700-7850-11eb-9688-168b05c0cd28.png)


![image](https://user-images.githubusercontent.com/13068832/109369207-6f99cf80-7850-11eb-96ab-4463384105eb.png)


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

