### PR TITLE
Update remaining notebook imports to jupyter_server

### DIFF
--- a/elyra/pipeline/http_kernel_manager.py
+++ b/elyra/pipeline/http_kernel_manager.py
@@ -25,8 +25,8 @@ from jupyter_client.clientabc import KernelClientABC
 from jupyter_client.manager import AsyncKernelManager
 from jupyter_client.managerabc import KernelManagerABC
 from logging import Logger
-from notebook.gateway.managers import GatewayClient, gateway_request
-from notebook.utils import url_path_join, maybe_future
+from jupyter_server.gateway.managers import GatewayClient, gateway_request
+from jupyter_server.utils import url_path_join, ensure_async
 from queue import Queue
 from threading import Thread
 from tornado import web
@@ -308,7 +308,7 @@ class HTTPKernelClient(AsyncKernelClient):
         self.response_router = Thread(target=self._route_responses)
         self.response_router.start()
 
-        await maybe_future(super().start_channels(shell=shell, iopub=iopub, stdin=stdin, hb=hb, control=control))
+        await ensure_async(super().start_channels(shell=shell, iopub=iopub, stdin=stdin, hb=hb, control=control))
 
     def stop_channels(self):
         """Stops all the running channels for this kernel.

--- a/elyra/pipeline/processor_local.py
+++ b/elyra/pipeline/processor_local.py
@@ -20,7 +20,7 @@ import time
 from abc import ABC, abstractmethod
 from elyra.pipeline import PipelineProcessor, PipelineProcessorResponse, Operation
 from elyra.util.path import get_absolute_path
-from notebook.gateway.managers import GatewayClient
+from jupyter_server.gateway.managers import GatewayClient
 from subprocess import run, CalledProcessError, PIPE
 from traitlets import log
 from typing import Dict


### PR DESCRIPTION
Updated a couple more instances of `notebook` import statements to reflect the `jupyter_server` location.  The problem was because we use [`GatewayClient`](https://github.com/jupyter-server/jupyter_server/blob/master/jupyter_server/gateway/managers.py#L22) from the "running server" to determine whether a gateway server is configured or not and, if so, the configuration settings to use (URL, timeouts, etc.).  Since this is a singleton and the reference is from the `notebook` package, yet `jupyter_server` is running, the notebook-relative singleton will not reflect the current configuration.

Fixes #1470
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

