### PR TITLE
Fix container image build command

### DIFF
--- a/docs/source/developer_guide/development-workflow.md
+++ b/docs/source/developer_guide/development-workflow.md
@@ -153,7 +153,7 @@ not just refresh your browser.
 Elyra's container image can be built using:
 
 ```bash
-make docker-image
+make container-image
 ```
 
 Official container images are published on [Docker Hub](https://hub.docker.com/r/elyra/elyra/tags) and [quay.io](https://quay.io/repository/elyra/elyra?tab=tags).


### PR DESCRIPTION
This PR fixes a developer documentation issue. The referenced build target was renamed but the documentation not updated.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

