### PR TITLE
Add publish-kf-notebook-image target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,11 @@ kf-notebook-image: ## Build elyra image for use with Kubeflow Notebook Server
 	DOCKER_BUILDKIT=1 docker build -t docker.io/$(KF_NOTEBOOK_IMAGE) -t quay.io/$(KF_NOTEBOOK_IMAGE) \
 	etc/docker/kubeflow/ --progress plain
 
+publish-kf-notebook-image: kf-notebook-image ## Publish KF Notebook Server container image
+    # this is a privileged operation; a `docker login` might be required
+	docker push docker.io/$(KF_NOTEBOOK_IMAGE)
+	docker push quay.io/$(KF_NOTEBOOK_IMAGE)
+
 validate-runtime-images: ## Validates delivered runtime-images meet minimum criteria
 	@required_commands=$(REQUIRED_RUNTIME_IMAGE_COMMANDS) ; \
 	pip install jq ; \

--- a/docs/source/developer_guide/release.md
+++ b/docs/source/developer_guide/release.md
@@ -44,11 +44,12 @@ elyra-r-editor-extension
 ```bash
 create-release.py publish --version 2.0.0 [--rc 0]
 ```
-- Build and publish docker images based on release tag
+- Build and publish container images based on release tag
 ```bash
 git pull --rebase
 git checkout tags/v2.0.0
 make container-image publish-container-image
+make kf-notebook-image publish-kf-notebook-image
 ```  
 
 - Update dev and latest image tags based on release tag


### PR DESCRIPTION
This PR
 - adds a new make target `publish-kf-notebook-image` that publishes the `kf-notebook` container image on Docker Hub and quay.io
 - updates the release process documentation
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

