### PR TITLE
Remove trailing / from github api URL to prevent failures

### DIFF
--- a/elyra/util/git.py
+++ b/elyra/util/git.py
@@ -42,7 +42,8 @@ class GithubClient(LoggingConfigurable):
 
         super().__init__()
 
-        self.server_url = server_url
+        # Remove trailing slash(es) from server URL to prevent failure
+        self.server_url = server_url.rstrip('/')
         self.repo_name = repo
         self.branch = branch
         self.client = Github(login_or_token=token, base_url=self.server_url)


### PR DESCRIPTION
If a user enters a GitHub URL that ends with a trailing slash (e.g. `https://api.github.com/`), the GitHub client returns a 404 error trying to locate an existing repository.

Simple example:

```
from github import Github
client = Github('...', base_url='https://api.github.com/')
r = client.get_repo('owner/test-repo')
...
github.GithubException.UnknownObjectException: 404 {"message": "Not Found", "documentation_url": "https://docs.github.com/rest"}
```

This PR resolves the issue by removing trailing `/`s from the URL.
 
```
from github import Github
client = Github('...', base_url='https://api.github.com')
r = client.get_repo('owner/test-repo')
...
r
Repository(full_name="owner/test-repo")
```

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

