### PR TITLE
Fix Apache Airflow export filepath when exporting DAG to local file

### DIFF
--- a/elyra/pipeline/processor_airflow.py
+++ b/elyra/pipeline/processor_airflow.py
@@ -117,12 +117,12 @@ class AirflowPipelineProcessor(RuntimePipelineProcess):
 
         self.log_pipeline_info(pipeline_name, f"exporting pipeline as a .{pipeline_export_format} file")
 
-        self.create_pipeline_file(pipeline=pipeline,
-                                  pipeline_export_format="py",
-                                  pipeline_export_path=pipeline_export_path,
-                                  pipeline_name=pipeline_name)
+        new_pipeline_file_path = self.create_pipeline_file(pipeline=pipeline,
+                                                           pipeline_export_format="py",
+                                                           pipeline_export_path=absolute_pipeline_export_path,
+                                                           pipeline_name=pipeline_name)
 
-        return pipeline_export_path
+        return new_pipeline_file_path
 
     def _cc_pipeline(self, pipeline, pipeline_name):
 


### PR DESCRIPTION
Use an absolute path instead of a relative one when exporting a DAG locally

Fixes #1414



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

