### PR TITLE
Add warning before submitting notebook with unsaved changes

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -891,9 +891,9 @@ export class PipelineEditor extends React.Component<
 
     if (this.widgetContext.model.dirty) {
       const dialogResult = await showDialog({
-        title: 'This pipeline has unsaved changes. Save before submitting?',
+        title: 'This pipeline contains unsaved changes. To submit the pipeline the changes need to be saved.',
         buttons: [
-          Dialog.cancelButton({ label: "Don't submit" }),
+          Dialog.cancelButton(),
           Dialog.okButton({ label: 'Save and Submit' })
         ]
       });
@@ -1298,9 +1298,9 @@ export class PipelineEditor extends React.Component<
 
     if (this.widgetContext.model.dirty) {
       const dialogResult = await showDialog({
-        title: 'This pipeline has unsaved changes. Save before submitting?',
+        title: 'This pipeline contains unsaved changes. To submit the pipeline the changes need to be saved.',
         buttons: [
-          Dialog.cancelButton({ label: "Don't submit" }),
+          Dialog.cancelButton(),
           Dialog.okButton({ label: 'Save and Submit' })
         ]
       });

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -888,6 +888,23 @@ export class PipelineEditor extends React.Component<
       });
       return;
     }
+
+    if (this.widgetContext.model.dirty) {
+      const dialogResult = await showDialog({
+        title: 'This notebook has unsaved changes. Save before submitting?',
+        buttons: [
+          Dialog.cancelButton({ label: "Don't submit" }),
+          Dialog.okButton({ label: 'Save and Submit' })
+        ]
+      });
+      if (dialogResult.button && dialogResult.button.accept === true) {
+        await this.widgetContext.save();
+      } else {
+        // Don't proceed if cancel button pressed
+        return;
+      }
+    }
+
     const runtimes = await PipelineService.getRuntimes().catch(error =>
       RequestErrors.serverError(error)
     );
@@ -1277,6 +1294,22 @@ export class PipelineEditor extends React.Component<
         }
       });
       return;
+    }
+
+    if (this.widgetContext.model.dirty) {
+      const dialogResult = await showDialog({
+        title: 'This notebook has unsaved changes. Save before submitting?',
+        buttons: [
+          Dialog.cancelButton({ label: "Don't submit" }),
+          Dialog.okButton({ label: 'Save and Submit' })
+        ]
+      });
+      if (dialogResult.button && dialogResult.button.accept === true) {
+        await this.widgetContext.save();
+      } else {
+        // Don't proceed if cancel button pressed
+        return;
+      }
     }
 
     const pipelineName = PathExt.basename(

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -891,7 +891,8 @@ export class PipelineEditor extends React.Component<
 
     if (this.widgetContext.model.dirty) {
       const dialogResult = await showDialog({
-        title: 'This pipeline contains unsaved changes. To submit the pipeline the changes need to be saved.',
+        title:
+          'This pipeline contains unsaved changes. To submit the pipeline the changes need to be saved.',
         buttons: [
           Dialog.cancelButton(),
           Dialog.okButton({ label: 'Save and Submit' })
@@ -1298,7 +1299,8 @@ export class PipelineEditor extends React.Component<
 
     if (this.widgetContext.model.dirty) {
       const dialogResult = await showDialog({
-        title: 'This pipeline contains unsaved changes. To submit the pipeline the changes need to be saved.',
+        title:
+          'This pipeline contains unsaved changes. To submit the pipeline the changes need to be saved.',
         buttons: [
           Dialog.cancelButton(),
           Dialog.okButton({ label: 'Save and Submit' })

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -891,7 +891,7 @@ export class PipelineEditor extends React.Component<
 
     if (this.widgetContext.model.dirty) {
       const dialogResult = await showDialog({
-        title: 'This notebook has unsaved changes. Save before submitting?',
+        title: 'This pipeline has unsaved changes. Save before submitting?',
         buttons: [
           Dialog.cancelButton({ label: "Don't submit" }),
           Dialog.okButton({ label: 'Save and Submit' })
@@ -1298,7 +1298,7 @@ export class PipelineEditor extends React.Component<
 
     if (this.widgetContext.model.dirty) {
       const dialogResult = await showDialog({
-        title: 'This notebook has unsaved changes. Save before submitting?',
+        title: 'This pipeline has unsaved changes. Save before submitting?',
         buttons: [
           Dialog.cancelButton({ label: "Don't submit" }),
           Dialog.okButton({ label: 'Save and Submit' })

--- a/packages/pipeline-editor/src/SubmitNotebookButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitNotebookButtonExtension.tsx
@@ -41,7 +41,8 @@ export class SubmitNotebookButtonExtension
   showWidget = async (): Promise<void> => {
     if (this.panel.model.dirty) {
       const dialogResult = await showDialog({
-        title: 'This notebook contains unsaved changes. To submit the notebook the changes need to be saved.',
+        title:
+          'This notebook contains unsaved changes. To submit the notebook the changes need to be saved.',
         buttons: [
           Dialog.cancelButton(),
           Dialog.okButton({ label: 'Save and Submit' })

--- a/packages/pipeline-editor/src/SubmitNotebookButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitNotebookButtonExtension.tsx
@@ -41,9 +41,9 @@ export class SubmitNotebookButtonExtension
   showWidget = async (): Promise<void> => {
     if (this.panel.model.dirty) {
       const dialogResult = await showDialog({
-        title: 'This notebook has unsaved changes. Save before submitting?',
+        title: 'This notebook contains unsaved changes. To submit the notebook the changes need to be saved.',
         buttons: [
-          Dialog.cancelButton({ label: "Don't submit" }),
+          Dialog.cancelButton(),
           Dialog.okButton({ label: 'Save and Submit' })
         ]
       });

--- a/packages/pipeline-editor/src/SubmitNotebookButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitNotebookButtonExtension.tsx
@@ -40,14 +40,19 @@ export class SubmitNotebookButtonExtension
 
   showWidget = async (): Promise<void> => {
     if (this.panel.model.dirty) {
-      await showDialog({
+      const dialogResult = await showDialog({
         title: 'This notebook has unsaved changes. Save before submitting?',
-        buttons: [Dialog.okButton(), Dialog.cancelButton()]
-      }).then(async (dialogResult: any) => {
-        if (dialogResult.button && dialogResult.button.accept === true) {
-          await this.panel.context.save();
-        } // Don't do anything if cancel button is pressed
+        buttons: [
+          Dialog.cancelButton({ label: "Don't submit" }),
+          Dialog.okButton({ label: 'Save and Submit' })
+        ]
       });
+      if (dialogResult.button && dialogResult.button.accept === true) {
+        await this.panel.context.save();
+      } else {
+        // Don't proceed if cancel button pressed
+        return;
+      }
     }
 
     const env = NotebookParser.getEnvVars(this.panel.content.model.toString());

--- a/packages/pipeline-editor/src/SubmitScriptButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitScriptButtonExtension.tsx
@@ -45,7 +45,7 @@ export class SubmitScriptButtonExtension
   showWidget = async (): Promise<void> => {
     if (this.editor.context.model.dirty) {
       const dialogResult = await showDialog({
-        title: 'This notebook has unsaved changes. Save before submitting?',
+        title: 'This script has unsaved changes. Save before submitting?',
         buttons: [
           Dialog.cancelButton({ label: "Don't submit" }),
           Dialog.okButton({ label: 'Save and Submit' })

--- a/packages/pipeline-editor/src/SubmitScriptButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitScriptButtonExtension.tsx
@@ -16,6 +16,7 @@
 
 // import { NotebookParser } from '@elyra/services';
 import { RequestErrors, showFormDialog } from '@elyra/ui-components';
+import { showDialog } from '@jupyterlab/apputils';
 import { Dialog, ToolbarButton } from '@jupyterlab/apputils';
 import { DocumentRegistry, DocumentWidget } from '@jupyterlab/docregistry';
 import { FileEditor } from '@jupyterlab/fileeditor';
@@ -42,6 +43,22 @@ export class SubmitScriptButtonExtension
   private editor: DocumentWidget<FileEditor, DocumentRegistry.ICodeModel>;
 
   showWidget = async (): Promise<void> => {
+    if (this.editor.context.model.dirty) {
+      const dialogResult = await showDialog({
+        title: 'This notebook has unsaved changes. Save before submitting?',
+        buttons: [
+          Dialog.cancelButton({ label: "Don't submit" }),
+          Dialog.okButton({ label: 'Save and Submit' })
+        ]
+      });
+      if (dialogResult.button && dialogResult.button.accept === true) {
+        await this.editor.context.save();
+      } else {
+        // Don't proceed if cancel button pressed
+        return;
+      }
+    }
+
     /*
     // TODO: 
     // get environment variables from the editor

--- a/packages/pipeline-editor/src/SubmitScriptButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitScriptButtonExtension.tsx
@@ -45,7 +45,8 @@ export class SubmitScriptButtonExtension
   showWidget = async (): Promise<void> => {
     if (this.editor.context.model.dirty) {
       const dialogResult = await showDialog({
-        title: 'This script contains unsaved changes. To submit the script the changes need to be saved.',
+        title:
+          'This script contains unsaved changes. To submit the script the changes need to be saved.',
         buttons: [
           Dialog.cancelButton(),
           Dialog.okButton({ label: 'Save and Submit' })

--- a/packages/pipeline-editor/src/SubmitScriptButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitScriptButtonExtension.tsx
@@ -45,9 +45,9 @@ export class SubmitScriptButtonExtension
   showWidget = async (): Promise<void> => {
     if (this.editor.context.model.dirty) {
       const dialogResult = await showDialog({
-        title: 'This script has unsaved changes. Save before submitting?',
+        title: 'This script contains unsaved changes. To submit the script the changes need to be saved.',
         buttons: [
-          Dialog.cancelButton({ label: "Don't submit" }),
+          Dialog.cancelButton(),
           Dialog.okButton({ label: 'Save and Submit' })
         ]
       });

--- a/tests/integration/submitnotebookbutton.ts
+++ b/tests/integration/submitnotebookbutton.ts
@@ -45,6 +45,10 @@ describe('Submit Notebook Button tests', () => {
     );
     // Click submit notebook button
     cy.contains('Submit Notebook').click();
+    // Should have warning for unsaved changes
+    cy.get('.jp-mod-accept > .jp-Dialog-buttonLabel')
+      .contains('Save and Submit')
+      .click();
     // Check for expected dialog title
     cy.get('.jp-Dialog')
       .find('div.jp-Dialog-header')


### PR DESCRIPTION
Fixes #1356. Adds a warning if there are unsaved changes in a notebook before submitting. If the user presses "OK", the changes are saved and the user moves to the submission dialog. If the user presses "Cancel", the changes will not be saved, but the user will still move to the submission dialog, and the notebook will be submitted without the in-memory changes. 
![image](https://user-images.githubusercontent.com/6673460/110391615-5ac9f280-802d-11eb-96c9-a7cb29778780.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

