### PR TITLE
Add default / placeholder to dropdown field in metadata editor

### DIFF
--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -479,7 +479,9 @@ export class MetadataEditor extends ReactWidget {
           description={this.schema[fieldName].description}
           required={required}
           defaultError={uihints.error}
-          defaultValue={this.metadata[fieldName]}
+          placeholder={uihints.placeholder}
+          defaultValue={this.schema[fieldName].default}
+          initialValue={this.metadata[fieldName]}
           options={this.getDefaultChoices(fieldName)}
           onChange={(value): void => {
             this.handleDropdownChange(fieldName, value);

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -481,6 +481,7 @@ export class MetadataEditor extends ReactWidget {
           defaultError={uihints.error}
           placeholder={uihints.placeholder}
           defaultValue={this.schema[fieldName].default}
+          readonly={this.schema[fieldName].enum !== undefined}
           initialValue={this.metadata[fieldName]}
           options={this.getDefaultChoices(fieldName)}
           onChange={(value): void => {

--- a/packages/ui-components/src/DropDown.tsx
+++ b/packages/ui-components/src/DropDown.tsx
@@ -69,10 +69,10 @@ export const DropDown: React.FC<IDropDownProps> = ({
     setError(defaultError);
   }, [defaultError]);
 
-  const handleChange = (event: any): void => {
-    setValue(event.target.value);
-    setError(required && event.target.value === '');
-    onChange(event.target.value);
+  const handleChange = (newValue: string): void => {
+    setValue(newValue);
+    setError(required && newValue === '');
+    onChange(newValue);
   };
 
   return (
@@ -86,7 +86,9 @@ export const DropDown: React.FC<IDropDownProps> = ({
               id={`${label}DropDown`}
               label={label}
               error={error}
-              onChange={handleChange}
+              onChange={(event: any): void => {
+                handleChange(event.target.value);
+              }}
             >
               {options.map((option: string) => {
                 return (
@@ -114,14 +116,18 @@ export const DropDown: React.FC<IDropDownProps> = ({
             options={options}
             style={{ width: 300 }}
             value={value ?? ''}
-            onChange={handleChange}
+            onChange={(event: any, newValue: string): void => {
+              handleChange(newValue);
+            }}
             renderInput={(params): React.ReactNode => (
               <TextField
                 {...params}
                 label={label}
                 required={required}
                 error={error}
-                onChange={handleChange}
+                onChange={(event: any): void => {
+                  handleChange(event.target.value);
+                }}
                 placeholder={
                   placeholder || `Create or select ${label.toLocaleLowerCase()}`
                 }

--- a/packages/ui-components/src/DropDown.tsx
+++ b/packages/ui-components/src/DropDown.tsx
@@ -34,6 +34,8 @@ export interface IDropDownProps {
   description?: string;
   required?: boolean;
   onChange: (value: string) => any;
+  placeholder?: string;
+  initialValue?: string;
 }
 
 const CustomTooltip = withStyles(_theme => ({
@@ -49,10 +51,12 @@ export const DropDown: React.FC<IDropDownProps> = ({
   label,
   description,
   required,
-  onChange
+  onChange,
+  placeholder,
+  initialValue
 }) => {
   const [error, setError] = React.useState(defaultError);
-  const [value, setValue] = React.useState(defaultValue);
+  const [value, setValue] = React.useState(initialValue || defaultValue);
 
   // This is necessary to rerender with error when clicking the save button.
   React.useEffect(() => {
@@ -87,7 +91,9 @@ export const DropDown: React.FC<IDropDownProps> = ({
               onChange={(event: any): void => {
                 handleChange(event.target.value);
               }}
-              placeholder={`Create or select ${label.toLocaleLowerCase()}`}
+              placeholder={
+                placeholder || `Create or select ${label.toLocaleLowerCase()}`
+              }
               variant="outlined"
             />
           )}

--- a/packages/ui-components/src/DropDown.tsx
+++ b/packages/ui-components/src/DropDown.tsx
@@ -18,7 +18,11 @@ import {
   TextField,
   FormHelperText,
   Tooltip,
-  withStyles
+  withStyles,
+  Select,
+  MenuItem,
+  InputLabel,
+  FormControl
 } from '@material-ui/core';
 import { Autocomplete } from '@material-ui/lab';
 
@@ -36,6 +40,7 @@ export interface IDropDownProps {
   onChange: (value: string) => any;
   placeholder?: string;
   initialValue?: string;
+  readonly?: boolean;
 }
 
 const CustomTooltip = withStyles(_theme => ({
@@ -53,7 +58,8 @@ export const DropDown: React.FC<IDropDownProps> = ({
   required,
   onChange,
   placeholder,
-  initialValue
+  initialValue,
+  readonly
 }) => {
   const [error, setError] = React.useState(defaultError);
   const [value, setValue] = React.useState(initialValue || defaultValue);
@@ -63,41 +69,67 @@ export const DropDown: React.FC<IDropDownProps> = ({
     setError(defaultError);
   }, [defaultError]);
 
-  const handleChange = (newValue: string): void => {
-    setValue(newValue);
-    setError(required && newValue === '');
-    onChange(newValue);
+  const handleChange = (event: any): void => {
+    setValue(event.target.value);
+    setError(required && event.target.value === '');
+    onChange(event.target.value);
   };
 
   return (
     <div className={`elyra-metadataEditor-formInput ${DROPDOWN_ITEM_CLASS}`}>
       <CustomTooltip title={description ?? ''} placement="top">
-        <Autocomplete
-          id="combo-box-demo"
-          freeSolo
-          key="elyra-DropDown"
-          options={options}
-          style={{ width: 300 }}
-          value={value ?? ''}
-          onChange={(_event, newValue): void => {
-            handleChange(newValue);
-          }}
-          renderInput={(params): React.ReactNode => (
-            <TextField
-              {...params}
+        {readonly ? (
+          <FormControl variant="outlined">
+            <InputLabel error={error}>{label}</InputLabel>
+            <Select
+              value={value}
+              id={`${label}DropDown`}
               label={label}
-              required={required}
               error={error}
-              onChange={(event: any): void => {
-                handleChange(event.target.value);
-              }}
-              placeholder={
-                placeholder || `Create or select ${label.toLocaleLowerCase()}`
-              }
-              variant="outlined"
-            />
-          )}
-        />
+              onChange={handleChange}
+            >
+              {options.map((option: string) => {
+                return (
+                  <MenuItem
+                    key={`${option}MenuItem`}
+                    value={option}
+                    style={{
+                      width: '100%',
+                      display: 'flex',
+                      justifyContent: 'flex-start',
+                      padding: '18.5px 14px'
+                    }}
+                  >
+                    {option}
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          </FormControl>
+        ) : (
+          <Autocomplete
+            id="combo-box-demo"
+            freeSolo
+            key="elyra-DropDown"
+            options={options}
+            style={{ width: 300 }}
+            value={value ?? ''}
+            onChange={handleChange}
+            renderInput={(params): React.ReactNode => (
+              <TextField
+                {...params}
+                label={label}
+                required={required}
+                error={error}
+                onChange={handleChange}
+                placeholder={
+                  placeholder || `Create or select ${label.toLocaleLowerCase()}`
+                }
+                variant="outlined"
+              />
+            )}
+          />
+        )}
       </CustomTooltip>
       {error === true && (
         <FormHelperText error>This field is required.</FormHelperText>


### PR DESCRIPTION
Fixes #1368.

* If `uihints.placeholder` is defined, the field will display that as a placeholder. Otherwise, it will use "Create or select <field name>" as a placeholder for dropdowns
* If the schema defines a `default` for a field, an empty field will automatically use that for the value of the field. Otherwise, the field will be empty.

The code snippet language field remains the same:
![image](https://user-images.githubusercontent.com/6673460/111358502-684c3180-8658-11eb-98db-2a8509e34e92.png)

The KFP runtimes editor automatically shows this when creating a new runtime config: 
![image](https://user-images.githubusercontent.com/6673460/111358628-8e71d180-8658-11eb-962c-08c180989823.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

