### PR TITLE
Add command line interface topic to user guide

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,6 +40,7 @@ Elyra is a set of AI-centric extensions to JupyterLab Notebooks.
    :maxdepth: 1
    :caption: User Guide
 
+   user_guide/command-line-interface
    user_guide/runtime-conf
    user_guide/runtime-image-conf
    user_guide/pipelines

--- a/docs/source/user_guide/command-line-interface.md
+++ b/docs/source/user_guide/command-line-interface.md
@@ -1,0 +1,102 @@
+<!--
+{% comment %}
+Copyright 2018-2021 Elyra Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+{% endcomment %}
+-->
+
+## Command line interface
+
+The Elyra command line interface (CLI) allows you to [manage metadata](#managing-metadata) and [work with pipelines](#working-with-pipelines).
+
+The CLI is part of the Elyra installation and can be used without a running JupyterLab instance.
+
+### Managing metadata
+
+In Elyra, information such as a [runtime configuration](runtime-conf.md) or a [runtime image](runtime-image-conf) is considered metadata. `elyra-metadata` is used to list, create, update, or delete metadata.
+
+#### Getting help
+
+To display the list of commands that `elyra-metadata` supports, run
+
+```
+$ elyra-metadata -h
+```
+
+To learn more about a specific command, e.g. `list`, run
+```
+$ elyra-metadata list -h
+```
+
+#### Formatting list output
+
+By default the `list` command displays the results in a user-friendly format. 
+
+```
+$ elyra-metadata list runtime-images
+Available metadata instances for runtime-images (includes invalid):
+
+Schema          Instance    Resource
+------          --------    --------
+runtime-image   anaconda    .../runtime-images/anaconda.json
+```
+
+Specify the `--json` parameter to return the results in JSON to allow for programmatic processing, e.g. using [`jq`](https://stedolan.github.io/jq/). 
+
+```
+$ elyra-metadata list runtime-images --json | jq ".[].display_name"
+"Tensorflow 1.15.2"
+"Tensorflow 1.15.2 with GPU"
+"R Script"
+"Anaconda (2020.07) with Python 3.x"
+"Tensorflow 2.3.0"
+"Pandas 1.1.1"
+"Pytorch 1.4 with CUDA-devel"
+"Tensorflow 2.3.0 with GPU"
+"Pytorch 1.4 with CUDA-runtime"
+"Pandas on quay.io"
+
+```
+
+#### List, create, update, and delete metadata
+
+Refer to the topics below for detailed information on how to use `elyra-metadata` to
+ - [Manage code snippets](code-snippets.md)
+ - [Manage runtime configurations](runtime-conf.html#managing-runtime-configurations-using-the-elyra-cli)
+ - [Manage runtime images](runtime-image-conf.html#managing-runtime-images-with-the-command-line-interface)
+
+### Working with pipelines
+
+In Elyra, [a pipeline](https://elyra.readthedocs.io/en/latest/user_guide/pipelines.html) is a representation of a workflow that you run locally or remotely on Kubeflow Pipelines or Apache Airflow.
+
+#### Getting help
+
+To display the list of commands that `elyra-pipeline` supports, run
+
+```
+$ elyra-pipeline --help
+```
+
+To learn more about a specific command, e.g. `run`, run
+```
+$ elyra-pipeline run --help
+```
+
+#### Running pipelines
+
+Refer to the topics below for detailed information on how to use `elyra-pipeline` to
+ - [Run a pipeline locally](pipelines.md#running-a-pipeline-using-the-command-line)
+ - [Submit a pipeline for remote execution](pipelines.md#running-a-pipeline-using-the-command-line)
+
+


### PR DESCRIPTION
This PR adds the `Command line interface` topic to the user guide:

![image](https://user-images.githubusercontent.com/13068832/113215231-66c16280-922f-11eb-955e-60f93150a88b.png)

This topic is only meant to provide high-level information and defers to the appropriate sections in other topics for more detailed information. The main motivation for not including the detailed information in this new topic is that usually some kind of context is required to understand the task. That context is already given elsewhere and I don't think it should be duplicated because that'd result in more maintenance, should changes be required.
 

Closes https://github.com/elyra-ai/elyra/issues/1491

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

