### PR TITLE
Fix common properties bug

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -565,7 +565,6 @@ export class PipelineEditor extends React.Component<
   }
 
   propertyListener(data: any): void {
-    console.log(data);
     if (data.action === 'UPDATE_PROPERTY' && this.CommonProperties) {
       const pipelineId = this.canvasController.getPrimaryPipelineId();
       // Use the currently selected node. If more than one node is selected,


### PR DESCRIPTION
Fixes #1493. The properties editor has a bug that causes properties to copy over to a different node when a new node is selected in the pipeline editor. This PR adds logic to apply the properties changes as they happen instead of when switching nodes to prevent that from happening. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

