### PR TITLE
Add GitHub link to Runtimes UI

### DIFF
--- a/packages/code-snippet/src/CodeSnippetWidget.tsx
+++ b/packages/code-snippet/src/CodeSnippetWidget.tsx
@@ -59,6 +59,7 @@ import {
 
 const METADATA_EDITOR_ID = 'elyra-metadata-editor';
 const SNIPPET_DRAG_IMAGE_CLASS = 'elyra-codeSnippet-drag-image';
+const CODE_SNIPPETS_METADATA_CLASS = 'elyra-metadata-code-snippets';
 
 /**
  * The threshold in pixels to start a drag event.
@@ -80,6 +81,7 @@ interface ICodeSnippetDisplayProps extends IMetadataDisplayProps {
   namespace: string;
   schema: string;
   sortMetadata: boolean;
+  className: string;
   getCurrentWidget: () => Widget;
   editorServices: IEditorServices;
   shell: JupyterFrontEnd.IShell;
@@ -525,6 +527,7 @@ export class CodeSnippetWidget extends MetadataWidget {
         namespace={CODE_SNIPPET_NAMESPACE}
         schema={CODE_SNIPPET_SCHEMA}
         getCurrentWidget={this.props.getCurrentWidget}
+        className={CODE_SNIPPETS_METADATA_CLASS}
         editorServices={this.props.editorServices}
         shell={this.props.app.shell}
         sortMetadata={true}

--- a/packages/code-snippet/style/index.css
+++ b/packages/code-snippet/style/index.css
@@ -21,3 +21,9 @@
   color: var(--jp-ui-font-color1);
   background: var(--jp-layout-color1);
 }
+
+.elyra-metadata-code-snippets
+  .elyra-metadata-item
+  .elyra-expandableContainer-details-visible {
+  height: 100px;
+}

--- a/packages/metadata-common/src/MetadataWidget.tsx
+++ b/packages/metadata-common/src/MetadataWidget.tsx
@@ -75,6 +75,7 @@ export interface IMetadataDisplayProps {
   updateMetadata: () => void;
   namespace: string;
   sortMetadata: boolean;
+  className: string;
 }
 
 /**
@@ -297,15 +298,13 @@ export class MetadataDisplay<
       this.sortMetadata();
     }
     return (
-      <div>
-        <div id="elyra-metadata">
-          <FilterTools
-            onFilter={this.filteredMetadata}
-            tags={this.getActiveTags()}
-            namespaceId={`${this.props.namespace}`}
-          />
-          <div>{this.props.metadata.map(this.renderMetadata)}</div>
-        </div>
+      <div id="elyra-metadata" className={this.props.className}>
+        <FilterTools
+          onFilter={this.filteredMetadata}
+          tags={this.getActiveTags()}
+          namespaceId={`${this.props.namespace}`}
+        />
+        <div>{this.props.metadata.map(this.renderMetadata)}</div>
       </div>
     );
   }
@@ -407,6 +406,7 @@ export class MetadataWidget extends ReactWidget {
         openMetadataEditor={this.openMetadataEditor}
         namespace={this.props.namespace}
         sortMetadata={true}
+        className={`${METADATA_CLASS}-${this.props.namespace}`}
       />
     );
   }

--- a/packages/metadata-common/style/index.css
+++ b/packages/metadata-common/style/index.css
@@ -69,7 +69,6 @@
 .elyra-metadata-item .elyra-expandableContainer-details-visible {
   background-color: var(--jp-cell-editor-background);
   resize: vertical;
-  height: 100px;
 }
 
 .elyra-metadata-item .CodeMirror.cm-s-jupyter {

--- a/packages/pipeline-editor/src/RuntimesWidget.tsx
+++ b/packages/pipeline-editor/src/RuntimesWidget.tsx
@@ -35,13 +35,11 @@ const addTrailingSlash = (url: string): string => {
 };
 
 const getGithubURLFromAPI = (apiEndpoint: string): string => {
-  // For enterprise instances the api is located at <hostname>/api/
+  // For Enterprise Server the api is located at <hostname>/api/
   let baseURL = new URL(apiEndpoint).origin;
 
-  // For github.com the api endpoint is located at api.github.com
-  if (baseURL.includes('api.github.com')) {
-    baseURL = baseURL.replace('api.', '');
-  }
+  // For Github.com and Github AE the api is located at api.<hostname>
+  baseURL = baseURL.replace('api.', '');
 
   return addTrailingSlash(baseURL);
 };
@@ -81,15 +79,16 @@ class RuntimesDisplay extends MetadataDisplay<
         getGithubURLFromAPI(metadata.metadata.github_api_endpoint) +
         metadata.metadata.github_repo +
         '/tree/' +
-        metadata.metadata.github_branch;
+        metadata.metadata.github_branch +
+        '/';
       githubRepoElement = (
         <span>
-          <br />
-          <br />
           <h6>{metadata_props.github_repo.title}</h6>
           <a href={githubRepoUrl} target="_blank" rel="noreferrer noopener">
             {githubRepoUrl}
           </a>
+          <br />
+          <br />
         </span>
       );
     }
@@ -104,6 +103,7 @@ class RuntimesDisplay extends MetadataDisplay<
         </a>
         <br />
         <br />
+        {githubRepoElement}
         <h6>
           {metadata_props
             ? metadata_props.cos_endpoint.title
@@ -112,7 +112,6 @@ class RuntimesDisplay extends MetadataDisplay<
         <a href={cosEndpoint} target="_blank" rel="noreferrer noopener">
           {cosEndpoint}
         </a>
-        {githubRepoElement}
       </div>
     );
   }


### PR DESCRIPTION
Fixes #1335

This adds a `GitHub DAG Repository` link to the Runtimes UI for airflow runtimes
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

