### PR TITLE
Expose user_namespace parameter in Apache Airflow runtime schema

### DIFF
--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -218,6 +218,8 @@ Example: `https://your-airflow-webserver:port`
 ##### Apache Airflow user namespace (user_namespace)
 The namespace used to run your DAG in Apache Airflow. The Kubernetes namespace must be configured with the correct permissions prior to use in Apache Airflow. This setting is Optional. 
 
+The default namespace is `default`.
+
 Example: `anonymous`
 
 ##### GitHub API Endpoint (github_api_endpoint)

--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -215,6 +215,11 @@ The Apache Airflow API endpoint you want to utilize. This setting is required.
 
 Example: `https://your-airflow-webserver:port`
 
+##### Apache Airflow user namespace (user_namespace)
+The namespace used to run your DAG in Apache Airflow. The Kubernetes namespace must be configured with the correct permissions prior to use in Apache Airflow. This setting is Optional. 
+
+Example: `anonymous`
+
 ##### GitHub API Endpoint (github_api_endpoint)
 
 The GitHub (or GitHub Enterprise) API endpoint where the git client will attempt to connect. This setting is required. Keep the default  `https://api.github.com` for github.com

--- a/elyra/metadata/schemas/airflow.json
+++ b/elyra/metadata/schemas/airflow.json
@@ -118,6 +118,16 @@
             "category": "Cloud Object Storage"
           }
         },
+        "user_namespace": {
+          "title": "Apache Airflow User Namespace",
+          "description": "The Apache Airflow user namespace used to run DAG workflows",
+          "type": "string",
+          "pattern": "^[a-z0-9][-a-z0-9]*[a-z0-9]$",
+          "maxLength": 63,
+          "uihints": {
+            "category": "Kubernetes"
+          }
+        },
         "tags": {
           "title": "Tags",
           "description": "Tags for categorizing Apache Airflow",

--- a/elyra/metadata/schemas/airflow.json
+++ b/elyra/metadata/schemas/airflow.json
@@ -48,6 +48,7 @@
           "type": "string",
           "pattern": "^[a-z0-9][-a-z0-9]*[a-z0-9]$",
           "maxLength": 63,
+          "default": "default",
           "uihints": {
             "category": "Apache Airflow"
           }

--- a/elyra/metadata/schemas/airflow.json
+++ b/elyra/metadata/schemas/airflow.json
@@ -42,6 +42,16 @@
             "placeholder": "https://your-airflow-webserver:port"
           }
         },
+        "user_namespace": {
+          "title": "Apache Airflow User Namespace",
+          "description": "The Apache Airflow user namespace used to run DAG workflows",
+          "type": "string",
+          "pattern": "^[a-z0-9][-a-z0-9]*[a-z0-9]$",
+          "maxLength": 63,
+          "uihints": {
+            "category": "Apache Airflow"
+          }
+        },
         "github_api_endpoint": {
           "title": "GitHub API Endpoint",
           "description": "The GitHub Server URL / API endpoint - Public or Enterprise",
@@ -116,16 +126,6 @@
           "maxLength": 222,
           "uihints": {
             "category": "Cloud Object Storage"
-          }
-        },
-        "user_namespace": {
-          "title": "Apache Airflow User Namespace",
-          "description": "The Apache Airflow user namespace used to run DAG workflows",
-          "type": "string",
-          "pattern": "^[a-z0-9][-a-z0-9]*[a-z0-9]$",
-          "maxLength": 63,
-          "uihints": {
-            "category": "Kubernetes"
           }
         },
         "tags": {


### PR DESCRIPTION
Current implementation only allows deployment in default namespace.
This change will will allows users to specify which k8s namespace
to start their pipeline/operator.

Fixes #1543
![image](https://user-images.githubusercontent.com/13340013/114239850-76316180-993b-11eb-947e-5ff8e441d417.png)

The ability to execute a DAG/operator in another namespace is dependent on the deployment and having the correct permissions(RBAC) to do so. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

