### PR TITLE
Fix submit button submitting most recent file

### DIFF
--- a/packages/pipeline-editor/src/SubmitNotebookButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitNotebookButtonExtension.tsx
@@ -16,7 +16,6 @@
 
 import { NotebookParser } from '@elyra/services';
 import { RequestErrors, showFormDialog } from '@elyra/ui-components';
-import { LabShell } from '@jupyterlab/application';
 import { Dialog, showDialog, ToolbarButton } from '@jupyterlab/apputils';
 import { DocumentRegistry } from '@jupyterlab/docregistry';
 import { INotebookModel, NotebookPanel } from '@jupyterlab/notebook';
@@ -37,11 +36,8 @@ import Utils from './utils';
  */
 export class SubmitNotebookButtonExtension
   implements DocumentRegistry.IWidgetExtension<NotebookPanel, INotebookModel> {
-  private panel: NotebookPanel;
-  private shell: LabShell;
-
-  showWidget = async (): Promise<void> => {
-    if (this.panel.model.dirty) {
+  showWidget = async (panel: NotebookPanel): Promise<void> => {
+    if (panel.model.dirty) {
       const dialogResult = await showDialog({
         title:
           'This notebook contains unsaved changes. To submit the notebook the changes need to be saved.',
@@ -51,14 +47,14 @@ export class SubmitNotebookButtonExtension
         ]
       });
       if (dialogResult.button && dialogResult.button.accept === true) {
-        await this.panel.context.save();
+        await panel.context.save();
       } else {
         // Don't proceed if cancel button pressed
         return;
       }
     }
 
-    const env = NotebookParser.getEnvVars(this.panel.content.model.toString());
+    const env = NotebookParser.getEnvVars(panel.content.model.toString());
     const action = 'submit notebook';
     const runtimes = await PipelineService.getRuntimes(
       true,
@@ -68,8 +64,9 @@ export class SubmitNotebookButtonExtension
     if (Utils.isDialogResult(runtimes)) {
       if (runtimes.button.label.includes(RUNTIMES_NAMESPACE)) {
         // Open the runtimes widget
-        this.shell = Utils.getLabShell(this.panel);
-        this.shell.activateById(`elyra-metadata:${RUNTIMES_NAMESPACE}`);
+        Utils.getLabShell(panel).activateById(
+          `elyra-metadata:${RUNTIMES_NAMESPACE}`
+        );
       }
       return;
     }
@@ -115,7 +112,7 @@ export class SubmitNotebookButtonExtension
 
     // prepare notebook submission details
     const pipeline = Utils.generateSingleFilePipeline(
-      this.panel.context.path,
+      panel.context.path,
       runtime_platform,
       runtime_config,
       framework,
@@ -140,12 +137,10 @@ export class SubmitNotebookButtonExtension
     panel: NotebookPanel,
     context: DocumentRegistry.IContext<INotebookModel>
   ): IDisposable {
-    this.panel = panel;
-
     // Create the toolbar button
     const submitNotebookButton = new ToolbarButton({
       label: 'Submit Notebook ...',
-      onClick: this.showWidget,
+      onClick: () => this.showWidget(panel),
       tooltip: 'Run notebook as batch'
     });
 


### PR DESCRIPTION
Currently there is a bug with the submit buttons where it submits the most
recently opened relevant file rather than the file the submit is run from.
This was caused by the use of global vars in the submit button extensions.

Fixes #1497



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

