### PR TITLE
Update list of documented Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ container-images: elyra-image kf-notebook-image airflow-image ## Build all conta
 
 publish-container-images: publish-elyra-image publish-airflow-image publish-kf-notebook-image ## Publish all container images
 
-validate-runtime-images: ## Validates delivered runtime-images meet minimum criteria
+validate-runtime-images: # Validates delivered runtime-images meet minimum criteria
 	@required_commands=$(REQUIRED_RUNTIME_IMAGE_COMMANDS) ; \
 	pip install jq ; \
 	for file in `find etc/config/metadata/runtime-images -name "*.json"` ; do \

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@
 #
 
 .PHONY: help purge install uninstall clean test-dependencies lint-server lint-ui lint yarn-install
-.PHONY: build-ui build-server install-server
-.PHONY: watch test-server test-ui test-ui-integration-debug test docs-dependencies docs dist-ui release
+.PHONY: build-ui build-server install-server watch
+.PHONY: test-server test-ui test-integration test-integration-debug test docs-dependencies docs dist-ui release
 .PHONY: validate-runtime-images elyra-image publish-elyra-image kf-notebook-image
 .PHONY: publish-kf-notebook-image airflow-image publish-airflow-image container-images publish-container-images
 
@@ -126,15 +126,15 @@ watch: ## Watch packages. For use alongside jupyter lab --watch
 test-server: install-server # Run unit tests
 	pytest -v elyra
 
-test-ui: lint-ui test-ui-unit test-ui-integration # Run frontend tests
+test-ui: lint-ui test-ui-unit test-integration # Run frontend tests
 
 test-ui-unit: # Run frontend jest unit tests
 	npm run test:unit
 
-test-ui-integration: # Run frontend cypress integration tests
+test-integration: # Run frontend cypress integration tests
 	npm run test:integration
 
-test-ui-integration-debug: # Open cypress integration test debugger
+test-integration-debug: # Open cypress integration test debugger
 	npm run test:integration:debug
 
 test: test-server test-ui ## Run all tests (backend, frontend and cypress integration tests)

--- a/Makefile
+++ b/Makefile
@@ -90,19 +90,15 @@ lint: lint-ui lint-server ## Run linters
 yarn-install:
 	yarn
 
-build-ui: yarn-install lint-ui ## Build packages
+build-ui: yarn-install lint-ui # Build packages
 	export PATH=$$(pwd)/node_modules/.bin:$$PATH && lerna run build
 
-build-server: lint-server ## Build backend
+build-server: lint-server # Build backend
 	python setup.py bdist_wheel sdist
 
 build: build-server build-ui
 
-install-server: build-server ## Install backend
-	pip install --upgrade pip
-	pip install --upgrade --upgrade-strategy $(UPGRADE_STRATEGY) --use-deprecated=legacy-resolver dist/elyra-*-py3-none-any.whl
-
-install-ui: build-ui
+install-ui: build-ui # Install packages
 	$(call LINK_LAB_EXTENSION,services)
 	$(call LINK_LAB_EXTENSION,ui-components)
 	$(call LINK_LAB_EXTENSION,metadata-common)
@@ -114,6 +110,10 @@ install-ui: build-ui
 	$(call INSTALL_LAB_EXTENSION,python-editor)
 	$(call INSTALL_LAB_EXTENSION,r-editor)
 
+install-server: build-server # Install backend
+	pip install --upgrade pip
+	pip install --upgrade --upgrade-strategy $(UPGRADE_STRATEGY) --use-deprecated=legacy-resolver dist/elyra-*-py3-none-any.whl
+
 install: install-server install-ui ## Build and install
 	jupyter lab build
 	jupyter serverextension list
@@ -123,21 +123,21 @@ install: install-server install-ui ## Build and install
 watch: ## Watch packages. For use alongside jupyter lab --watch
 	export PATH=$$(pwd)/node_modules/.bin:$$PATH && lerna run watch --parallel
 
-test-server: install-server ## Run unit tests
+test-server: install-server # Run unit tests
 	pytest -v elyra
 
-test-ui: lint-ui test-ui-unit test-ui-integration ## Run frontend tests
+test-ui: lint-ui test-ui-unit test-ui-integration # Run frontend tests
 
-test-ui-integration: ## Run frontend cypress integration tests
+test-ui-integration: # Run frontend cypress integration tests
 	npm run test:integration
 
-test-ui-unit: ## Run frontend jest unit tests
+test-ui-unit: # Run frontend jest unit tests
 	npm run test:unit
 
 test-ui-debug: ## Open cypress integration test debugger
 	npm run test:integration:debug
 
-test: test-server test-ui ## Run all tests
+test: test-server test-ui ## Run all tests (backend, frontend and cypress integration tests)
 
 docs-dependencies:
 	@pip install -q -r docs/requirements.txt
@@ -156,37 +156,31 @@ dist-ui: build-ui
 
 release: dist-ui build-server ## Build wheel file for release
 
-elyra-image:
-	## Build Elyra stand-alone container image
+elyra-image: # Build Elyra stand-alone container image
 	@mkdir -p build/docker
 	cp etc/docker/elyra/Dockerfile build/docker/Dockerfile
 	cp etc/docker/elyra/start-elyra.sh build/docker/start-elyra.sh
 	DOCKER_BUILDKIT=1 docker build -t docker.io/$(ELYRA_IMAGE) -t quay.io/$(ELYRA_IMAGE) build/docker/ --progress plain
 
-publish-elyra-image: elyra-image
-	## Publish Elyra stand-alone container image
-      # this is a privileged operation; a `docker login` might be required
+publish-elyra-image: elyra-image # Publish Elyra stand-alone container image
+    # this is a privileged operation; a `docker login` might be required
 	docker push docker.io/$(ELYRA_IMAGE)
 	docker push quay.io/$(ELYRA_IMAGE)
 
-airflow-image:
-	## Build airflow image for use with Elyra
+airflow-image: # Build airflow image for use with Elyra
 	DOCKER_BUILDKIT=1 docker build -t docker.io/$(ELYRA_AIRFLOW_IMAGE) -t quay.io/$(ELYRA_AIRFLOW_IMAGE) \
 	--build-arg AIRFLOW_NOTEBOOK_VERSION=$(AIRFLOW_NOTEBOOK_VERSION) etc/docker/airflow/ --progress plain
 
-publish-airflow-image: airflow-image
-	## Publish airflow image for use with Elyra
+publish-airflow-image: airflow-image # Publish airflow image for use with Elyra
 	# this is a privileged operation; a `docker login` might be required
 	docker push docker.io/$(ELYRA_AIRFLOW_IMAGE)
 	docker push quay.io/$(ELYRA_AIRFLOW_IMAGE)
 
-kf-notebook-image:
-	## Build elyra image for use with Kubeflow Notebook Server
+kf-notebook-image: # Build elyra image for use with Kubeflow Notebook Server
 	DOCKER_BUILDKIT=1 docker build -t docker.io/$(KF_NOTEBOOK_IMAGE) -t quay.io/$(KF_NOTEBOOK_IMAGE) \
 	etc/docker/kubeflow/ --progress plain
 
-publish-kf-notebook-image: kf-notebook-image
-	## Publish elyra image for use with Kubeflow Notebook Server
+publish-kf-notebook-image: kf-notebook-image # Publish elyra image for use with Kubeflow Notebook Server
 	# this is a privileged operation; a `docker login` might be required
 	docker push docker.io/$(KF_NOTEBOOK_IMAGE)
 	docker push quay.io/$(KF_NOTEBOOK_IMAGE)
@@ -200,7 +194,6 @@ container-images: elyra-image kf-notebook-image airflow-image ## Build all conta
 	docker images quay.io/$(ELYRA_AIRFLOW_IMAGE)
 
 publish-container-images: publish-elyra-image publish-airflow-image publish-kf-notebook-image ## Publish all container images
-
 
 validate-runtime-images: ## Validates delivered runtime-images meet minimum criteria
 	@required_commands=$(REQUIRED_RUNTIME_IMAGE_COMMANDS) ; \

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@
 
 .PHONY: help purge install uninstall clean test-dependencies lint-server lint-ui lint yarn-install
 .PHONY: build-ui build-server install-server
-.PHONY: watch test-server test-ui test-ui-debug test docs-dependencies docs dist-ui release
+.PHONY: watch test-server test-ui test-ui-integration-debug test docs-dependencies docs dist-ui release
 .PHONY: validate-runtime-images elyra-image publish-elyra-image kf-notebook-image
 .PHONY: publish-kf-notebook-image airflow-image publish-airflow-image container-images publish-container-images
 
@@ -128,13 +128,13 @@ test-server: install-server # Run unit tests
 
 test-ui: lint-ui test-ui-unit test-ui-integration # Run frontend tests
 
-test-ui-integration: # Run frontend cypress integration tests
-	npm run test:integration
-
 test-ui-unit: # Run frontend jest unit tests
 	npm run test:unit
 
-test-ui-debug: ## Open cypress integration test debugger
+test-ui-integration: # Run frontend cypress integration tests
+	npm run test:integration
+
+test-ui-integration-debug: # Open cypress integration test debugger
 	npm run test:integration:debug
 
 test: test-server test-ui ## Run all tests (backend, frontend and cypress integration tests)

--- a/docs/source/developer_guide/development-workflow.md
+++ b/docs/source/developer_guide/development-workflow.md
@@ -85,18 +85,15 @@ Issuing a `make` command with no task specified will provide a list of the curre
 ```bash
 $ make
 
-build-server                   Build backend
-build-ui                       Build packages
 clean                          Make a clean source tree and uninstall extensions
-docker-image                   Build docker image
+container-images               Build all container images
 docs                           Build docs
-install-server                 Install backend
 install                        Build and install
 lint                           Run linters
+publish-container-images       Publish all container images
 release                        Build wheel file for release
-test-server                    Run unit tests
-test-ui                        Run frontend tests
-test                           Run all tests
+test-ui-debug                  Open cypress integration test debugger
+test                           Run all tests (backend, frontend and cypress integration tests)
 validate-runtime-images        Validates delivered runtime-images meet minimum criteria
 watch                          Watch packages. For use alongside jupyter lab --watch
 ```

--- a/docs/source/developer_guide/development-workflow.md
+++ b/docs/source/developer_guide/development-workflow.md
@@ -92,9 +92,7 @@ install                        Build and install
 lint                           Run linters
 publish-container-images       Publish all container images
 release                        Build wheel file for release
-test-ui-debug                  Open cypress integration test debugger
 test                           Run all tests (backend, frontend and cypress integration tests)
-validate-runtime-images        Validates delivered runtime-images meet minimum criteria
 watch                          Watch packages. For use alongside jupyter lab --watch
 ```
 

--- a/docs/source/developer_guide/testing.md
+++ b/docs/source/developer_guide/testing.md
@@ -1,7 +1,7 @@
 # Contributing to frontend tests
 Elyra uses two types of frontend tests: integration tests (which use [cypress](https://docs.cypress.io/)) and unit tests (which use [jest](https://jestjs.io/docs/en/getting-started)). 
 ## Integration tests
-There are two ways to run the integration tests: to only see the output logs from all of the integration tests, run `make test-ui-integration` from the root directory. To debug tests that are going wrong or develop new tests, run `make test-ui-integration-debug` - this will open an interactive tool for writing and debugging tests. 
+There are two ways to run the integration tests: to only see the output logs from all of the integration tests, run `make test-integration` from the root directory. To debug tests that are going wrong or develop new tests, run `make test-integration-debug` - this will open an interactive tool for writing and debugging tests.
 
 Elyra's integration tests automatically start JupyterLab and visit / interact with pages through cypress API calls. The tests use the cypress API to check for the existence of various buttons and visual elements. Refer to the [cypress API](https://docs.cypress.io/api/api/table-of-contents.html) for more details.
 

--- a/docs/source/developer_guide/testing.md
+++ b/docs/source/developer_guide/testing.md
@@ -1,7 +1,7 @@
 # Contributing to frontend tests
 Elyra uses two types of frontend tests: integration tests (which use [cypress](https://docs.cypress.io/)) and unit tests (which use [jest](https://jestjs.io/docs/en/getting-started)). 
 ## Integration tests
-There are two ways to run the integration tests: to only see the output logs from all of the integration tests, run `make test-ui-integration` from the root directory. To debug tests that are going wrong or develop new tests, run `make test-ui-debug` - this will open an interactive tool for writing and debugging tests. 
+There are two ways to run the integration tests: to only see the output logs from all of the integration tests, run `make test-ui-integration` from the root directory. To debug tests that are going wrong or develop new tests, run `make test-ui-integration-debug` - this will open an interactive tool for writing and debugging tests. 
 
 Elyra's integration tests automatically start JupyterLab and visit / interact with pages through cypress API calls. The tests use the cypress API to check for the existence of various buttons and visual elements. Refer to the [cypress API](https://docs.cypress.io/api/api/table-of-contents.html) for more details.
 


### PR DESCRIPTION
Some Makefile targets are composed of more fine-grained
targets (e.g. build is composed by build-ui and build-server)

This will cleanup the documented targets to only display
the corase grained targets when make is invoked without commands.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

