### PR TITLE
Fix pipeline error message not updating

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -1099,6 +1099,13 @@ export class PipelineEditor extends React.Component<
       return true;
     }
 
+    // update app_data with latest invalidNodeError value
+    this.canvasController.setNodeProperties(
+      node.id,
+      { app_data: node.app_data },
+      pipelineId
+    );
+
     // Add or remove decorations
     if (node.app_data != null && node.app_data.invalidNodeError != null) {
       this.canvasController.setNodeDecorations(


### PR DESCRIPTION
Canvas 9.2.5 updated the Canvas Controller API to return copies of
objects rather than pointers. Our error message handling for nodes
was still assuming the node properties were pointers and was not
updating the conroller with the new values.

Fixes #1389



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

