### PR TITLE
Update links in extension tracker documentation

### DIFF
--- a/docs/source/developer_guide/trackers.md
+++ b/docs/source/developer_guide/trackers.md
@@ -19,12 +19,12 @@ limitations under the License.
 
 This section will go over how extension trackers in Elyra are created and how they can be used.
 
-JupyterLab is designed to follow a modular architecture, where every component is built to be extended. Extensions interact with each other through [token objects](https://jupyterlab.readthedocs.io/en/stable/developer/extension_dev.html#core-tokens), such as [widget trackers](https://jupyterlab.readthedocs.io/en/stable/developer/extension_points.html#widget-tracker). Widget trackers keep track of widget instances on an application shell, also commonly used to restore their state.
+JupyterLab is designed to follow a modular architecture, where every component is built to be extended. Extensions interact with each other through [token objects](https://jupyterlab.readthedocs.io/en/stable/extension/extension_points.html?#core-tokens), such as [widget trackers](https://jupyterlab.readthedocs.io/en/stable/extension/extension_points.html?token#widget-tracker). Widget trackers keep track of widget instances on an application shell, also commonly used to restore their state.
 
 Since Elyra is a collection of JupyterLab extensions, every extension in Elyra requires core extension tokens in order to interact with them and implement its own usage. Elyra also exposes their own trackers to the application, which are currently being used for restoring state upon page reload, but could also be used by further extensions to add their own widgets.
 
 ### Python File Editor Trackers
-The Python Editor extension in Elyra extends [JupyterLab File Editor](https://jupyterlab.github.io/jupyterlab/fileeditor/classes/fileeditor.html).
+The Python Editor extension in Elyra extends [JupyterLab File Editor](https://github.com/jupyterlab/jupyterlab/tree/master/packages/fileeditor).
 
 When Python File Editor extension is activated, it requests an [File Editor Tracker](https://jupyterlab.github.io/jupyterlab/fileeditor/interfaces/ieditortracker.html). This is how the extension is able to track the editor widget it extends.
 In order to File Editors to recognize Python File Editor widgets as File Editors, which they are, the Python Editor widget is then added to the File Editor Tracker, therefore it can properly inherit all default components and behaviors of a File Editor.
@@ -39,7 +39,7 @@ where `PYTHON_EDITOR_NAMESPACE = 'elyra-python-editor-extension'`
 
 
 ### Pipeline Editor Trackers
-The Pipeline Editor extension in Elyra extends [JupyterLab Document Widget](https://jupyterlab.github.io/jupyterlab/docregistry/classes/documentwidget.html). Similar to the Python Editor widget tracker, the Pipeline Editor tracker is used by a restorer, and it is defined as below
+The Pipeline Editor extension in Elyra extends [JupyterLab Document Widget](https://jupyterlab.readthedocs.io/en/latest/extension/documents.html). Similar to the Python Editor widget tracker, the Pipeline Editor tracker is used by a restorer, and it is defined as below
 ```
 const tracker = new WidgetTracker<DocumentWidget>({
   namespace: PIPELINE_EDITOR_NAMESPACE
@@ -49,4 +49,4 @@ where `PIPELINE_EDITOR_NAMESPACE = 'elyra-pipeline-editor-extension'`
 
 In this case, Pipeline Editor tracker has a broader scope when compared to the Python Editor tracker, as it allows other Document Widget instances to be added to it. For instance, if Pipeline Editor is further extended, its API would allow it to have a new File Editor widget, which actually is a `DocumentWidget<FileEditor>` type.
 
-More information about the architecture of Document Widgets can be found in [JupyterLab documentation](https://jupyterlab.readthedocs.io/en/stable/developer/documents.html#overview-of-document-architecture)
+More information about the architecture of Document Widgets can be found in [JupyterLab documentation](https://jupyterlab.readthedocs.io/en/stable/index.html).

--- a/docs/source/developer_guide/trackers.md
+++ b/docs/source/developer_guide/trackers.md
@@ -26,10 +26,10 @@ Since Elyra is a collection of JupyterLab extensions, every extension in Elyra r
 ### Python File Editor Trackers
 The Python Editor extension in Elyra extends [JupyterLab File Editor](https://github.com/jupyterlab/jupyterlab/tree/master/packages/fileeditor).
 
-When Python File Editor extension is activated, it requests an [File Editor Tracker](https://jupyterlab.github.io/jupyterlab/fileeditor/interfaces/ieditortracker.html). This is how the extension is able to track the editor widget it extends.
+When Python File Editor extension is activated, it requests a File Editor Tracker. This is how the extension is able to track the editor widget it extends.
 In order to File Editors to recognize Python File Editor widgets as File Editors, which they are, the Python Editor widget is then added to the File Editor Tracker, therefore it can properly inherit all default components and behaviors of a File Editor.
 
-Python File Editor widget has its own tracker, which is used by the [restorer](https://jupyterlab.github.io/jupyterlab/application/interfaces/ilayoutrestorer.html) to track the widget state and allow activity restoration on page refresh.
+Python File Editor widget has its own tracker, which is used by the ILayoutRestorer to track the widget state and allow activity restoration on page refresh.
 ```
 const tracker = new WidgetTracker<PythonFileEditor>({
   namespace: PYTHON_EDITOR_NAMESPACE


### PR DESCRIPTION
Addresses #1346. Links in Elyra [extension documentation](https://elyra.readthedocs.io/en/latest/developer_guide/trackers.html) that had no current corresponding page/subheader in the current JupyterLab documentation and no analogous README in the JupyterLab GitHub have been removed. The remaining links have been updated with similar working addresses based on my [currently limited] knowledge of the subject matter. Happily accepting change requests!

Fixes #1346
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

