### PR TITLE
Fix placeholder in submit notebook dialog

### DIFF
--- a/packages/pipeline-editor/src/FileSubmissionDialog.tsx
+++ b/packages/pipeline-editor/src/FileSubmissionDialog.tsx
@@ -22,7 +22,7 @@ import Utils from './utils';
 
 interface IProps {
   env: string[];
-  fileExtension?: string;
+  dependencyFileExtension: string;
   images: IDictionary<string>;
   runtimes: IRuntime[];
   schema: ISchema[];
@@ -114,7 +114,7 @@ export class FileSubmissionDialog extends React.Component<IProps, IState> {
   }
 
   render(): React.ReactNode {
-    const { env, images, fileExtension } = this.props;
+    const { env, images, dependencyFileExtension } = this.props;
     const {
       displayedRuntimeOptions,
       includeDependency,
@@ -129,8 +129,8 @@ export class FileSubmissionDialog extends React.Component<IProps, IState> {
           id="dependencies"
           className="jp-mod-styled"
           name="dependencies"
-          placeholder={`*${fileExtension}`}
-          defaultValue={`*${fileExtension}`}
+          placeholder={`*${dependencyFileExtension}`}
+          defaultValue={`*${dependencyFileExtension}`}
           size={30}
         />
       </div>

--- a/packages/pipeline-editor/src/SubmitNotebookButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitNotebookButtonExtension.tsx
@@ -83,6 +83,7 @@ export class SubmitNotebookButtonExtension
       body: formDialogWidget(
         <FileSubmissionDialog
           env={env}
+          dependencyFileExtension=".py"
           runtimes={runtimes}
           images={images}
           schema={schema}

--- a/packages/pipeline-editor/src/SubmitScriptButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitScriptButtonExtension.tsx
@@ -96,7 +96,7 @@ export class SubmitScriptButtonExtension
       body: formDialogWidget(
         <FileSubmissionDialog
           env={env}
-          fileExtension={fileExtension}
+          dependencyFileExtension={fileExtension}
           images={images}
           runtimes={runtimes}
           schema={schema}


### PR DESCRIPTION
Fix file dependencies field in notebook submit dialogs:
![image](https://user-images.githubusercontent.com/25207344/113315896-c4ab8400-92db-11eb-91ab-fab55f6fd178.png)

This PR restores default python file extension placeholder:
![image](https://user-images.githubusercontent.com/25207344/113315839-b52c3b00-92db-11eb-8517-724057eb02eb.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

