### PR TITLE
Can't remove string array properties

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -545,9 +545,13 @@ export class PipelineEditor extends React.Component<
     }
 
     app_data.runtime_image = propertySet.runtime_image;
-    app_data.outputs = propertySet.outputs;
-    app_data.env_vars = propertySet.env_vars;
-    app_data.dependencies = propertySet.dependencies;
+    app_data.outputs = propertySet.outputs.filter((x: any) => x !== undefined);
+    app_data.env_vars = propertySet.env_vars.filter(
+      (x: any) => x !== undefined
+    );
+    app_data.dependencies = propertySet.dependencies.filter(
+      (x: any) => x !== undefined
+    );
     app_data.include_subdirectories = propertySet.include_subdirectories;
     app_data.cpu = propertySet.cpu;
     app_data.memory = propertySet.memory;


### PR DESCRIPTION
When `StringArrayInput` deletes a value in string array properties
it does not actually delete it, instead leaving an `undefined` value.

This needs to be addressed by removing the undefined values when
saving property changes. This is due to js allowing sparse arrays.

Fixes #1426



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

