### PR TITLE
Format Github exceptions in Airflow pipeline

### DIFF
--- a/elyra/util/git.py
+++ b/elyra/util/git.py
@@ -51,8 +51,9 @@ class GithubClient(LoggingConfigurable):
         try:
             self.github_repository = self.client.get_repo(self.repo_name)
         except GithubException as e:
-            self.log.error(f'Error accessing repository {self.repo_name}: ' + str(e))
-            raise RuntimeError(f'Error accessing repository {self.repo_name}: {str(e)}') from e
+            self.log.error(f'Error accessing repository {self.repo_name}: {e.data["message"]} ({e.status})')
+            raise RuntimeError(f'Error accessing repository {self.repo_name}: {e.data["message"]} ({e.status}). ' +
+                               'Please validate your runtime configuration details and retry.') from e
 
     def upload_dag(self,
                    pipeline_filepath: str,
@@ -80,8 +81,9 @@ class GithubClient(LoggingConfigurable):
             self.log.error(f'Unable to locate local DAG file to upload: {pipeline_filepath}: ' + str(fnfe))
             raise RuntimeError(f'Unable to locate local DAG file to upload: {pipeline_filepath}: {str(fnfe)}') from fnfe
         except GithubException as e:
-            self.log.error(f'Error uploading DAG to branch {self.branch}: ' + str(e))
-            raise RuntimeError(f'Error uploading DAG to branch {self.branch}: {str(e)}') from e
+            self.log.error(f'Error uploading DAG to branch {self.branch}: {e.data["message"]} ({e.status})')
+            raise RuntimeError(f'Error uploading DAG to branch {self.branch}: {e.data["message"]} ({e.status}). ' +
+                               'Please validate your runtime configuration details and retry.') from e
 
     @staticmethod
     def get_github_url(api_url: str,


### PR DESCRIPTION
Parses the GithubException object into its `status` and `data` properties and writes them to formatted error string, along with a message that directs the user to check their entered runtime configuration details. 

Covers the following cases:

- incorrect branch name
- incorrect repository name
- incorrect repository token
- incorrect GitHub server API endpoint

## Screenshots 
Incorrect branch name. Error caught in `upload_dag` function
<img width="840" alt="wrong-branch-fix" src="https://user-images.githubusercontent.com/31816267/109830572-3e305380-7c04-11eb-96ed-24b6c2e2bc00.png">

Incorrect repository name. Error caught in `get_repo` function on GithubClient init and moves up the exception chain to the try/except block in processor_airflow.py
<img width="1017" alt="wrong-token-fix" src="https://user-images.githubusercontent.com/31816267/109830931-949d9200-7c04-11eb-8a56-4d0f139f8639.png">

Fixes #1332

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

