### PR TITLE
Pin version range of autopep8 due to version conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup_args = dict(
                 ('share/jupyter/metadata/runtime-images', glob(metadata_path))],
     packages=find_packages(),
     install_requires=[
-        'autopep8',
+        'autopep8>=1.5.0,<1.5.6',
         'click',
         'colorama',
         'entrypoints>=0.3',
@@ -84,7 +84,7 @@ setup_args = dict(
         'pyyaml>=5.3.1,<6.0',
         'requests>=2.9.1,<3.0',
         'rfc3986-validator>=0.1.1',
-        'tornado >=6.1.0',
+        'tornado>=6.1.0',
         'traitlets>=4.3.2',
         'urllib3>=1.24.2',
         'websocket-client',


### PR DESCRIPTION
This resolves transient pycodestyle package version conflicts between
autopep8 and python-language-server



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

