### PR TITLE
Add link to Kubeflow Notebook Server configuration recipe

### DIFF
--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -257,6 +257,10 @@ Open the displayed URL in your browser to start using JupyterLab and Elyra.
      or http://127.0.0.1:8888/?token=d690bde267ec75d6f88c64a39825f8b05b919dd084451f82
 ```
 
+### Kubeflow Notebook Server
+
+The instructions in 
+[this topic](/recipes/using-elyra-with-kubeflow-notebook-server.md) outline how to configure a [Kubeflow Notebook Server](https://www.kubeflow.org/docs/components/notebooks) for Elyra.
 
 ### Red Hat OpenShift
 


### PR DESCRIPTION
This PR adds a link to the Kubeflow Notebook Server configuration recipe to the installation guide to make it more easily discoverable. the assumption is that a user might look in the _installation guide_ for this type of content instead of the recipes, which are not organized by domain.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

