### PR TITLE
Add inputs for resource usage in submit notebook/script

### DIFF
--- a/packages/pipeline-editor/src/FileSubmissionDialog.tsx
+++ b/packages/pipeline-editor/src/FileSubmissionDialog.tsx
@@ -180,16 +180,16 @@ export class FileSubmissionDialog extends React.Component<IProps, IState> {
         <br />
         <div className="elyra-resourcesWrapper">
           <div className="elyra-resourceInput">
-            <label htmlFor="gpu"> GPU:</label>
-            <input id="gpu" type="number" name="gpu" />
-          </div>
-          <div className="elyra-resourceInput">
             <label htmlFor="cpu"> CPU:</label>
             <input id="cpu" type="number" name="cpu" />
           </div>
           <div className="elyra-resourceInput">
-            <label htmlFor="ram"> RAM:</label>
-            <input id="ram" type="number" name="ram" />
+            <label htmlFor="gpu"> GPU:</label>
+            <input id="gpu" type="number" name="gpu" />
+          </div>
+          <div className="elyra-resourceInput">
+            <label htmlFor="memory"> RAM (GB):</label>
+            <input id="memory" type="number" name="memory" />
           </div>
         </div>
         <br />

--- a/packages/pipeline-editor/src/FileSubmissionDialog.tsx
+++ b/packages/pipeline-editor/src/FileSubmissionDialog.tsx
@@ -178,6 +178,21 @@ export class FileSubmissionDialog extends React.Component<IProps, IState> {
           ))}
         </select>
         <br />
+        <div className="elyra-resourcesWrapper">
+          <div className="elyra-resourceInput">
+            <label htmlFor="gpu"> GPU:</label>
+            <input id="gpu" type="number" name="gpu" />
+          </div>
+          <div className="elyra-resourceInput">
+            <label htmlFor="cpu"> CPU:</label>
+            <input id="cpu" type="number" name="cpu" />
+          </div>
+          <div className="elyra-resourceInput">
+            <label htmlFor="ram"> RAM:</label>
+            <input id="ram" type="number" name="ram" />
+          </div>
+        </div>
+        <br />
         <input
           type="checkbox"
           className="elyra-Dialog-checkbox"

--- a/packages/pipeline-editor/src/SubmitNotebookButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitNotebookButtonExtension.tsx
@@ -105,6 +105,9 @@ export class SubmitNotebookButtonExtension
       runtime_platform,
       runtime_config,
       framework,
+      cpu,
+      gpu,
+      memory,
       dependency_include,
       dependencies,
       ...envObject
@@ -117,7 +120,10 @@ export class SubmitNotebookButtonExtension
       runtime_config,
       framework,
       dependency_include ? dependencies : undefined,
-      envObject
+      envObject,
+      cpu,
+      gpu,
+      memory
     );
 
     const displayName = PipelineService.getDisplayName(

--- a/packages/pipeline-editor/src/SubmitScriptButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitScriptButtonExtension.tsx
@@ -114,6 +114,9 @@ export class SubmitScriptButtonExtension
       runtime_platform,
       runtime_config,
       framework,
+      cpu,
+      gpu,
+      memory,
       dependency_include,
       dependencies,
       ...envObject
@@ -126,7 +129,10 @@ export class SubmitScriptButtonExtension
       runtime_config,
       framework,
       dependency_include ? dependencies : undefined,
-      envObject
+      envObject,
+      cpu,
+      gpu,
+      memory
     );
 
     const displayName = PipelineService.getDisplayName(

--- a/packages/pipeline-editor/src/utils.ts
+++ b/packages/pipeline-editor/src/utils.ts
@@ -39,7 +39,10 @@ export default class Utils {
     runtime_config: string,
     runtimeImage: string,
     dependencies: string[],
-    envObject: { [key: string]: string }
+    envObject: { [key: string]: string },
+    cpu?: number,
+    gpu?: number,
+    memory?: number
   ): any {
     const template = JSON.parse(JSON.stringify(pipeline_template));
     const generated_uuid: string = Utils.getUUID();
@@ -59,6 +62,9 @@ export default class Utils {
     template.pipelines[0].nodes[0].app_data.runtime_image = runtimeImage;
     template.pipelines[0].nodes[0].app_data.env_vars = envVars;
     template.pipelines[0].nodes[0].app_data.dependencies = dependencies;
+    template.pipelines[0].nodes[0].app_data.cpu = cpu;
+    template.pipelines[0].nodes[0].app_data.gpu = gpu;
+    template.pipelines[0].nodes[0].app_data.memory = memory;
 
     template.pipelines[0].app_data.name = artifactName;
     template.pipelines[0].app_data.runtime = runtime_platform;

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -171,7 +171,10 @@ td {
 }
 
 .elyra-resourceInput {
-  width: 33%;
+  width: 12%;
+  display: flex;
+  flex-direction: column;
+  padding-right: 9px;
 }
 
 .elyra-experiments {

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -165,6 +165,15 @@ td {
   overflow: scroll;
 }
 
+.elyra-resourcesWrapper {
+  display: flex;
+  flex-direction: row;
+}
+
+.elyra-resourceInput {
+  width: 33%;
+}
+
 .elyra-experiments {
   padding-right: 5px;
 }


### PR DESCRIPTION
Fixes #1429. Adds 3 number fields to the submit notebook / script dialogs for cpu, gpu, and ram. 
The notebook/script submission dialog looks like this with the new changes:
![image](https://user-images.githubusercontent.com/6673460/112538997-7566d000-8d7e-11eb-8aa6-02b2d851154c.png)

On hover, each field has up and down arrows:
![image](https://user-images.githubusercontent.com/6673460/112539770-65032500-8d7f-11eb-91ad-304264849284.png)

With values:
![image](https://user-images.githubusercontent.com/6673460/112539828-73e9d780-8d7f-11eb-8720-dd0aa683fc11.png)
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

