### PR TITLE
Fix properties editor node deletion bug

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -765,11 +765,10 @@ export class PipelineEditor extends React.Component<
           }
           break;
         case 'deleteSelectedObjects':
-          if (data.type === 'node') {
-            if (this.state.showPropertiesDialog) {
-              this.closePropertiesDialog();
-            }
+          if (this.state.showPropertiesDialog) {
+            this.closePropertiesDialog();
           }
+          break;
       }
     }
 

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -530,6 +530,10 @@ export class PipelineEditor extends React.Component<
           break;
         }
       }
+      // If still couldn't find the node, cancel this function
+      if (!node) {
+        return;
+      }
     }
     const app_data = node.app_data;
 
@@ -760,6 +764,12 @@ export class PipelineEditor extends React.Component<
             this.openPropertiesDialog(data);
           }
           break;
+        case 'deleteSelectedObjects':
+          if (data.type === 'node') {
+            if (this.state.showPropertiesDialog) {
+              this.closePropertiesDialog();
+            }
+          }
       }
     }
 


### PR DESCRIPTION
Fixes #1457. When the properties editor is open for a node and that node is deleted, it causes a bug that prevents the user from closing the properties editor and using it for other nodes. (It was looking to save the properties of the node before closing the editor, and because it couldn't find the node it would throw an error)

This PR has two changes:
* Automatically closes the properties editor if its node is deleted
* Fixes the bug that caused the properties editor not to be able to close when it can't find the node being edited
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

