### PR TITLE
Use node labels instead of filename as operation names

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,5 +15,5 @@
 #
 import pytest
 
-#pytest_plugins = ["jupyter_server.pytest_plugin"]
+pytest_plugins = ["jupyter_server.pytest_plugin"]
 

--- a/conftest.py
+++ b/conftest.py
@@ -15,5 +15,5 @@
 #
 import pytest
 
-pytest_plugins = ["jupyter_server.pytest_plugin"]
+#pytest_plugins = ["jupyter_server.pytest_plugin"]
 

--- a/elyra/pipeline/parser.py
+++ b/elyra/pipeline/parser.py
@@ -139,6 +139,7 @@ class PipelineParser(LoggingConfigurable):
             id=node_id,
             type=node.get('type'),
             classifier=node.get('op'),
+            name=PipelineParser._get_ui_data_field(node, 'label'),
             cpu=PipelineParser._get_app_data_field(node, 'cpu'),
             gpu=PipelineParser._get_app_data_field(node, 'gpu'),
             memory=PipelineParser._get_app_data_field(node, 'memory'),
@@ -165,6 +166,11 @@ class PipelineParser(LoggingConfigurable):
     def _get_app_data_field(obj: Dict, field_name: str, default_value: Any = None) -> Any:
         """Helper method to pull the field's value from the app_data child of object obj."""
         return PipelineParser._get_child_field(obj, 'app_data', field_name, default_value=default_value)
+
+    @staticmethod
+    def _get_ui_data_field(obj: Dict, field_name: str, default_value: Any = None) -> Any:
+        ui_data = PipelineParser._get_child_field(obj, 'app_data', 'ui_data')
+        return ui_data.get(field_name, default_value)
 
     @staticmethod
     def _get_port_node_id(link: Dict) -> [None, str]:

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import sys
 
 from typing import Dict, Optional
@@ -24,7 +23,7 @@ class Operation(object):
     Represents a single operation in a pipeline
     """
 
-    def __init__(self, id, type, classifier, filename, runtime_image, memory=None, cpu=None, gpu=None,
+    def __init__(self, id, type, name, classifier, filename, runtime_image, memory=None, cpu=None, gpu=None,
                  dependencies=None, include_subdirectories: bool = False, env_vars=None, inputs=None,
                  outputs=None, parent_operations=None):
         """
@@ -32,6 +31,7 @@ class Operation(object):
                    e.g. 123e4567-e89b-12d3-a456-426614174000
         :param type: The type of node e.g. execution_node
         :param classifier: classifier for processor execution e.g. Argo
+        :param name: The name of the operation
         :param filename: The relative path to the source file in the users local environment
                          to be executed e.g. path/to/file.ext
         :param runtime_image: The DockerHub image to be used for the operation
@@ -56,6 +56,8 @@ class Operation(object):
             raise ValueError("Invalid pipeline operation: Missing field 'operation type'.")
         if not classifier:
             raise ValueError("Invalid pipeline operation: Missing field 'operation classifier'.")
+        if not name:
+            raise ValueError("Invalid pipeline operation: Missing field 'operation name'.")
         if not filename:
             raise ValueError("Invalid pipeline operation: Missing field 'operation filename'.")
         if not runtime_image:
@@ -70,6 +72,7 @@ class Operation(object):
         self._id = id
         self._type = type
         self._classifier = classifier
+        self._name = name
         self._filename = filename
         self._runtime_image = runtime_image
         self._dependencies = dependencies or []
@@ -96,7 +99,7 @@ class Operation(object):
 
     @property
     def name(self):
-        return os.path.basename(self._filename).split(".")[0]
+        return self._name
 
     @property
     def filename(self):
@@ -175,6 +178,7 @@ class Operation(object):
             return self.id == other.id and \
                 self.type == other.type and \
                 self.classifier == other.classifier and \
+                self.name == other.name and \
                 self.filename == other.filename and \
                 self.runtime_image == other.runtime_image and \
                 self.env_vars == other.env_vars and \

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -193,6 +193,7 @@ class Operation(object):
                 self.cpu == other.cpu and \
                 self.gpu == other.gpu and \
                 self.memory == other.memory
+        return False
 
     def __str__(self) -> str:
         return "componentID : {id} \n " \

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
 import sys
 
 from typing import Dict, Optional
@@ -99,6 +100,8 @@ class Operation(object):
 
     @property
     def name(self):
+        if self._name == os.path.basename(self._filename):
+            return os.path.basename(self._name).split(".")[0]
         return self._name
 
     @property

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -101,7 +101,7 @@ class Operation(object):
     @property
     def name(self):
         if self._name == os.path.basename(self._filename):
-            return os.path.basename(self._name).split(".")[0]
+            self._name = os.path.basename(self._name).split(".")[0]
         return self._name
 
     @property

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -433,8 +433,7 @@ class KfpPipelineProcessor(RuntimePipelineProcess):
         In KFP, only letters, numbers, spaces, "_", and "-" are allowed in name.
         :param name: name of the operation
         """
-        return re.sub('-+', '-', re.sub('[^-_0-9A-Za-z ]+', '-',
-                                 name)).lstrip('-').rstrip('-')
+        return re.sub('-+', '-', re.sub('[^-_0-9A-Za-z ]+', '-', name)).lstrip('-').rstrip('-')
 
     @staticmethod
     def _get_user_auth_session_cookie(url, username, password):

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -17,6 +17,7 @@ import autopep8
 import kfp
 import kfp_tekton
 import os
+import re
 import tempfile
 import time
 import requests
@@ -432,7 +433,8 @@ class KfpPipelineProcessor(RuntimePipelineProcess):
         In KFP, only letters, numbers, spaces, "_", and "-" are allowed in name.
         :param name: name of the operation
         """
-        return kfp.dsl._pipeline_param.sanitize_k8s_name(name, allow_capital_underscore=True)
+        return re.sub('-+', '-', re.sub('[^-_0-9A-Za-z ]+', '-',
+                                 name)).lstrip('-').rstrip('-')
 
     @staticmethod
     def _get_user_auth_session_cookie(url, username, password):

--- a/elyra/pipeline/tests/resources/sample_pipelines/pipeline_3_node_sample.json
+++ b/elyra/pipeline/tests/resources/sample_pipelines/pipeline_3_node_sample.json
@@ -14,7 +14,14 @@
           "op": "execute-notebook-node",
           "app_data": {
             "filename": "demo-pipelines/generate-contributions.ipynb",
-            "runtime_image": "elyra/tensorflow:1.15.2-py3"
+            "runtime_image": "elyra/tensorflow:1.15.2-py3",
+            "ui_data": {
+              "label": "{{label}}",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 112,
+              "y_pos": 97,
+              "description": "Notebook file"
+            }
           }
         },
         {
@@ -23,7 +30,14 @@
           "op": "execute-notebook-node",
           "app_data": {
             "filename": "demo-pipelines/generate-stats.ipynb",
-            "runtime_image": "elyra/tensorflow:1.15.2-py3"
+            "runtime_image": "elyra/tensorflow:1.15.2-py3",
+            "ui_data": {
+              "label": "{{label}}",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 130,
+              "y_pos": 80,
+              "description": "Notebook file"
+            }
           }
         },
         {
@@ -32,7 +46,14 @@
           "op": "execute-notebook-node",
           "app_data": {
             "filename": "demo-pipelines/overview.ipynb",
-            "runtime_image": "elyra/tensorflow:1.15.2-py3"
+            "runtime_image": "elyra/tensorflow:1.15.2-py3",
+            "ui_data": {
+              "label": "{{label}}",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 148,
+              "y_pos": 62,
+              "description": "Notebook file"
+            }
           }
         }
       ],

--- a/elyra/pipeline/tests/resources/sample_pipelines/pipeline_3_node_sample.json
+++ b/elyra/pipeline/tests/resources/sample_pipelines/pipeline_3_node_sample.json
@@ -17,7 +17,6 @@
             "runtime_image": "elyra/tensorflow:1.15.2-py3",
             "ui_data": {
               "label": "{{label}}",
-              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
               "x_pos": 112,
               "y_pos": 97,
               "description": "Notebook file"
@@ -33,7 +32,6 @@
             "runtime_image": "elyra/tensorflow:1.15.2-py3",
             "ui_data": {
               "label": "{{label}}",
-              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
               "x_pos": 130,
               "y_pos": 80,
               "description": "Notebook file"
@@ -49,7 +47,6 @@
             "runtime_image": "elyra/tensorflow:1.15.2-py3",
             "ui_data": {
               "label": "{{label}}",
-              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
               "x_pos": 148,
               "y_pos": 62,
               "description": "Notebook file"

--- a/elyra/pipeline/tests/resources/sample_pipelines/pipeline_3_node_sample_with_dependencies.json
+++ b/elyra/pipeline/tests/resources/sample_pipelines/pipeline_3_node_sample_with_dependencies.json
@@ -14,7 +14,14 @@
           "op": "execute-notebook-node",
           "app_data": {
             "filename": "demo-pipelines/generate-contributions.ipynb",
-            "runtime_image": "elyra/tensorflow:1.15.2-py3"
+            "runtime_image": "elyra/tensorflow:1.15.2-py3",
+            "ui_data": {
+              "label": "{{label}}",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 112,
+              "y_pos": 97,
+              "description": "Notebook file"
+            }
           },
           "inputs": [
             {
@@ -51,7 +58,14 @@
           "op": "execute-notebook-node",
           "app_data": {
             "filename": "demo-pipelines/generate-stats.ipynb",
-            "runtime_image": "elyra/tensorflow:1.15.2-py3"
+            "runtime_image": "elyra/tensorflow:1.15.2-py3",
+            "ui_data": {
+              "label": "{{label}}",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 130,
+              "y_pos": 80,
+              "description": "Notebook file"
+            }
           },
           "inputs": [
             {
@@ -80,7 +94,14 @@
           "op": "execute-notebook-node",
           "app_data": {
             "filename": "demo-pipelines/overview.ipynb",
-            "runtime_image": "elyra/tensorflow:1.15.2-py3"
+            "runtime_image": "elyra/tensorflow:1.15.2-py3",
+            "ui_data": {
+              "label": "{{label}}",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 148,
+              "y_pos": 62,
+              "description": "Notebook file"
+            }
           },
           "inputs": [
             {

--- a/elyra/pipeline/tests/resources/sample_pipelines/pipeline_3_node_sample_with_dependencies.json
+++ b/elyra/pipeline/tests/resources/sample_pipelines/pipeline_3_node_sample_with_dependencies.json
@@ -17,7 +17,6 @@
             "runtime_image": "elyra/tensorflow:1.15.2-py3",
             "ui_data": {
               "label": "{{label}}",
-              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
               "x_pos": 112,
               "y_pos": 97,
               "description": "Notebook file"
@@ -61,7 +60,6 @@
             "runtime_image": "elyra/tensorflow:1.15.2-py3",
             "ui_data": {
               "label": "{{label}}",
-              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
               "x_pos": 130,
               "y_pos": 80,
               "description": "Notebook file"
@@ -97,7 +95,6 @@
             "runtime_image": "elyra/tensorflow:1.15.2-py3",
             "ui_data": {
               "label": "{{label}}",
-              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
               "x_pos": 148,
               "y_pos": 62,
               "description": "Notebook file"

--- a/elyra/pipeline/tests/resources/sample_pipelines/pipeline_valid.json
+++ b/elyra/pipeline/tests/resources/sample_pipelines/pipeline_valid.json
@@ -17,7 +17,14 @@
             "runtime_image": "{{runtime_image}}",
             "env_vars": ["var1=var1", "var2=var2"],
             "dependencies": ["a.txt", "b.txt", "c.txt"],
-            "outputs": ["d.txt", "e.txt", "f.txt"]
+            "outputs": ["d.txt", "e.txt", "f.txt"],
+            "ui_data": {
+              "label": "{{label}}",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 112,
+              "y_pos": 97,
+              "description": "Notebook file"
+            }
           }
         }
       ],

--- a/elyra/pipeline/tests/resources/sample_pipelines/pipeline_valid.json
+++ b/elyra/pipeline/tests/resources/sample_pipelines/pipeline_valid.json
@@ -20,7 +20,6 @@
             "outputs": ["d.txt", "e.txt", "f.txt"],
             "ui_data": {
               "label": "{{label}}",
-              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
               "x_pos": 112,
               "y_pos": 97,
               "description": "Notebook file"

--- a/elyra/pipeline/tests/resources/sample_pipelines/pipeline_with_invalid_list_values.json
+++ b/elyra/pipeline/tests/resources/sample_pipelines/pipeline_with_invalid_list_values.json
@@ -20,7 +20,6 @@
             "outputs": ["d.txt", null, "", "e.txt", "f.txt"],
             "ui_data": {
               "label": "{{label}}",
-              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
               "x_pos": 112,
               "y_pos": 97,
               "description": "Notebook file"

--- a/elyra/pipeline/tests/resources/sample_pipelines/pipeline_with_invalid_list_values.json
+++ b/elyra/pipeline/tests/resources/sample_pipelines/pipeline_with_invalid_list_values.json
@@ -17,7 +17,14 @@
             "runtime_image": "{{runtime_image}}",
             "env_vars": ["var1=var1", "var2=var2", "", null],
             "dependencies": ["a.txt", "b.txt", "", null, "c.txt"],
-            "outputs": ["d.txt", null, "", "e.txt", "f.txt"]
+            "outputs": ["d.txt", null, "", "e.txt", "f.txt"],
+            "ui_data": {
+              "label": "{{label}}",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 112,
+              "y_pos": 97,
+              "description": "Notebook file"
+            }
           }
         }
       ],

--- a/elyra/pipeline/tests/test_kfp_processor.py
+++ b/elyra/pipeline/tests/test_kfp_processor.py
@@ -48,6 +48,7 @@ def test_generate_dependency_archive(processor):
     test_operation = Op(id='123e4567-e89b-12d3-a456-426614174000',
                         type='execution-node',
                         classifier='kfp',
+                        name='test',
                         filename=pipelines_test_file,
                         dependencies=pipeline_dependencies,
                         runtime_image='tensorflow/tensorflow:latest')
@@ -71,6 +72,7 @@ def test_fail_generate_dependency_archive(processor):
     test_operation = Op(id='123e4567-e89b-12d3-a456-426614174000',
                         type='execution-node',
                         classifier='kfp',
+                        name='test',
                         filename=pipelines_test_file,
                         dependencies=pipeline_dependencies,
                         runtime_image='tensorflow/tensorflow:latest')
@@ -87,6 +89,7 @@ def test_get_dependency_source_dir(processor):
     test_operation = Op(id='123e4567-e89b-12d3-a456-426614174000',
                         type='execution-node',
                         classifier='kfp',
+                        name='test',
                         filename=pipelines_test_file,
                         runtime_image='tensorflow/tensorflow:latest')
 
@@ -102,6 +105,7 @@ def test_get_dependency_archive_name(processor):
     test_operation = Op(id='this-is-a-test-id',
                         type='execution-node',
                         classifier='kfp',
+                        name='test',
                         filename=pipelines_test_file,
                         runtime_image='tensorflow/tensorflow:latest')
 

--- a/elyra/pipeline/tests/test_pipeline_constructor.py
+++ b/elyra/pipeline/tests/test_pipeline_constructor.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
 import pytest
 import sys
 from elyra.pipeline import Operation, Pipeline
@@ -132,6 +133,20 @@ def test_create_operation_with_parent_operations():
                                runtime_image='tensorflow/tensorflow:latest')
 
     assert test_operation.parent_operations == parent_operation_ids
+
+
+def test_create_operation_correct_naming():
+    label = 'test.ipynb'
+    filename = 'elyra/pipeline/tests/resources/archive/' + label
+
+    test_operation = Operation(id='test-id',
+                               type='test',
+                               classifier='execution-node',
+                               name=label,
+                               filename=filename,
+                               runtime_image='tensorflow/tensorflow:latest')
+
+    assert test_operation.name == label.split('.')[0]
 
 
 def test_fail_create_operation_missing_id():

--- a/elyra/pipeline/tests/test_pipeline_constructor.py
+++ b/elyra/pipeline/tests/test_pipeline_constructor.py
@@ -169,6 +169,7 @@ def test_fail_create_operation_missing_runtime_image():
                   name='test',
                   filename='elyra/pipeline/tests/resources/archive/test.ipynb')
 
+
 def test_fail_create_operation_missing_name():
     with pytest.raises(TypeError):
         Operation(id='test-id',

--- a/elyra/pipeline/tests/test_pipeline_constructor.py
+++ b/elyra/pipeline/tests/test_pipeline_constructor.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import pytest
 import sys
 from elyra.pipeline import Operation, Pipeline

--- a/elyra/pipeline/tests/test_pipeline_constructor.py
+++ b/elyra/pipeline/tests/test_pipeline_constructor.py
@@ -23,6 +23,7 @@ def good_operation():
     test_operation = Operation(id='test-id',
                                type='test',
                                classifier='execution-node',
+                               name='test',
                                filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                                runtime_image='tensorflow/tensorflow:latest')
     return test_operation
@@ -43,6 +44,7 @@ def test_create_operation_minimal(good_operation):
     assert test_operation.id == 'test-id'
     assert test_operation.type == 'test'
     assert test_operation.classifier == 'execution-node'
+    assert test_operation.name == 'test'
     assert test_operation.filename == 'elyra/pipeline/tests/resources/archive/test.ipynb'
     assert test_operation.runtime_image == 'tensorflow/tensorflow:latest'
     assert test_operation.name == 'test'
@@ -54,6 +56,7 @@ def test_create_operation_with_dependencies():
     test_operation = Operation(id='test-id',
                                type='test',
                                classifier='execution-node',
+                               name='test',
                                filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                                dependencies=dependencies,
                                runtime_image='tensorflow/tensorflow:latest')
@@ -67,6 +70,7 @@ def test_create_operation_include_subdirectories():
     test_operation = Operation(id='test-id',
                                type='test',
                                classifier='execution-node',
+                               name='test',
                                filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                                include_subdirectories=include_subdirectories,
                                runtime_image='tensorflow/tensorflow:latest')
@@ -80,6 +84,7 @@ def test_create_operation_with_environmental_variables():
     test_operation = Operation(id='test-id',
                                type='test',
                                classifier='execution-node',
+                               name='test',
                                filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                                env_vars=env_variables,
                                runtime_image='tensorflow/tensorflow:latest')
@@ -93,6 +98,7 @@ def test_create_operation_with_inputs():
     test_operation = Operation(id='test-id',
                                type='test',
                                classifier='execution-node',
+                               name='test',
                                filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                                inputs=inputs,
                                runtime_image='tensorflow/tensorflow:latest')
@@ -106,6 +112,7 @@ def test_create_operation_with_outputs():
     test_operation = Operation(id='test-id',
                                type='test',
                                classifier='execution-node',
+                               name='test',
                                filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                                outputs=outputs,
                                runtime_image='tensorflow/tensorflow:latest')
@@ -119,6 +126,7 @@ def test_create_operation_with_parent_operations():
     test_operation = Operation(id='test-id',
                                type='test',
                                classifier='execution-node',
+                               name='test',
                                filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                                parent_operations=parent_operation_ids,
                                runtime_image='tensorflow/tensorflow:latest')
@@ -130,6 +138,7 @@ def test_fail_create_operation_missing_id():
     with pytest.raises(TypeError):
         Operation(type='test',
                   classifier='execution-node',
+                  name='test',
                   filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                   runtime_image='tensorflow/tensorflow:latest')
 
@@ -138,6 +147,7 @@ def test_fail_create_operation_missing_type():
     with pytest.raises(TypeError):
         Operation(id='test-id',
                   classifier='execution-node',
+                  name='test',
                   filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                   runtime_image='tensorflow/tensorflow:latest')
 
@@ -146,6 +156,7 @@ def test_fail_create_operation_missing_classifier():
     with pytest.raises(TypeError):
         Operation(id='test-id',
                   type='test',
+                  name='test',
                   filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                   runtime_image='tensorflow/tensorflow:latest')
 
@@ -155,7 +166,16 @@ def test_fail_create_operation_missing_runtime_image():
         Operation(id='test-id',
                   type='test',
                   classifier='execution-node',
+                  name='test',
                   filename='elyra/pipeline/tests/resources/archive/test.ipynb')
+
+def test_fail_create_operation_missing_name():
+    with pytest.raises(TypeError):
+        Operation(id='test-id',
+                  type='test',
+                  classifier='execution-node',
+                  filename='elyra/pipeline/tests/resources/archive/test.ipynb',
+                  runtime_image='tensorflow/tensorflow:latest')
 
 
 def test_fail_operations_are_equal(good_operation):
@@ -163,6 +183,7 @@ def test_fail_operations_are_equal(good_operation):
     compare_operation = Operation(id='test-id',
                                   type='test',
                                   classifier='execution-node',
+                                  name='test',
                                   filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                                   parent_operations=parent_operation_ids,
                                   runtime_image='tensorflow/tensorflow:latest')
@@ -174,6 +195,7 @@ def test_operations_are_equal(good_operation):
     compare_operation = Operation(id='test-id',
                                   type='test',
                                   classifier='execution-node',
+                                  name='test',
                                   filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                                   runtime_image='tensorflow/tensorflow:latest')
 
@@ -249,6 +271,7 @@ def test_env_list_to_dict_function():
     test_operation = Operation(id='test-id',
                                type='test',
                                classifier='execution-node',
+                               name='test',
                                filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                                env_vars=env_variables,
                                runtime_image='tensorflow/tensorflow:latest')
@@ -261,6 +284,7 @@ def test_validate_resource_values():
     test_operation = Operation(id='test-id',
                                type='test',
                                classifier='execution-node',
+                               name='test',
                                filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                                cpu='4',
                                gpu='6',
@@ -277,6 +301,7 @@ def test_validate_resource_values_as_none():
     test_operation = Operation(id='test-id',
                                type='test',
                                classifier='execution-node',
+                               name='test',
                                filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                                runtime_image='tensorflow/tensorflow:latest')
 
@@ -290,6 +315,7 @@ def test_validate_gpu_accepts_zero_as_value():
     test_operation = Operation(id='test-id',
                                type='test',
                                classifier='execution-node',
+                               name='test',
                                filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                                cpu='4',
                                gpu='0',
@@ -305,6 +331,7 @@ def test_validate_max_resource_value():
     test_operation = Operation(id='test-id',
                                type='test',
                                classifier='execution-node',
+                               name='test',
                                filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                                memory=system_max_size,
                                runtime_image='tensorflow/tensorflow:latest')
@@ -319,6 +346,7 @@ def test_fail_validate_max_resource_value_exceeded():
         Operation(id='test-id',
                   type='test',
                   classifier='execution-node',
+                  name='test',
                   filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                   memory=system_max_size,
                   runtime_image='tensorflow/tensorflow:latest')
@@ -329,6 +357,7 @@ def test_fail_creating_operation_with_negative_gpu_resources():
         Operation(id='test-id',
                   type='test',
                   classifier='execution-node',
+                  name='test',
                   filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                   gpu='-1',
                   runtime_image='tensorflow/tensorflow:latest')
@@ -339,6 +368,7 @@ def test_fail_creating_operation_with_0_cpu_resources():
         Operation(id='test-id',
                   type='test',
                   classifier='execution-node',
+                  name='test',
                   filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                   cpu='0',
                   runtime_image='tensorflow/tensorflow:latest')
@@ -349,6 +379,7 @@ def test_fail_creating_operation_with_negative_cpu_resources():
         Operation(id='test-id',
                   type='test',
                   classifier='execution-node',
+                  name='test',
                   filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                   cpu='-1',
                   runtime_image='tensorflow/tensorflow:latest')
@@ -359,6 +390,7 @@ def test_fail_creating_operation_with_0_memory_resources():
         Operation(id='test-id',
                   type='test',
                   classifier='execution-node',
+                  name='test',
                   filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                   memory='0',
                   runtime_image='tensorflow/tensorflow:latest')
@@ -369,6 +401,7 @@ def test_fail_creating_operation_with_negative_memory_resources():
         Operation(id='test-id',
                   type='test',
                   classifier='execution-node',
+                  name='test',
                   filename='elyra/pipeline/tests/resources/archive/test.ipynb',
                   memory='-1',
                   runtime_image='tensorflow/tensorflow:latest')

--- a/elyra/pipeline/tests/test_pipeline_parser.py
+++ b/elyra/pipeline/tests/test_pipeline_parser.py
@@ -24,6 +24,7 @@ def valid_operation():
     return Operation(id='{{uuid}}',
                      type='execution_node',
                      classifier='execute-notebook-node',
+                     name='{{label}}',
                      filename='{{filename}}',
                      runtime_image='{{runtime_image}}',
                      env_vars=["var1=var1", "var2=var2"],

--- a/elyra/pipeline/tests/util.py
+++ b/elyra/pipeline/tests/util.py
@@ -79,7 +79,7 @@ class NodeBase(object):
         if self.outputs:
             self.env_vars.append(f"OUTPUT_FILENAMES={';'.join(self.outputs)}")
 
-        return Operation(self.id, 'execution_node', self.classifier, self.filename, self.image_name or "NA",
+        return Operation(self.id, 'execution_node', self.name, self.classifier, self.filename, self.image_name or "NA",
                          dependencies=self.dependencies, env_vars=self.env_vars,
                          inputs=self.inputs, outputs=self.outputs,
                          parent_operations=self.parent_operations)


### PR DESCRIPTION
Changes the naming of the node from using the filename e.g. script
or notebook to using a sanitized label defined in the pipeline editor to
avoid naming collosions during compilation.

Fixes #971

- [x] changes for airflow processor - no changes needed, there is a regex filter in the airflow dag template to replace invalid chars
- [x] add/modify existing tests

 ![image](https://user-images.githubusercontent.com/13340013/112205289-e452f600-8bd1-11eb-95e4-d0265e00531b.png)
![image](https://user-images.githubusercontent.com/13340013/112205316-e917aa00-8bd1-11eb-9c72-d7dde4e667bd.png)
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

