### PR TITLE
Trap non-JSON request body errors in pipeline handler

### DIFF
--- a/elyra/pipeline/handlers.py
+++ b/elyra/pipeline/handlers.py
@@ -81,7 +81,12 @@ class PipelineSchedulerHandler(HttpErrorMixin, APIHandler):
     async def post(self, *args, **kwargs):
         self.log.debug("Pipeline SchedulerHandler now executing post request")
 
-        pipeline_definition = self.get_json_body()
+        try:
+            pipeline_definition = self.get_json_body()
+        except Exception as e:
+            self.log.error(f'Request body could not be parsed: {str(e)}')
+            raise RuntimeError(f'Request body could not be parsed: {str(e)}') from e
+
         self.log.debug("JSON payload: %s", pipeline_definition)
 
         pipeline = PipelineParser().parse(pipeline_definition)


### PR DESCRIPTION
Seeks to partially fix #1297 with the addition of a simple try/except block to catch pipeline schedule API requests with a body that is not JSON-formatted.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

