### PR TITLE
Add reference documentation link to MetadataEditor

### DIFF
--- a/elyra/metadata/schemas/airflow.json
+++ b/elyra/metadata/schemas/airflow.json
@@ -6,7 +6,8 @@
   "namespace": "runtimes",
   "uihints": {
     "title": "Apache Airflow runtimes",
-    "icon": "elyra:runtimes"
+    "icon": "elyra:runtimes",
+    "reference_url": "https://elyra.readthedocs.io/en/latest/user_guide/runtime-conf.html"
   },
   "properties": {
     "schema_name": {

--- a/elyra/metadata/schemas/code-snippet.json
+++ b/elyra/metadata/schemas/code-snippet.json
@@ -6,7 +6,8 @@
   "namespace": "code-snippets",
   "uihints": {
     "title": "Code Snippets",
-    "icon": "elyra:code-snippet"
+    "icon": "elyra:code-snippet",
+    "reference_url": "https://elyra.readthedocs.io/en/latest/user_guide/code-snippets.html"
   },
   "properties": {
     "schema_name": {

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -6,7 +6,8 @@
   "namespace": "runtimes",
   "uihints": {
     "title": "Kubeflow Pipelines runtimes",
-    "icon": "elyra:runtimes"
+    "icon": "elyra:runtimes",
+    "reference_url": "https://elyra.readthedocs.io/en/latest/user_guide/runtime-conf.html"
   },
   "properties": {
     "schema_name": {

--- a/elyra/metadata/schemas/runtime-image.json
+++ b/elyra/metadata/schemas/runtime-image.json
@@ -6,7 +6,8 @@
   "namespace": "runtime-images",
   "uihints": {
     "icon": "elyra:container",
-    "title": "Runtime Images"
+    "title": "Runtime Images",
+    "reference_url": "https://elyra.readthedocs.io/en/latest/user_guide/runtime-image-conf.html"
   },
   "properties": {
     "schema_name": {

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -34,7 +34,7 @@ import { CodeEditor, IEditorServices } from '@jupyterlab/codeeditor';
 import { find } from '@lumino/algorithm';
 import { IDisposable } from '@lumino/disposable';
 import { Message } from '@lumino/messaging';
-import { InputLabel, FormHelperText, Button } from '@material-ui/core';
+import { InputLabel, FormHelperText, Button, Link } from '@material-ui/core';
 
 import React, { useEffect, useRef } from 'react';
 
@@ -135,7 +135,7 @@ export class MetadataEditor extends ReactWidget {
   showSecure: IDictionary<boolean>;
   widgetClass: string;
   themeManager: IThemeManager;
-  schemaUIHints: IDictionary<any>;
+  referenceURL: string;
   language: string;
 
   schema: IDictionary<any> = {};
@@ -177,7 +177,7 @@ export class MetadataEditor extends ReactWidget {
       for (const schema of schemas) {
         if (this.schemaName === schema.name) {
           this.schema = schema.properties.metadata.properties;
-          this.schemaUIHints = schema.uihints;
+          this.referenceURL = schema.uihints?.reference_url;
           this.schemaDisplayName = schema.title;
           this.requiredFields = schema.properties.metadata.required;
           if (!this.name) {
@@ -535,16 +535,15 @@ export class MetadataEditor extends ReactWidget {
         <div className={ELYRA_METADATA_EDITOR_CLASS}>
           <h3> {headerText} </h3>
           <p style={{ width: '100%', marginBottom: '10px' }}>
-            All fields marked with an asterisk are required
-            {this.schemaUIHints?.reference_url ? (
-              <Button
-                href={this.schemaUIHints.reference_url}
+            All fields marked with an asterisk are required.&nbsp;
+            {this.referenceURL ? (
+              <Link
+                href={this.referenceURL}
                 target="_blank"
                 rel="noreferrer noopener"
-                style={{ float: 'right' }}
               >
-                {this.schemaUIHints.title} Documentation
-              </Button>
+                [Learn more ...]
+              </Link>
             ) : null}
           </p>
           {this.displayName !== undefined ? (

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -135,7 +135,7 @@ export class MetadataEditor extends ReactWidget {
   showSecure: IDictionary<boolean>;
   widgetClass: string;
   themeManager: IThemeManager;
-
+  schemaUIHints: IDictionary<any>;
   language: string;
 
   schema: IDictionary<any> = {};
@@ -177,6 +177,7 @@ export class MetadataEditor extends ReactWidget {
       for (const schema of schemas) {
         if (this.schemaName === schema.name) {
           this.schema = schema.properties.metadata.properties;
+          this.schemaUIHints = schema.uihints;
           this.schemaDisplayName = schema.title;
           this.requiredFields = schema.properties.metadata.required;
           if (!this.name) {
@@ -533,9 +534,19 @@ export class MetadataEditor extends ReactWidget {
       <ThemeComponent themeManager={this.themeManager}>
         <div className={ELYRA_METADATA_EDITOR_CLASS}>
           <h3> {headerText} </h3>
-          <InputLabel style={{ width: '100%', marginBottom: '10px' }}>
+          <p style={{ width: '100%', marginBottom: '10px' }}>
             All fields marked with an asterisk are required
-          </InputLabel>
+            {this.schemaUIHints?.reference_url ? (
+              <Button
+                href={this.schemaUIHints.reference_url}
+                target="_blank"
+                rel="noreferrer noopener"
+                style={{ float: 'right' }}
+              >
+                {this.schemaUIHints.title} Documentation
+              </Button>
+            ) : null}
+          </p>
           {this.displayName !== undefined ? (
             <TextInput
               label={'Name'}

--- a/packages/metadata-common/src/MetadataWidget.tsx
+++ b/packages/metadata-common/src/MetadataWidget.tsx
@@ -43,6 +43,7 @@ import { FilterTools } from './FilterTools';
 /**
  * The CSS class added to metadata widgets.
  */
+export const METADATA_CLASS = 'elyra-metadata';
 export const METADATA_HEADER_CLASS = 'elyra-metadataHeader';
 export const METADATA_ITEM = 'elyra-metadata-item';
 const METADATA_JSON_CLASS = 'jp-RenderedJSON CodeMirror cm-s-jupyter';
@@ -413,7 +414,7 @@ export class MetadataWidget extends ReactWidget {
   render(): React.ReactElement {
     return (
       <ThemeComponent themeManager={this.props.themeManager}>
-        <div>
+        <div className={METADATA_CLASS}>
           <header className={METADATA_HEADER_CLASS}>
             <div style={{ display: 'flex' }}>
               <this.props.icon.react

--- a/packages/metadata-common/style/index.css
+++ b/packages/metadata-common/style/index.css
@@ -88,7 +88,7 @@
   margin-right: 70px;
 }
 
-.elyra-metadataEditor h4 {
+.elyra-metadataEditor {
   color: var(--jp-ui-font-color1);
 }
 

--- a/packages/metadata-common/style/index.css
+++ b/packages/metadata-common/style/index.css
@@ -20,6 +20,10 @@
   background: var(--jp-layout-color1);
 }
 
+.elyra-metadata a,
+.elyra-metadataEditor a {
+  color: var(--jp-content-link-color);
+}
 .elyra-metadataHeader {
   font-weight: bold;
   padding: 8px 10px;

--- a/packages/metadata-common/style/index.css
+++ b/packages/metadata-common/style/index.css
@@ -24,6 +24,7 @@
 .elyra-metadataEditor a {
   color: var(--jp-content-link-color);
 }
+
 .elyra-metadataHeader {
   font-weight: bold;
   padding: 8px 10px;

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -183,7 +183,7 @@ const extension: JupyterFrontEndPlugin<void> = {
           command: commandIDs.openMetadata,
           args: {
             label: `Manage ${title}`,
-            display_name: schema.title,
+            display_name: schema.uihints.title,
             namespace: schema.namespace,
             icon: icon
           },


### PR DESCRIPTION
Fixes #838

Adds a button to the top right of the MetadataEditor when a schema
has `reference_url` defined in it's `uihints`



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

