### PR TITLE
Trap KFP namespace errors and display cause appropriately

### DIFF
--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -127,11 +127,14 @@ class KfpPipelineProcessor(RuntimePipelineProcess):
             if ae.body:
                 error_body = json.loads(ae.body)
                 error_msg += f": {error_body['error']}"
+            if error_msg[-1] not in ['.', '?', '!']:
+                error_msg += '.'
 
             namespace = "namespace" if not user_namespace else f"namespace {user_namespace}"
 
             self.log.error(f"Error validating {namespace}: {error_msg}")
-            raise RuntimeError(f"Error validating {namespace}: {error_msg}") from ae
+            raise RuntimeError(f"Error validating {namespace}: {error_msg} " +
+                               "Please validate your runtime configuration details and retry.") from ae
 
         self.log_pipeline_info(pipeline_name, "submitting pipeline")
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Resolves #1467. Now that this has been trapped separately, the double scroll bars in the error details have disappeared and only the single scrollbar remains.


### Screenshots/log output
**When namespace is required, but no namespace is entered in the runtime config:**
<img width="910" alt="Screen Shot 2021-03-23 at 3 42 10 PM" src="https://user-images.githubusercontent.com/31816267/112218006-30616300-8bf1-11eb-83d8-7d6c13be3c22.png">

<details><summary>Log Output</summary>
<pre>
Traceback (most recent call last):
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/processor_kfp.py", line 181, in process
    experiment = client.create_experiment(name=experiment_name,
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp/_client.py", line 345, in create_experiment
    experiment = self.get_experiment(experiment_name=name, namespace=namespace)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp/_client.py", line 449, in get_experiment
    list_experiments_response = self.list_experiments(page_size=100, page_token=next_page_token, namespace=namespace)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp/_client.py", line 416, in list_experiments
    response = self._experiment_api.list_experiment(
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/api/experiment_service_api.py", line 581, in list_experiment
    return self.list_experiment_with_http_info(**kwargs)  # noqa: E501
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/api/experiment_service_api.py", line 682, in list_experiment_with_http_info
    return self.api_client.call_api(
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/api_client.py", line 378, in call_api
    return self.__call_api(resource_path, method,
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/api_client.py", line 202, in __call_api
    raise e
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/api_client.py", line 195, in __call_api
    response_data = self.request(
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/api_client.py", line 403, in request
    return self.rest_client.GET(url,
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/rest.py", line 244, in GET
    return self.request("GET", url,
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/rest.py", line 238, in request
    raise ApiException(http_resp=r)
kfp_server_api.exceptions.ApiException: (400)
Reason: Bad Request
HTTP response headers: HTTPHeaderDict({'x-powered-by': 'Express', 'content-type': 'application/json', 'trailer': 'Grpc-Trailer-Content-Type', 'date': 'Tue, 23 Mar 2021 20:42:25 GMT', 'x-envoy-upstream-service-time': '9', 'server': 'istio-envoy', 'transfer-encoding': 'chunked'})
HTTP response body: {"error":"Invalid input error: Invalid resource references for experiment. Namespace is empty.","message":"Invalid input error: Invalid resource references for experiment. Namespace is empty.","code":3,"details":[{"@type":"type.googleapis.com/api.Error","error_message":"Invalid resource references for experiment. Namespace is empty.","error_details":"Invalid input error: Invalid resource references for experiment. Namespace is empty."}]}


The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/tornado/web.py", line 1705, in _execute
    result = await result
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/handlers.py", line 89, in post
    response = await PipelineProcessorManager.instance().process(pipeline)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/processor.py", line 78, in process
    res = await asyncio.get_event_loop().run_in_executor(None, processor.process, pipeline)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/processor_kfp.py", line 190, in process
    raise RuntimeError(f'Could not create experiment {experiment_name}: {ae.reason} ({ae.status}): ' +
RuntimeError: Could not create experiment tutorial: Bad Request (400): Invalid input error: Invalid resource references for experiment. Namespace is empty.
</pre>
</details>

---

**When namespace entered is incorrect:**
Unfortunately, in this case, the message given as response repeats itself. I'm not sure if we want to further parse that to remove it or just leave it as is.
<img width="1016" alt="Screen Shot 2021-03-23 at 3 43 03 PM" src="https://user-images.githubusercontent.com/31816267/112218016-35261700-8bf1-11eb-830c-6e00bd8071a5.png">

<details><summary>Log Output</summary>
<pre>
Traceback (most recent call last):
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/processor_kfp.py", line 181, in process
    experiment = client.create_experiment(name=experiment_name,
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp/_client.py", line 345, in create_experiment
    experiment = self.get_experiment(experiment_name=name, namespace=namespace)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp/_client.py", line 449, in get_experiment
    list_experiments_response = self.list_experiments(page_size=100, page_token=next_page_token, namespace=namespace)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp/_client.py", line 416, in list_experiments
    response = self._experiment_api.list_experiment(
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/api/experiment_service_api.py", line 581, in list_experiment
    return self.list_experiment_with_http_info(**kwargs)  # noqa: E501
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/api/experiment_service_api.py", line 682, in list_experiment_with_http_info
    return self.api_client.call_api(
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/api_client.py", line 378, in call_api
    return self.__call_api(resource_path, method,
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/api_client.py", line 202, in __call_api
    raise e
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/api_client.py", line 195, in __call_api
    response_data = self.request(
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/api_client.py", line 403, in request
    return self.rest_client.GET(url,
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/rest.py", line 244, in GET
    return self.request("GET", url,
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_server_api/rest.py", line 238, in request
    raise ApiException(http_resp=r)
kfp_server_api.exceptions.ApiException: (409)
Reason: Conflict
HTTP response headers: HTTPHeaderDict({'x-powered-by': 'Express', 'content-type': 'application/json', 'trailer': 'Grpc-Trailer-Content-Type', 'date': 'Tue, 23 Mar 2021 20:43:15 GMT', 'x-envoy-upstream-service-time': '21', 'server': 'istio-envoy', 'transfer-encoding': 'chunked'})
HTTP response body: {"error":"Failed to authorize with API resource references: BadRequestError: Unauthorized access for anonymous@kubeflow.org to namespace anon: Unauthorized access for anonymous@kubeflow.org to namespace anon","message":"Failed to authorize with API resource references: BadRequestError: Unauthorized access for anonymous@kubeflow.org to namespace anon: Unauthorized access for anonymous@kubeflow.org to namespace anon","code":10,"details":[{"@type":"type.googleapis.com/api.Error","error_message":"Unauthorized access for anonymous@kubeflow.org to namespace anon","error_details":"Failed to authorize with API resource references: BadRequestError: Unauthorized access for anonymous@kubeflow.org to namespace anon: Unauthorized access for anonymous@kubeflow.org to namespace anon"}]}


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/tornado/web.py", line 1705, in _execute
    result = await result
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/handlers.py", line 89, in post
    response = await PipelineProcessorManager.instance().process(pipeline)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/processor.py", line 78, in process
    res = await asyncio.get_event_loop().run_in_executor(None, processor.process, pipeline)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/processor_kfp.py", line 190, in process
    raise RuntimeError(f'Could not create experiment {experiment_name}: {ae.reason} ({ae.status}): ' +
RuntimeError: Could not create experiment tutorial: Conflict (409): Failed to authorize with API resource references: BadRequestError: Unauthorized access for anonymous@kubeflow.org to namespace anon: Unauthorized access for anonymous@kubeflow.org to namespace anon
</pre>
</details>

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

