### PR TITLE
Created RuntimeImagesWidget for customized UI

### DIFF
--- a/packages/pipeline-editor/src/RuntimeImagesWidget.tsx
+++ b/packages/pipeline-editor/src/RuntimeImagesWidget.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018-2021 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  MetadataWidget,
+  IMetadataWidgetProps,
+  IMetadata,
+  MetadataDisplay,
+  IMetadataDisplayProps,
+  IMetadataDisplayState
+} from '@elyra/metadata-common';
+import { IDictionary } from '@elyra/services';
+
+import React from 'react';
+
+export const RUNTIME_IMAGES_NAMESPACE = 'runtime-images';
+
+const RUNTIME_IMAGES_CLASS = 'elyra-metadata-runtime-images';
+
+/**
+ * A React Component for displaying the runtime images list.
+ */
+class RuntimeImagesDisplay extends MetadataDisplay<
+  IMetadataDisplayProps,
+  IMetadataDisplayState
+> {
+  renderExpandableContent(metadata: IDictionary<any>): JSX.Element {
+    const imageRepo = metadata.metadata.image_name.split(':')[0];
+
+    return (
+      <div>
+        <h6>Container Image</h6>
+        <a
+          href={`https://hub.docker.com/r/${imageRepo}`}
+          target="_blank"
+          rel="noreferrer noopener"
+        >
+          {metadata.metadata.image_name}
+        </a>
+      </div>
+    );
+  }
+}
+
+/**
+ * A widget for displaying runtime images.
+ */
+export class RuntimeImagesWidget extends MetadataWidget {
+  constructor(props: IMetadataWidgetProps) {
+    super(props);
+  }
+
+  renderDisplay(metadata: IMetadata[]): React.ReactElement {
+    return (
+      <RuntimeImagesDisplay
+        metadata={metadata}
+        updateMetadata={this.updateMetadata}
+        openMetadataEditor={this.openMetadataEditor}
+        namespace={RUNTIME_IMAGES_NAMESPACE}
+        sortMetadata={true}
+        className={RUNTIME_IMAGES_CLASS}
+      />
+    );
+  }
+}

--- a/packages/pipeline-editor/src/RuntimeImagesWidget.tsx
+++ b/packages/pipeline-editor/src/RuntimeImagesWidget.tsx
@@ -30,6 +30,28 @@ export const RUNTIME_IMAGES_NAMESPACE = 'runtime-images';
 
 const RUNTIME_IMAGES_CLASS = 'elyra-metadata-runtime-images';
 
+const getLinkFromImageName = (imageName: string): string => {
+  let hostname = '';
+  const fqinParts = imageName.split('/');
+
+  if (
+    fqinParts[0].includes('.') ||
+    fqinParts[0].includes(':') ||
+    fqinParts[0].includes('localhost')
+  ) {
+    hostname = fqinParts[0];
+    imageName = fqinParts.slice(1).join('/');
+  }
+
+  if (!hostname || hostname.includes('docker.io')) {
+    hostname = 'hub.docker.com/r';
+  }
+
+  const imageRepo = imageName.split(':')[0];
+
+  return `https://${hostname}/${imageRepo}`;
+};
+
 /**
  * A React Component for displaying the runtime images list.
  */
@@ -38,13 +60,11 @@ class RuntimeImagesDisplay extends MetadataDisplay<
   IMetadataDisplayState
 > {
   renderExpandableContent(metadata: IDictionary<any>): JSX.Element {
-    const imageRepo = metadata.metadata.image_name.split(':')[0];
-
     return (
       <div>
         <h6>Container Image</h6>
         <a
-          href={`https://hub.docker.com/r/${imageRepo}`}
+          href={getLinkFromImageName(metadata.metadata.image_name)}
           target="_blank"
           rel="noreferrer noopener"
         >

--- a/packages/pipeline-editor/src/index.ts
+++ b/packages/pipeline-editor/src/index.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { pipelineIcon, runtimesIcon } from '@elyra/ui-components';
+import {
+  containerIcon,
+  pipelineIcon,
+  runtimesIcon
+} from '@elyra/ui-components';
 
 import {
   JupyterFrontEnd,
@@ -34,6 +38,10 @@ import { addIcon } from '@jupyterlab/ui-components';
 
 import { PipelineEditorFactory, commandIDs } from './PipelineEditorWidget';
 import { RUNTIMES_NAMESPACE } from './PipelineService';
+import {
+  RUNTIME_IMAGES_NAMESPACE,
+  RuntimeImagesWidget
+} from './RuntimeImagesWidget';
 import { RuntimesWidget } from './RuntimesWidget';
 import { SubmitNotebookButtonExtension } from './SubmitNotebookButtonExtension';
 import { SubmitScriptButtonExtension } from './SubmitScriptButtonExtension';
@@ -204,6 +212,21 @@ const extension: JupyterFrontEndPlugin<void> = {
 
     restorer.add(runtimesWidget, runtimesWidgetID);
     app.shell.add(runtimesWidget, 'left', { rank: 950 });
+
+    const runtimeImagesWidget = new RuntimeImagesWidget({
+      app,
+      themeManager,
+      display_name: 'Runtime Images',
+      namespace: RUNTIME_IMAGES_NAMESPACE,
+      icon: containerIcon
+    });
+    const runtimeImagesWidgetID = `elyra-metadata:${RUNTIME_IMAGES_NAMESPACE}`;
+    runtimeImagesWidget.id = runtimeImagesWidgetID;
+    runtimeImagesWidget.title.icon = containerIcon;
+    runtimeImagesWidget.title.caption = 'Runtime Images';
+
+    restorer.add(runtimeImagesWidget, runtimeImagesWidgetID);
+    app.shell.add(runtimeImagesWidget, 'left', { rank: 951 });
   }
 };
 export default extension;


### PR DESCRIPTION
With this the Runtime Images UI is permanently added to the sidebar
and includes links to the image repos on DockerHub.

Fixes #581



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

