### PR TITLE
Fix pipeline properties css bug in Safari

### DIFF
--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -351,3 +351,8 @@ input.elyra-Dialog-checkbox.jp-mod-styled {
 .elyra-dialog-form input[type='text'] {
   width: 100%;
 }
+
+/* fix a Safari bug where button margins default to 2px */
+.properties-control-panel button {
+  margin: 0;
+}


### PR DESCRIPTION
For some reason Safari is defaulting margins to 2px for buttons
in common properties, though the style sheet says 0. This sets the
default margin for buttons inside common properties to have a
0 margin as is expected and as Chrome and FF already assume.

Fixes #1436



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

