### PR TITLE
Pin documentation links to stable/specific Elyra version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 [![PyPI version](https://badge.fury.io/py/elyra.svg)](https://badge.fury.io/py/elyra)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/elyra/badges/version.svg)](https://anaconda.org/conda-forge/elyra)
 [![Downloads](https://pepy.tech/badge/elyra)](https://pepy.tech/project/elyra)
-[![Documentation Status](https://readthedocs.org/projects/elyra/badge/?version=latest)](https://elyra.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/elyra/badge/?version=stable)](https://elyra.readthedocs.io/en/stable/?badge=stable)
 [![GitHub](https://img.shields.io/badge/issue_tracking-github-blue.svg)](https://github.com/elyra-ai/elyra/issues)
 [![Gitter](https://badges.gitter.im/elyra-ai/community.svg)](https://gitter.im/elyra-ai/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ limitations under the License.
 [![PyPI version](https://badge.fury.io/py/elyra.svg)](https://badge.fury.io/py/elyra)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/elyra/badges/version.svg)](https://anaconda.org/conda-forge/elyra)
 [![Downloads](https://pepy.tech/badge/elyra)](https://pepy.tech/project/elyra)
-[![Documentation Status](https://readthedocs.org/projects/elyra/badge/?version=stable)](https://elyra.readthedocs.io/en/stable/?badge=stable)
+[![Documentation Status](https://readthedocs.org/projects/elyra/badge/?version=latest)](https://elyra.readthedocs.io/en/latest/?badge=latest)
 [![GitHub](https://img.shields.io/badge/issue_tracking-github-blue.svg)](https://github.com/elyra-ai/elyra/issues)
 [![Gitter](https://badges.gitter.im/elyra-ai/community.svg)](https://gitter.im/elyra-ai/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 

--- a/create-release.py
+++ b/create-release.py
@@ -239,7 +239,7 @@ def update_version_to_dev() -> None:
 
         sed(_source('packages/theme/src/index.ts'),
             r"https://elyra.readthedocs.io/en/stable/",
-            f"https://elyra.readthedocs.io/en/latest/")
+            f"https://elyra.readthedocs.io/en/v{new_version}/")
 
         check_run(["lerna", "version", dev_npm_version, "--no-git-tag-version", "--no-push", "--yes"], cwd=config.source_dir)
         check_run(["yarn", "version", "--new-version", dev_npm_version, "--no-git-tag-version"], cwd=config.source_dir)

--- a/create-release.py
+++ b/create-release.py
@@ -163,7 +163,7 @@ def update_version_to_release() -> None:
 
         sed(_source('packages/theme/src/index.ts'),
             r"https://elyra.readthedocs.io/en/latest/",
-            f"https://elyra.readthedocs.io/en/stable/")
+            rf"https://elyra.readthedocs.io/en/v{new_version}/")
 
         check_run(["lerna", "version", new_npm_version, "--no-git-tag-version", "--no-push", "--yes"], cwd=config.source_dir)
         check_run(["yarn", "version", "--new-version", new_npm_version, "--no-git-tag-version"], cwd=config.source_dir)
@@ -238,8 +238,8 @@ def update_version_to_dev() -> None:
             f"extension v{dev_npm_version}")
 
         sed(_source('packages/theme/src/index.ts'),
-            r"https://elyra.readthedocs.io/en/stable/",
-            f"https://elyra.readthedocs.io/en/v{new_version}/")
+            rf"https://elyra.readthedocs.io/en/v{new_version}/",
+            rf"https://elyra.readthedocs.io/en/latest/")
 
         check_run(["lerna", "version", dev_npm_version, "--no-git-tag-version", "--no-push", "--yes"], cwd=config.source_dir)
         check_run(["yarn", "version", "--new-version", dev_npm_version, "--no-git-tag-version"], cwd=config.source_dir)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx>=1.8
 sphinx_rtd_theme
 recommonmark>=0.6.0
 sphinx-markdown-tables
+sphinx-version-warning

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,7 +59,8 @@ release = version_ns['__version__']
 extensions = [
     "sphinx_rtd_theme",
     "recommonmark",
-    "sphinx_markdown_tables"
+    "sphinx_markdown_tables",
+    "versionwarning.extension",
 ]
 
 source_suffix = {
@@ -99,3 +100,16 @@ html_static_path = ['_static']
 html_css_files = [
     "custom.css"
 ]
+
+# -- Options for version warning
+
+# sphinx-version-warning config
+versionwarning_messages = {
+    "latest": (
+        "This document is for the development version. "
+        'For the stable version documentation, see <a href="/en/stable/">here</a>.'
+    )}
+
+# Show warning at top of page
+versionwarning_body_selector = "div.document"
+versionwarning_banner_title = ""


### PR DESCRIPTION
This PR
 - updates the documentation in link the repository README (now pointing to the stable documentation version instead of the development version)
 - updates the release script to pin the Launcher's Elyra documentation link to the installed Elyra version
 - adds a warning message if a user accesses the documentation development version 
    **Rendered page on `latest` version:**
   
    ![image](https://user-images.githubusercontent.com/13068832/115454441-a3043500-a1d5-11eb-9c42-bb9395458f78.png)

    **Rendered page on other versions:**
    ![image](https://user-images.githubusercontent.com/13068832/115454022-2b360a80-a1d5-11eb-8066-19f0b1ee8a11.png)

 
The PR does not_close #1566 because there is additional work that cannot be delivered in a PR.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

