### PR TITLE
Improve messaging for COS credential exceptions

### DIFF
--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -27,6 +27,7 @@ from elyra.util.path import get_expanded_path
 from traitlets.config import SingletonConfigurable, LoggingConfigurable, Unicode, Bool
 from typing import List
 from urllib3.exceptions import MaxRetryError
+from minio.error import SignatureDoesNotMatch
 
 
 elyra_log_pipeline_info = os.getenv("ELYRA_LOG_PIPELINE_INFO", True)
@@ -300,6 +301,9 @@ class RuntimePipelineProcess(PipelineProcessor):
                            format(cos_endpoint), exc_info=True)
             raise RuntimeError("Connection was refused when attempting to upload artifacts to : '{}'. Please "
                                "check your object storage settings. ".format(cos_endpoint)) from ex
+        except SignatureDoesNotMatch as ex:
+            raise RuntimeError("Connection was refused due to incorrect Object Storage credentials. " +
+                               "Please validate your runtime configuration details and retry.") from ex
         except BaseException as ex:
             self.log.error("Error uploading artifacts to object storage for operation: {}".
                            format(operation.name), exc_info=True)

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -160,7 +160,7 @@ class KfpPipelineProcessor(RuntimePipelineProcess):
             except Exception as ex:
                 if ex.__cause__:
                     raise RuntimeError(str(ex)) from ex
-                raise RuntimeError('Error compiling pipeline {} for engine {} at {}'.
+                raise RuntimeError('Error pre-processing pipeline {} for engine {} at {}'.
                                    format(pipeline_name, engine, pipeline_path), str(ex)) from ex
 
             self.log.debug("Kubeflow Pipeline was created in %s", pipeline_path)
@@ -274,7 +274,7 @@ class KfpPipelineProcessor(RuntimePipelineProcess):
             except Exception as ex:
                 if ex.__cause__:
                     raise RuntimeError(str(ex)) from ex
-                raise RuntimeError('Error compiling pipeline {} for export at {}'.
+                raise RuntimeError('Error pre-processing pipeline {} for export at {}'.
                                    format(pipeline_name, absolute_pipeline_export_path), str(ex)) from ex
         else:
             # Export pipeline as Python DSL

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -158,6 +158,8 @@ class KfpPipelineProcessor(RuntimePipelineProcess):
                 else:
                     kfp_argo_compiler.Compiler().compile(pipeline_function, pipeline_path)
             except Exception as ex:
+                if ex.__cause__:
+                    raise RuntimeError(str(ex)) from ex
                 raise RuntimeError('Error compiling pipeline {} for engine {} at {}'.
                                    format(pipeline_name, engine, pipeline_path), str(ex)) from ex
 
@@ -270,6 +272,8 @@ class KfpPipelineProcessor(RuntimePipelineProcess):
                     self.log.info("Compiling pipeline for Argo engine")
                     kfp_argo_compiler.Compiler().compile(pipeline_function, absolute_pipeline_export_path)
             except Exception as ex:
+                if ex.__cause__:
+                    raise RuntimeError(str(ex)) from ex
                 raise RuntimeError('Error compiling pipeline {} for export at {}'.
                                    format(pipeline_name, absolute_pipeline_export_path), str(ex)) from ex
         else:

--- a/elyra/util/cos.py
+++ b/elyra/util/cos.py
@@ -15,7 +15,7 @@
 #
 import os
 from minio import Minio
-from minio.error import ResponseError, BucketAlreadyOwnedByYou, BucketAlreadyExists
+from minio.error import ResponseError, BucketAlreadyOwnedByYou, BucketAlreadyExists, SignatureDoesNotMatch
 from urllib.parse import urlparse
 from traitlets.config import LoggingConfigurable
 
@@ -60,6 +60,9 @@ class CosClient(LoggingConfigurable):
             raise ex from ex
         except ResponseError as ex:
             self.log.error("Object Storage error", exc_info=True)
+            raise ex from ex
+        except SignatureDoesNotMatch as ex:
+            self.log.error("Incorrect Object Storage credentials supplied")
             raise ex from ex
 
         return self.client


### PR DESCRIPTION
Fixes #1568.

**New screenshot**:
<img width="831" alt="Screen Shot 2021-04-15 at 4 47 51 PM" src="https://user-images.githubusercontent.com/31816267/114942588-5e118480-9e0a-11eb-8ab1-1bffe9ba0284.png">

<details>
<summary>Traceback</summary>

```
Traceback (most recent call last):
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/processor.py", line 282, in _upload_dependencies_to_object_store
    cos_client = CosClient(config=runtime_configuration)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/util/cos.py", line 41, in __init__
    self.client = self.__initialize_object_store()
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/util/cos.py", line 66, in __initialize_object_store
    raise ex from ex
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/util/cos.py", line 53, in __initialize_object_store
    if not self.client.bucket_exists(self.bucket):
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/minio/api.py", line 404, in bucket_exists
    self._url_open('HEAD', bucket_name=bucket_name)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/minio/api.py", line 2189, in _url_open
    region = self._get_bucket_region(bucket_name)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/minio/api.py", line 2067, in _get_bucket_region
    region = self._get_bucket_location(bucket_name)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/minio/api.py", line 2109, in _get_bucket_location
    raise ResponseError(response, method, bucket_name).get_exception()
minio.error.SignatureDoesNotMatch: SignatureDoesNotMatch: message: The request signature we calculated does not match the signature you provided.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/processor_kfp.py", line 157, in process
    kfp_tekton_compiler.TektonCompiler().compile(pipeline_function, pipeline_path)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_tekton/compiler/compiler.py", line 740, in compile
    super().compile(pipeline_func, package_path, type_check, pipeline_conf=pipeline_conf)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp/compiler/compiler.py", line 948, in compile
    self._create_and_write_workflow(
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_tekton/compiler/compiler.py", line 833, in _create_and_write_workflow
    workflow = self._create_workflow(
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/kfp_tekton/compiler/compiler.py", line 661, in _create_workflow
    pipeline_func(*args_list)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/processor_kfp.py", line 151, in <lambda>
    pipeline_function = lambda: self._cc_pipeline(pipeline,  # nopep8 E731
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/processor_kfp.py", line 454, in _cc_pipeline
    self._upload_dependencies_to_object_store(runtime_configuration,
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/processor.py", line 305, in _upload_dependencies_to_object_store
    raise RuntimeError("Connection was refused due to incorrect Object Storage credentials. " +
RuntimeError: Connection was refused due to incorrect Object Storage credentials. Please validate your runtime configuration details and retry.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/tornado/web.py", line 1705, in _execute
    result = await result
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/handlers.py", line 89, in post
    response = await PipelineProcessorManager.instance().process(pipeline)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/processor.py", line 79, in process
    res = await asyncio.get_event_loop().run_in_executor(None, processor.process, pipeline)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/kierstenstokes/miniconda3/envs/dev1/lib/python3.9/site-packages/elyra/pipeline/processor_kfp.py", line 162, in process
    raise RuntimeError(str(ex)) from ex
RuntimeError: Connection was refused due to incorrect Object Storage credentials. Please validate your runtime configuration details and retry.
```
</details>

**Logging output:**
```
[E 2021-04-15 16:47:43.314 ServerApp] Incorrect Object Storage credentials supplied
```
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

