### PR TITLE
Refactor container related Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ publish-kf-notebook-image: kf-notebook-image
 	docker push docker.io/$(KF_NOTEBOOK_IMAGE)
 	docker push quay.io/$(KF_NOTEBOOK_IMAGE)
 
-container-images: elyra-image kf-notebook-image airflow-image ## build all container images
+container-images: elyra-image kf-notebook-image airflow-image ## Build all container images
 	docker images $(ELYRA_IMAGE)
 	docker images quay.io/$(ELYRA_IMAGE)
 	docker images $(KF_NOTEBOOK_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ container-images: elyra-image kf-notebook-image airflow-image ## Build all conta
 	docker images $(ELYRA_AIRFLOW_IMAGE)
 	docker images quay.io/$(ELYRA_AIRFLOW_IMAGE)
 
-publish-container-images: publish-elyra-image publish-airflow-image publish-kf-notebook-image
+publish-container-images: publish-elyra-image publish-airflow-image publish-kf-notebook-image ## Publish all container images
 
 
 validate-runtime-images: ## Validates delivered runtime-images meet minimum criteria

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,11 @@
 # limitations under the License.
 #
 
-.PHONY: help purge uninstall clean test-dependencies lint-server lint-ui lint yarn-install build-ui build-server install-server
-.PHONY: install watch test-server test-ui test-ui-debug test docs-dependencies docs dist-ui release
-.PHONY: elyra-image validate-runtime-images kf-notebook-image publish-kf-notebook-image airflow-image publish-airflow-image
-.PHONY: container-images publish-container-images
+.PHONY: help purge install uninstall clean test-dependencies lint-server lint-ui lint yarn-install
+.PHONY: build-ui build-server install-server
+.PHONY: watch test-server test-ui test-ui-debug test docs-dependencies docs dist-ui release
+.PHONY: validate-runtime-images elyra-image publish-elyra-image kf-notebook-image
+.PHONY: publish-kf-notebook-image airflow-image publish-airflow-image container-images publish-container-images
 
 SHELL:=/bin/bash
 

--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ elyra-image:
 
 publish-elyra-image: elyra-image
 	## Publish Elyra stand-alone container image
-    # this is a privileged operation; a `docker login` might be required
+      # this is a privileged operation; a `docker login` might be required
 	docker push docker.io/$(ELYRA_IMAGE)
 	docker push quay.io/$(ELYRA_IMAGE)
 

--- a/docs/source/developer_guide/release.md
+++ b/docs/source/developer_guide/release.md
@@ -57,6 +57,16 @@ docker tag elyra/elyra:2.0.0 elyra/elyra:dev && docker push elyra/elyra:dev
 docker tag elyra/elyra:2.0.0 elyra/elyra:latest && docker push elyra/elyra:latest
 docker tag quay.io/elyra/elyra:2.0.0 quay.io/elyra/elyra:dev && docker push quay.io/elyra/elyra:dev
 docker tag quay.io/elyra/elyra:2.0.0 quay.io/elyra/elyra:latest && docker push quay.io/elyra/elyra:latest
+
+docker tag elyra/airflow:2.0.0 elyra/airflow:dev && docker push elyra/airflow:dev
+docker tag elyra/airflow:2.0.0 elyra/airflow:latest && docker push elyra/airflow:latest
+docker tag quay.io/elyra/airflow:2.0.0 quay.io/elyra/airflow:dev && docker push quay.io/elyra/airflow:dev
+docker tag quay.io/elyra/airflow:2.0.0 quay.io/elyra/airflow:latest && docker push quay.io/elyra/airflow:latest
+
+docker tag elyra/kf-notebook:2.0.0 elyra/kf-notebook:dev && docker push elyra/kf-notebook:dev
+docker tag elyra/kf-notebook:2.0.0 elyra/kf-notebook:latest && docker push elyra/kf-notebook:latest
+docker tag quay.io/elyra/kf-notebook:2.0.0 quay.io/elyra/kf-notebook:dev && docker push quay.io/elyra/kf-notebook:dev
+docker tag quay.io/elyra/kf-notebook:2.0.0 quay.io/elyra/kf-notebook:latest && docker push quay.io/elyra/kf-notebook:latest
 ```
 
 - Merge changes for conda-forge


### PR DESCRIPTION
- Rename container-image to elyra-image
- Refactor targets to have build/publish target per container image
- Refactor collective targets to depend on a single container target
- Undocument single/dev container-related Makefile targets


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

