### PR TITLE
Add python tests for contents handler

### DIFF
--- a/elyra/contents/tests/conftest.py
+++ b/elyra/contents/tests/conftest.py
@@ -1,0 +1,25 @@
+#
+# Copyright 2018-2021 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+import os
+
+
+@pytest.fixture
+def test_directory():
+    directory = "dir1.py"
+    dir_path = os.path.join(os.path.dirname(__file__), directory)
+    os.mkdir(dir_path)
+    return dir_path

--- a/elyra/contents/tests/conftest.py
+++ b/elyra/contents/tests/conftest.py
@@ -16,7 +16,8 @@
 import pytest
 import json
 
-from .test_utils import create_dir, create_file, text_content, notebook_content, python_content, r_content
+from .test_utils import create_dir, create_file, text_content, notebook_content, python_content, r_content, \
+    empty_notebook_content
 
 
 @pytest.fixture
@@ -67,6 +68,11 @@ def create_python_file(jp_root_dir, python_filename):
 @pytest.fixture
 def create_r_file(jp_root_dir, r_filename):
     create_file(jp_root_dir, r_filename, r_content)
+
+
+@pytest.fixture
+def create_empty_notebook_file(jp_root_dir, notebook_filename):
+    create_file(jp_root_dir, notebook_filename, json.dumps(empty_notebook_content))
 
 
 # Set Elyra server extension as enabled (overriding server_config fixture from jupyter_server)

--- a/elyra/contents/tests/conftest.py
+++ b/elyra/contents/tests/conftest.py
@@ -14,12 +14,68 @@
 # limitations under the License.
 #
 import pytest
-import os
+import json
+
+from .test_utils import create_dir, create_file, text_content, notebook_content, python_content, r_content
 
 
 @pytest.fixture
-def test_directory():
-    directory = "dir1.py"
-    dir_path = os.path.join(os.path.dirname(__file__), directory)
-    os.mkdir(dir_path)
-    return dir_path
+def directory_name():
+    return "dir.py"
+
+
+@pytest.fixture
+def text_filename():
+    return "test.txt"
+
+
+@pytest.fixture
+def notebook_filename():
+    return "test.ipynb"
+
+
+@pytest.fixture
+def python_filename():
+    return "test.py"
+
+
+@pytest.fixture
+def r_filename():
+    return "test.r"
+
+
+@pytest.fixture
+def create_directory(jp_root_dir, directory_name):
+    create_dir(jp_root_dir, directory_name)
+
+
+@pytest.fixture
+def create_text_file(jp_root_dir, text_filename):
+    create_file(jp_root_dir, text_filename, text_content)
+
+
+@pytest.fixture
+def create_notebook_file(jp_root_dir, notebook_filename):
+    create_file(jp_root_dir, notebook_filename, json.dumps(notebook_content))
+
+
+@pytest.fixture
+def create_python_file(jp_root_dir, python_filename):
+    create_file(jp_root_dir, python_filename, python_content)
+
+
+@pytest.fixture
+def create_r_file(jp_root_dir, r_filename):
+    create_file(jp_root_dir, r_filename, r_content)
+
+
+# Set Elyra server extension as enabled (overriding server_config fixture from jupyter_server)
+@pytest.fixture
+def jp_server_config():
+    return {
+        "ServerApp": {
+            "jpserver_extensions": {
+                "elyra": True
+            }
+        }
+    }

--- a/elyra/contents/tests/test_handlers.py
+++ b/elyra/contents/tests/test_handlers.py
@@ -17,7 +17,8 @@ import pytest
 import json
 
 from tornado.httpclient import HTTPClientError
-from .test_utils import expected_http_error, expected_response, expected_response_empty
+from jupyter_server.tests.utils import expected_http_error
+from .test_utils import expected_response, expected_response_empty
 
 
 async def test_file_not_found(jp_fetch):
@@ -30,12 +31,12 @@ async def test_file_not_found(jp_fetch):
 
 async def test_file_is_not_directory(jp_fetch, create_directory, directory_name):
     with pytest.raises(HTTPClientError) as e:
-        await jp_fetch('elyra', 'contents/properties', 'dir.py')
+        await jp_fetch('elyra', 'contents/properties', directory_name)
     assert expected_http_error(e, 400)
 
 
-async def test_invalid_post_request(jp_fetch):
-    response = await jp_fetch('elyra', 'contents/properties', 'dir.py', body=json.dumps(""), method='POST')
+async def test_invalid_post_request(jp_fetch, create_python_file, python_filename):
+    response = await jp_fetch('elyra', 'contents/properties', python_filename, body=json.dumps(""), method='POST')
     response_body = json.loads(response.body)
 
     assert response_body['title'] == "Operation not supported."

--- a/elyra/contents/tests/test_handlers.py
+++ b/elyra/contents/tests/test_handlers.py
@@ -1,0 +1,42 @@
+#
+# Copyright 2018-2021 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+import os
+
+from tornado.httpclient import HTTPClientError
+from .test_utils import expected_http_error
+
+
+async def test_file_not_found(jp_fetch):
+    filepath = "nofile.py"
+
+    with pytest.raises(HTTPClientError) as e:
+        await jp_fetch('elyra', 'contents/properties', filepath)
+    assert expected_http_error(e, 404)
+
+
+async def test_file_is_not_directory(jp_fetch, jp_root_dir):
+    # print(test_directory)
+    directory = "dir.py"
+    dir_path = os.path.join(jp_root_dir, directory)
+
+    os.mkdir(dir_path)
+    print(dir_path)
+    with pytest.raises(HTTPClientError) as e:
+        await jp_fetch('elyra', 'contents/properties', dir_path)
+    assert expected_http_error(e, 400)
+
+    os.rmdir(directory)

--- a/elyra/contents/tests/test_handlers.py
+++ b/elyra/contents/tests/test_handlers.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 import pytest
-import os
 import json
 
 from tornado.httpclient import HTTPClientError

--- a/elyra/contents/tests/test_handlers.py
+++ b/elyra/contents/tests/test_handlers.py
@@ -68,3 +68,10 @@ async def test_valid_r_file(jp_fetch, create_r_file, r_filename):
 
     assert response.code == 200
     assert json.loads(response.body) == expected_response
+
+
+async def test_empty_notebook(jp_fetch, create_empty_notebook_file, notebook_filename):
+    response = await jp_fetch('elyra', 'contents/properties', notebook_filename)
+
+    assert response.code == 200
+    assert json.loads(response.body) == expected_response_empty

--- a/elyra/contents/tests/test_utils.py
+++ b/elyra/contents/tests/test_utils.py
@@ -13,32 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import json
-import tornado
 import os
 import errno
-
-
-def expected_http_error(error, expected_code, expected_message=None):
-    """Check that the error matches the expected output error."""
-    e = error.value
-    if isinstance(e, tornado.web.HTTPError):
-        if expected_code != e.status_code:
-            return False
-        if expected_message is not None and expected_message != str(e):
-            return False
-        return True
-    elif any([
-        isinstance(e, tornado.httpclient.HTTPClientError),
-        isinstance(e, tornado.httpclient.HTTPError)
-    ]):
-        if expected_code != e.code:
-            return False
-        if expected_message:
-            message = json.loads(e.response.body.decode())['message']
-            if expected_message != message:
-                return False
-        return True
 
 
 def create_dir(location, dir_name):

--- a/elyra/contents/tests/test_utils.py
+++ b/elyra/contents/tests/test_utils.py
@@ -72,7 +72,7 @@ expected_response = {
         "VAR6": "6",
         "VAR7": "value7",
         "VAR8": None
-        },
+    },
     "inputs": [],
     "outputs": []
 }

--- a/elyra/contents/tests/test_utils.py
+++ b/elyra/contents/tests/test_utils.py
@@ -15,6 +15,8 @@
 #
 import json
 import tornado
+import os
+import errno
 
 
 def expected_http_error(error, expected_code, expected_message=None):
@@ -37,3 +39,146 @@ def expected_http_error(error, expected_code, expected_message=None):
             if expected_message != message:
                 return False
         return True
+
+
+def create_dir(location, dir_name):
+    try:
+        dir_path = os.path.join(location, dir_name)
+        os.mkdir(dir_path)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
+
+def create_file(location, file_name, content):
+    try:
+        os.makedirs(location)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
+    resource = os.path.join(location, file_name)
+    with open(resource, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+
+expected_response = {
+    "env_vars": {
+        "VAR1": "newvalue",
+        "VAR2": None,
+        "VAR3": None,
+        "VAR4": None,
+        "VAR5": "localhost",
+        "VAR6": "6",
+        "VAR7": "value7",
+        "VAR8": None
+        },
+    "inputs": [],
+    "outputs": []
+}
+
+
+expected_response_empty = {
+    "env_vars": {},
+    "inputs": [],
+    "outputs": []
+}
+
+
+text_content = "This is a text file."
+
+
+notebook_content = {
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "id": "advanced-touch",
+            "metadata": {},
+            "source": [
+                "# Python Notebook with Environment Variables\n",
+                "\n",
+                "This python Notebook contains various environment variables to test the parser functionality.",
+            ],
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 0,
+            "id": "regional-indie",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import os\n",
+                "\n",
+                'os.getenv("VAR1")\n',
+                'os.environ["VAR2"]\n',
+                'os.environ.get("VAR3")\n',
+                "\n",
+                "print(os.environ['VAR4'])\n",
+                "print(os.getenv(\"VAR5\", 'localhost'))",
+            ],
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "id": "completed-timothy",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "os.environ['VAR6'] = \"6\"\n",
+                "print(os.environ.get('VAR7', 'value7'))\n",
+                "os.getenv('VAR8')\n",
+                "\n",
+                'os.environ["VAR1"] = "newvalue"',
+            ],
+        },
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3",
+        },
+        "language_info": {
+            "codemirror_mode": {"name": "ipython", "version": 3},
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.9.1",
+        },
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5,
+}
+
+python_content = '''
+    import os
+
+    os.getenv("VAR1")
+    os.environ["VAR2"]
+    os.environ.get("VAR3")
+
+    print(os.environ['VAR4'])
+    print(os.getenv("VAR5", 'localhost'))
+
+    os.environ['VAR6'] = "6"
+    print(os.environ.get('VAR7', 'value7'))
+    os.getenv('VAR8')
+
+    os.environ["VAR1"] = "newvalue"
+'''
+
+r_content = '''
+    Sys.setenv(VAR1 = "newvalue")
+    Sys.getenv(VAR2)
+
+    Sys.getenv("VAR3")
+    Sys.getenv('VAR4')
+
+    Sys.setenv('VAR5' = 'localhost')
+    Sys.setenv("VAR6" = 6)
+
+     Sys.setenv(VAR7 = "value7")
+    Sys.getenv('VAR8')
+'''

--- a/elyra/contents/tests/test_utils.py
+++ b/elyra/contents/tests/test_utils.py
@@ -53,16 +53,13 @@ expected_response = {
     "outputs": []
 }
 
-
 expected_response_empty = {
     "env_vars": {},
     "inputs": [],
     "outputs": []
 }
 
-
 text_content = "This is a text file."
-
 
 notebook_content = {
     "cells": [
@@ -158,3 +155,44 @@ r_content = '''
      Sys.setenv(VAR7 = "value7")
     Sys.getenv('VAR8')
 '''
+
+empty_notebook_content = {
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "id": "literary-parts",
+            "metadata": {},
+            "source": [
+                "# Python Notebook with No Environment Variables\n",
+                "\n",
+                "This python Notebook contains no environment variables to test the parser functionality.",
+            ],
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 0,
+            "id": "dental-manchester",
+            "metadata": {},
+            "outputs": [],
+            "source": ["import os\n", "\n", "print(os.cwd())"],
+        },
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3",
+        },
+        "language_info": {
+            "codemirror_mode": {"name": "ipython", "version": 3},
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.9.1",
+        },
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5,
+}

--- a/elyra/contents/tests/test_utils.py
+++ b/elyra/contents/tests/test_utils.py
@@ -1,0 +1,39 @@
+#
+# Copyright 2018-2021 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+import tornado
+
+
+def expected_http_error(error, expected_code, expected_message=None):
+    """Check that the error matches the expected output error."""
+    e = error.value
+    if isinstance(e, tornado.web.HTTPError):
+        if expected_code != e.status_code:
+            return False
+        if expected_message is not None and expected_message != str(e):
+            return False
+        return True
+    elif any([
+        isinstance(e, tornado.httpclient.HTTPClientError),
+        isinstance(e, tornado.httpclient.HTTPError)
+    ]):
+        if expected_code != e.code:
+            return False
+        if expected_message:
+            message = json.loads(e.response.body.decode())['message']
+            if expected_message != message:
+                return False
+        return True


### PR DESCRIPTION
Fixes #1542. Currently tests the following scenarios:

- [x] File not found
- [x] File is a directory
- [x] Invalid POST request
- [x] Invalid file extension
- [x] Notebook file (with python kernel) with env vars
- [x] Python file with env vars
- [x] R file with env vars

Additional scenarios that we may want to test:

- [x] Notebook with no env vars
- ~~Python file with no env vars~~ (general case covered by Notebook 'no-env' test)
- ~~R file with no env vars~~ (general case covered by Notebook 'no-env' test)
- ~~Notebooks with an R kernel~~ (covered by unit tests)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

