### PR TITLE
Update ui-components dependencies with missing material-ui package

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@jupyterlab/apputils": "^3.0.0",
     "@jupyterlab/ui-components": "^3.0.0",
+    "@material-ui/lab": "^4.0.0-alpha.18",
     "@material-ui/core": "^4.1.2",
     "@material-ui/icons": "^4.2.1",
     "react": "^17.0.1",


### PR DESCRIPTION
Missing material-ui/lab dependency results in failure to rebuild lab
when installing extensions individually.

Fixes #1564

- [ ] Rebuild and test packages

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

