### PR TITLE
Refactor script processors, include brief detail on generic errors

### DIFF
--- a/elyra/pipeline/processor_local.py
+++ b/elyra/pipeline/processor_local.py
@@ -42,7 +42,7 @@ class LocalPipelineProcessor(PipelineProcessor):
     _type = 'local'
 
     def __init__(self, root_dir, **kwargs):
-        super(LocalPipelineProcessor, self).__init__(root_dir, **kwargs)
+        super().__init__(root_dir, **kwargs)
         notebook_op_processor = NotebookOperationProcessor(self.root_dir)
         python_op_processor = PythonScriptOperationProcessor(self.root_dir)
         r_op_processor = RScriptOperationProcessor(self.root_dir)
@@ -121,7 +121,7 @@ class FileOperationProcessor(OperationProcessor):
     MAX_ERROR_LEN: int = 80
 
     def __init__(self, root_dir: str):
-        super(FileOperationProcessor, self).__init__()
+        super().__init__()
         self._root_dir = root_dir
 
     @property
@@ -171,9 +171,6 @@ class FileOperationProcessor(OperationProcessor):
 
 class NotebookOperationProcessor(FileOperationProcessor):
     _operation_name = 'execute-notebook-node'
-
-    def __init__(self, root_dir: str):
-        super(NotebookOperationProcessor, self).__init__(root_dir)
 
     def process(self, operation: Operation):
         filepath = self.get_valid_filepath(operation.filename)
@@ -263,9 +260,6 @@ class PythonScriptOperationProcessor(ScriptOperationProcessor):
     _operation_name = 'execute-python-node'
     _script_type = 'Python'
 
-    def __init__(self, root_dir):
-        super(PythonScriptOperationProcessor, self).__init__(root_dir)
-
     def get_argv(self, file_path) -> List[str]:
         return ['python3', file_path, '--PYTHONHOME', os.path.dirname(file_path)]
 
@@ -273,9 +267,6 @@ class PythonScriptOperationProcessor(ScriptOperationProcessor):
 class RScriptOperationProcessor(ScriptOperationProcessor):
     _operation_name = 'execute-r-node'
     _script_type = 'R'
-
-    def __init__(self, root_dir):
-        super(RScriptOperationProcessor, self).__init__(root_dir)
 
     def get_argv(self, file_path) -> List[str]:
         return ['Rscript', file_path]

--- a/elyra/pipeline/processor_local.py
+++ b/elyra/pipeline/processor_local.py
@@ -23,7 +23,7 @@ from elyra.util.path import get_absolute_path
 from jupyter_server.gateway.managers import GatewayClient
 from subprocess import run, CalledProcessError, PIPE
 from traitlets import log
-from typing import Dict
+from typing import Dict, List
 
 
 class LocalPipelineProcessor(PipelineProcessor):
@@ -118,6 +118,8 @@ class OperationProcessor(ABC):
 
 class FileOperationProcessor(OperationProcessor):
 
+    MAX_ERROR_LEN: int = 80
+
     def __init__(self, root_dir: str):
         super(FileOperationProcessor, self).__init__()
         self._root_dir = root_dir
@@ -130,13 +132,41 @@ class FileOperationProcessor(OperationProcessor):
     def process(self, operation: Operation):
         raise NotImplementedError
 
-    def get_valid_filepath(self, op_filename):
+    def get_valid_filepath(self, op_filename: str) -> str:
         filepath = get_absolute_path(self._root_dir, op_filename)
         if not os.path.exists(filepath):
             raise FileNotFoundError(f'Could not find {filepath}')
         if not os.path.isfile(filepath):
             raise ValueError(f'Not a file: {filepath}')
         return filepath
+
+    def log_and_raise(self, file_name: str, ex: Exception) -> None:
+        """Log and raise the exception that occurs when processing file_name.
+
+        If the exception's message is longer than MAX_ERROR_LEN, it will be
+        truncated with an ellipses (...) when raised.  The complete message
+        will be logged.
+        """
+        self.log.error(f'Error executing {file_name}: {str(ex)}')
+        truncated_msg = FileOperationProcessor._truncate_msg(str(ex))
+        raise RuntimeError(f'({file_name}): {truncated_msg}') from ex
+
+    @staticmethod
+    def _truncate_msg(msg: str) -> str:
+        """Truncates the msg string to be less that MAX_ERROR_LEN.
+
+        If msg is longer than MAX_ERROR_LEN, the first space is found from the right,
+        then ellipses (...) are appended to that location so that they don't appear
+        in the middle of a word.  As a result, the truncation could result in lengths
+        less than the max+2.
+        """
+        if len(msg) < FileOperationProcessor.MAX_ERROR_LEN:
+            return msg
+        # locate the first whitespace from the 80th character and truncate from there
+        last_space = msg.rfind(' ', 0, FileOperationProcessor.MAX_ERROR_LEN)
+        if last_space >= 0:
+            return msg[:last_space] + "..."
+        return msg[:FileOperationProcessor.MAX_ERROR_LEN]
 
 
 class NotebookOperationProcessor(FileOperationProcessor):
@@ -183,19 +213,19 @@ class NotebookOperationProcessor(FileOperationProcessor):
             raise RuntimeError(f'({file_name}) in cell {pmee.exec_count}: ' +
                                f'{str(pmee.ename)} {str(pmee.evalue)}') from pmee
         except Exception as ex:
-            self.log.error(f'Error executing {file_name}: {str(ex)}')
-            raise RuntimeError(f'({file_name})') from ex
+            self.log_and_raise(file_name, ex)
 
         t1 = time.time()
         duration = (t1 - t0)
         self.log.debug(f'Execution of {file_name} took {duration:.3f} secs.')
 
 
-class PythonScriptOperationProcessor(FileOperationProcessor):
-    _operation_name = 'execute-python-node'
+class ScriptOperationProcessor(FileOperationProcessor):
 
-    def __init__(self, root_dir):
-        super(PythonScriptOperationProcessor, self).__init__(root_dir)
+    _script_type: str = None
+
+    def get_argv(self, filepath) -> List[str]:
+        raise NotImplementedError
 
     def process(self, operation: Operation):
         filepath = self.get_valid_filepath(operation.filename)
@@ -203,9 +233,9 @@ class PythonScriptOperationProcessor(FileOperationProcessor):
         file_dir = os.path.dirname(filepath)
         file_name = os.path.basename(filepath)
 
-        self.log.debug(f'Processing python script: {filepath}')
+        self.log.debug(f'Processing {self._script_type} script: {filepath}')
 
-        argv = ['python3', filepath, '--PYTHONHOME', file_dir]
+        argv = self.get_argv(filepath)
 
         envs = os.environ.copy()  # Make sure this process's env is "available" in subprocess
         envs.update(operation.env_vars_as_dict())
@@ -222,38 +252,30 @@ class PythonScriptOperationProcessor(FileOperationProcessor):
             else:
                 raise RuntimeError(f'({file_name})') from cpe
         except Exception as ex:
-            self.log.error(f'Error executing {file_name}: {str(ex)}')
-            raise RuntimeError(f'({file_name})') from ex
+            self.log_and_raise(file_name, ex)
 
         t1 = time.time()
         duration = (t1 - t0)
         self.log.debug(f'Execution of {file_name} took {duration:.3f} secs.')
 
 
-class RScriptOperationProcessor(FileOperationProcessor):
+class PythonScriptOperationProcessor(ScriptOperationProcessor):
+    _operation_name = 'execute-python-node'
+    _script_type = 'Python'
+
+    def __init__(self, root_dir):
+        super(PythonScriptOperationProcessor, self).__init__(root_dir)
+
+    def get_argv(self, file_path) -> List[str]:
+        return ['python3', file_path, '--PYTHONHOME', os.path.dirname(file_path)]
+
+
+class RScriptOperationProcessor(ScriptOperationProcessor):
     _operation_name = 'execute-r-node'
+    _script_type = 'R'
 
     def __init__(self, root_dir):
         super(RScriptOperationProcessor, self).__init__(root_dir)
 
-    def process(self, operation: Operation):
-        filepath = self.get_valid_filepath(operation.filename)
-
-        file_dir = os.path.dirname(filepath)
-        file_name = os.path.basename(filepath)
-
-        self.log.debug(f'Processing R script: {filepath}')
-
-        argv = ['Rscript', filepath]
-
-        envs = os.environ.copy()  # Make sure this process's env is "available" in subprocess
-        envs.update(operation.env_vars_as_dict())
-        t0 = time.time()
-        try:
-            run(argv, cwd=file_dir, env=envs, check=True)
-        except Exception as ex:
-            raise RuntimeError(f'Internal error executing {filepath}: {ex}') from ex
-
-        t1 = time.time()
-        duration = (t1 - t0)
-        self.log.debug(f'Execution of {file_name} took {duration:.3f} secs.')
+    def get_argv(self, file_path) -> List[str]:
+        return ['Rscript', file_path]

--- a/elyra/pipeline/tests/resources/node_util/node.ipynb
+++ b/elyra/pipeline/tests/resources/node_util/node.ipynb
@@ -17,24 +17,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 install --upgrade pygithub"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from github import Github"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import os\n",
     "from node_util import NotebookNode\n",
     "# These getenv calls are here to help seed the environment variables \n",


### PR DESCRIPTION
Although this change was instigated by #1337, it primarily focuses on the aftermath of the merges for #1411 and #1418 - which essentially crossed paths, leaving the R script processor behind the Python script processor in terms of its error handling.  

While looking into #1337, it was found that Papermill release 2.3.3 handles the missing kernelspec much more gracefully than raising a `KeyError`.  Instead, it raises a `ValueError` indicating the kernel could not be determined nor was one provided.  However, the general error processing for notebook and both forms of script operations drop any level of details due to the unknown nature of error messages.  

This PR does the following:
- It introduces a new base class named `ScriptOperationProcessor` from which the _existing_`PythonScriptOperationProcessor` and `RScriptOperationProcessor` classes now derive.  This base class contains 90% of the applicable code with the subclasses providing their name and argument vectors.
- It introduces a `log_and_raise()` method on the base `FIleOperationProcessor` class that is available to all file-based operations.  Building on the work done in #1411, this method checks the length of the error message and truncates it to around the max (80), replacing overflow with an ellipses (...).
- Adds a test that removes the kernel metadata from a notebook node and ensures the appropriate error is raised.

When the kernelspec information is missing, the following message will be produced:
![Screen Shot 2021-03-25 at 2 35 42 PM](https://user-images.githubusercontent.com/22599560/112554469-9978e000-8d83-11eb-95d6-c75ab22dc7e4.png)

Resolves #1337
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

