### PR TITLE
Fix runtime CLI examples in documentation to include schema_name param

### DIFF
--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -98,7 +98,8 @@ elyra-metadata install runtimes \
        --cos_username=minio \
        --cos_password=minio123 \
        --cos_bucket=test-bucket \
-       --tags="['kfp', 'v1.0']"
+       --tags="['kfp', 'v1.0']" \
+       --schema_name=kfp
 ```
 
 Refer to the [Kubeflow Pipelines Configuration settings](#kubeflow-pipelines-configuration-settings) section for an explanation of the parameters.
@@ -120,7 +121,8 @@ elyra-metadata install runtimes \
        --cos_username=minio \
        --cos_password=minio123 \
        --cos_bucket=test-bucket \
-       --tags="['kfp', 'v1.1']"
+       --tags="['kfp', 'v1.1']" \
+       --schema_name=kfp
 ```
 
 Refer to the [Kubeflow Pipelines Configuration settings](#kubeflow-pipelines-configuration-settings) section for an explanation of the parameters. Note that you must specify the `--name` parameter. 


### PR DESCRIPTION
Fixes #1458.

<details>
  <summary>Successful Output</summary>
  
```
% elyra-metadata install runtimes \
       --display_name="My Kubeflow Pipelines Runtime" \
       --api_endpoint=https://kubernetes-service.ibm.com/pipeline \
       --api_username=username@email.com \
       --api_password=mypassword \
       --engine=Argo \
       --cos_endpoint=http://minio-service.kubeflow:9000 \
       --cos_username=minio \
       --cos_password=minio123 \
       --cos_bucket=test-bucket \
       --tags="['kfp', 'v1.0']" \
       --schema_name=kfp
Metadata instance 'my_kubeflow_pipelines_runtime' for schema 'kfp' has been written to: /Users/kierstenstokes/Library/Jupyter/metadata/runtimes/my_kubeflow_pipelines_runtime.json

% elyra-metadata install runtimes \
       --replace \
       --name="my_kubeflow_pipelines_runtime" \
       --display_name="My Kubeflow Pipelines Runtime" \
       --api_endpoint=https://kubernetes-service.ibm.com/pipeline \
       --api_username=username@email.com \
       --api_password=mynewpassword \
       --engine=Argo \
       --cos_endpoint=http://minio-service.kubeflow:9000 \
       --cos_username=minio \
       --cos_password=minio123 \
       --cos_bucket=test-bucket \
       --tags="['kfp', 'v1.1']" \
       --schema_name=kfp
Metadata instance 'my_kubeflow_pipelines_runtime' for schema 'kfp' has been written to: /Users/kierstenstokes/Library/Jupyter/metadata/runtimes/my_kubeflow_pipelines_runtime.json
```
</details>
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

