### PR TITLE
Update kf-notebook container image instructions

### DIFF
--- a/create-release.py
+++ b/create-release.py
@@ -200,8 +200,8 @@ def update_version_to_dev() -> None:
             rf"elyra:{new_version} ",
             "elyra:dev ")
         sed(_source('etc/docker/kubeflow/README.md'),
-            rf"kf-notebook:{new_version} ",
-            "kf-notebook:dev ")
+            rf"kf-notebook:{new_version}",
+            "kf-notebook:dev")
         # this does not goes back to dev
         # sed(source('README.md'), r"/v[0-9].[0-9].[0-9]", "/v{}".format(dev_version))
         sed(_source('docs/source/getting_started/installation.md'),

--- a/create-release.py
+++ b/create-release.py
@@ -127,18 +127,24 @@ def update_version_to_release() -> None:
         sed(_source('README.md'),
             r"/v[0-9].[0-9].[0-9]?",
             f"/v{new_version}?")
+        sed(_source('etc/docker/kubeflow/README.md'),
+            r"kf-notebook:dev",
+            f"kf-notebook:{new_version}")
         sed(_source('docs/source/getting_started/installation.md'),
             r"elyra:dev ",
             f"elyra:{new_version} ")
         sed(_source('docs/source/getting_started/installation.md'),
             r"/v[0-9].[0-9].[0-9]?",
             f"/v{new_version}?")
-        sed(_source('docs/source/recipes/deploying-elyra-in-a-jupyterhub-environment.md'),
-            r"dev",
-            f"{new_version}")
         sed(_source('docs/source/recipes/configure-airflow-as-a-runtime.md'),
             r"master",
             f"{config.tag}")
+        sed(_source('docs/source/recipes/deploying-elyra-in-a-jupyterhub-environment.md'),
+            r"dev",
+            f"{new_version}")
+        sed(_source('docs/source/recipes/using-elyra-with-kubeflow-notebook-server.md'),
+            r"master",
+            f"{new_version}")
 
         sed(_source('etc/docker/elyra/Dockerfile'),
             r"    cd /tmp/elyra && make UPGRADE_STRATEGY=eager install && rm -rf /tmp/elyra",
@@ -193,6 +199,9 @@ def update_version_to_dev() -> None:
         sed(_source('README.md'),
             rf"elyra:{new_version} ",
             "elyra:dev ")
+        sed(_source('etc/docker/kubeflow/README.md'),
+            rf"kf-notebook:{new_version} ",
+            "kf-notebook:dev ")
         # this does not goes back to dev
         # sed(source('README.md'), r"/v[0-9].[0-9].[0-9]", "/v{}".format(dev_version))
         sed(_source('docs/source/getting_started/installation.md'),
@@ -200,11 +209,14 @@ def update_version_to_dev() -> None:
             "elyra:dev ")
         # this does not goes back to dev
         # sed(source('docs/source/getting_started/installation.md'), r"/v[0-9].[0-9].[0-9]", "/v{}".format(dev_version))
+        sed(_source('docs/source/recipes/configure-airflow-as-a-runtime.md'),
+            rf"{config.tag}",
+            "master")
         sed(_source('docs/source/recipes/deploying-elyra-in-a-jupyterhub-environment.md'),
             rf"{new_version}",
             "dev")
-        sed(_source('docs/source/recipes/configure-airflow-as-a-runtime.md'),
-            rf"{config.tag}",
+        sed(_source('docs/source/recipes/using-elyra-with-kubeflow-notebook-server.md'),
+            rf"{new_version}",
             "master")
 
         sed(_source('etc/docker/elyra/Dockerfile'),

--- a/docs/source/recipes/using-elyra-with-kubeflow-notebook-server.md
+++ b/docs/source/recipes/using-elyra-with-kubeflow-notebook-server.md
@@ -27,9 +27,9 @@ In this example we will show how to launch Elyra using [Kubeflow's Notebook Serv
 
 - Select the desired Elyra container image version from the `elyra/kf-notebook` repositories on [Docker Hub](https://hub.docker.com/r/elyra/kf-notebook) or [quay.io](https://quay.io/repository/elyra/kf-notebook). Do NOT use other images, such as the ones in `elyra/elyra`.
   
-    OR
+  OR
 
-  - Create a custom Elyra container image using [this `Dockerfile`](https://github.com/elyra-ai/elyra/blob/master/etc/docker/kubeflow/Dockerfile) as a base and customize it as desired.
+  Create a custom Elyra container image following the [instructions in this directory](https://github.com/elyra-ai/elyra/tree/master/etc/docker/kubeflow). 
     
 ## Launching Elyra in the Kubeflow Notebook Server
 1. In the default Kubeflow welcome page, in the left side menu, click on `Notebook Servers`   

--- a/etc/docker/kubeflow/README.md
+++ b/etc/docker/kubeflow/README.md
@@ -19,3 +19,12 @@ limitations under the License.
 ### Elyra notebook container image for use with Kubeflow's Notebook Server
 
 This `Dockerfile` is used to build an Elyra notebook image that can be launched by [Kubeflow's Notebook Server](https://www.kubeflow.org/docs/components/notebooks/). Ready-to-use  container images are published on [Docker Hub](https://hub.docker.com/r/elyra/kf-notebook) and [quay.io](https://quay.io/repository/elyra/kf-notebook). Refer to [the documentation](https://elyra.readthedocs.io/en/latest/recipes/using-elyra-with-kubeflow-notebook-server.html) for details.
+
+#### Building a custom container image
+
+To build a custom version of this container image:
+- Clone this repository.
+- Update the requirements in `etc/docker/kubeflow/requirements.txt`.
+- Run `make kf-notebook-image` in the root directory of this repository.
+
+> The container image is automatically tagged with `elyra/kf-notebook:dev` and `quay.io/elyra/kf-notebook:dev`.


### PR DESCRIPTION
This PR updates the [Using Elyra with the Kubeflow Notebook Server](https://elyra.readthedocs.io/en/latest/recipes/using-elyra-with-kubeflow-notebook-server.html) topic and the related readme to include information about the build process.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

