### PR TITLE
Enable server extensions as both Notebook/Jupyter Server extensions

### DIFF
--- a/elyra/__init__.py
+++ b/elyra/__init__.py
@@ -51,3 +51,5 @@ def _load_jupyter_server_extension(nb_server_app):
     # Create PipelineProcessorManager instance passing root directory
     PipelineProcessorManager.instance(root_dir=web_app.settings['server_root_dir'], parent=nb_server_app)
 
+# For backward compatibility
+load_jupyter_server_extension = _load_jupyter_server_extension

--- a/etc/config/jupyter_notebook_config.d/elyra.json
+++ b/etc/config/jupyter_notebook_config.d/elyra.json
@@ -1,0 +1,7 @@
+{
+  "NotebookApp": {
+    "nbserver_extensions": {
+      "elyra": true
+    }
+  }
+}

--- a/etc/config/jupyter_notebook_config.d/jupyter_resource_usage.json
+++ b/etc/config/jupyter_notebook_config.d/jupyter_resource_usage.json
@@ -1,0 +1,7 @@
+{
+  "NotebookApp": {
+    "nbserver_extensions": {
+      "jupyter_resource_usage": true
+    }
+  }
+}

--- a/etc/config/jupyter_notebook_config.d/jupyterlab_git.json
+++ b/etc/config/jupyter_notebook_config.d/jupyterlab_git.json
@@ -1,0 +1,7 @@
+{
+  "NotebookApp": {
+    "nbserver_extensions": {
+      "jupyterlab_git": true
+    }
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ with open(os.path.join(here, 'elyra', '_version.py')) as f:
     exec(f.read(), {}, version_ns)
 
 npm_packages_path = "./dist/*.tgz"
-auto_extension_path = "./etc/config/jupyter_server_config.d/*.json"
+auto_jupyter_notebook_extension_path = "./etc/config/jupyter_notebook_config.d/*.json"
+auto_jupyter_server_extension_path = "./etc/config/jupyter_server_config.d/*.json"
 settings_path = './etc/config/settings/*.json'
 metadata_path = './etc/config/metadata/runtime-images/*.json'
 
@@ -54,7 +55,8 @@ setup_args = dict(
     long_description=long_desc,
     author="Elyra Maintainers",
     license="Apache License Version 2.0",
-    data_files=[('etc/jupyter/jupyter_server_config.d', glob(auto_extension_path)),
+    data_files=[('etc/jupyter/jupyter_notebook_config.d', glob(auto_jupyter_notebook_extension_path)),
+                ('etc/jupyter/jupyter_server_config.d', glob(auto_jupyter_server_extension_path)),
                 ('share/jupyter/lab/settings', glob(settings_path)),
                 ('share/jupyter/metadata/runtime-images', glob(metadata_path))],
     packages=find_packages(),
@@ -67,7 +69,7 @@ setup_args = dict(
         'jupyter_client>=6.1.7',
         'jupyter_server>=1.2.0',
         'jupyterlab>=3.0.0',
-        'jupyterlab-git==0.30.0b1',
+        'jupyterlab-git==0.30.0b2',
         'jupyterlab-lsp>=3.0.0',
         'jupyter-resource-usage>=0.5.1',
         'minio>=5.0.7,<7.0.0',


### PR DESCRIPTION
The Elyra image was working fine in JupyterHub/Binder until recently, which seems to have introduced a regression where `Jupyter Server` extensions are not being recognized. This has been reported/workarounded in a few JupyterLab extensions running on Hub/Binder environments (e.g. https://github.com/jupyterlab/jupyterlab-git/pull/863) and we are following the same approach, which we used to have in the past as well. 

I also looked into Hub/Binder to see if I could find the culprit commit, but I am not very familiar with where things are handled in Binder and didn't have much success and decided to stop. 


Fixes #1474 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

