### PR TITLE
Pin the testutils and filebrowser version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "~17.0.0",
     "@types/react-intl": "^3.0.0",
+    "@lumino/widgets": "1.17.0",
     "cypress": "^6.2.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@4tw/cypress-drag-drop": "^1.3.1",
     "@cypress/webpack-preprocessor": "^5.5.0",
-    "@jupyterlab/testutils": "~3.0.0",
+    "@jupyterlab/testutils": "3.0.0",
     "@types/jest": "^26.0.20",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@4tw/cypress-drag-drop": "^1.3.1",
     "@cypress/webpack-preprocessor": "^5.5.0",
-    "@jupyterlab/testutils": "^3.0.0",
+    "@jupyterlab/testutils": "~3.0.0",
     "@types/jest": "^26.0.20",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -41,7 +41,7 @@
     "react-intl": "^3.0.0"
   },
   "devDependencies": {
-    "@jupyterlab/testutils": "^3.0.0",
+    "@jupyterlab/testutils": "~3.0.0",
     "@types/jest": "^23.3.11",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -41,7 +41,7 @@
     "react-intl": "^3.0.0"
   },
   "devDependencies": {
-    "@jupyterlab/testutils": "~3.0.0",
+    "@jupyterlab/testutils": "3.0.0",
     "@types/jest": "^23.3.11",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",


### PR DESCRIPTION
Locks the version of @lumino/widgets and @jupyterlab/testutils because of bugs that arose from recent releases. 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

