### PR TITLE
Display message when no code snippet or tag is defined

### DIFF
--- a/elyra/pipeline/tests/test_airflow_processor.py
+++ b/elyra/pipeline/tests/test_airflow_processor.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 import github
-import mock
 import os
 import pytest
 import tempfile
@@ -25,6 +24,7 @@ from elyra.pipeline.tests.test_pipeline_parser import _read_pipeline_resource
 from elyra.metadata.metadata import Metadata
 from elyra.util import git
 from pathlib import Path
+from unittest import mock
 
 PIPELINE_FILE = 'resources/sample_pipelines/pipeline_dependency_complex.json'
 

--- a/packages/code-snippet/src/CodeSnippetWidget.tsx
+++ b/packages/code-snippet/src/CodeSnippetWidget.tsx
@@ -527,6 +527,18 @@ export class CodeSnippetWidget extends MetadataWidget {
   }
 
   renderDisplay(metadata: IMetadata[]): React.ReactElement {
+    if (Array.isArray(metadata) && !metadata.length) {
+      // Empty metadata
+      return (
+        <div>
+          <br />
+          <h6 className="elyra-no-metadata-msg">
+            Click the + button to add a new Code Snippet
+          </h6>
+        </div>
+      );
+    }
+
     return (
       <CodeSnippetDisplay
         metadata={metadata}

--- a/packages/code-snippet/src/CodeSnippetWidget.tsx
+++ b/packages/code-snippet/src/CodeSnippetWidget.tsx
@@ -464,7 +464,7 @@ class CodeSnippetDisplay extends MetadataDisplay<
     );
   };
 
-  componentDidUpdate(): void {
+  createPreviewEditors = (): void => {
     const editorFactory = this.props.editorServices.factoryService
       .newInlineEditor;
     const getMimeTypeByLanguage = this.props.editorServices.mimeTypeService
@@ -490,6 +490,14 @@ class CodeSnippetDisplay extends MetadataDisplay<
         });
       }
     });
+  };
+
+  componentDidMount(): void {
+    this.createPreviewEditors();
+  }
+
+  componentDidUpdate(): void {
+    this.createPreviewEditors();
   }
 
   private _drag: Drag;

--- a/packages/metadata-common/src/FilterTools.tsx
+++ b/packages/metadata-common/src/FilterTools.tsx
@@ -39,6 +39,7 @@ const FILTER_SEARCHBAR = 'elyra-searchbar';
 const FILTER_SEARCHWRAPPER = 'elyra-searchwrapper';
 const FILTER_CLASS = 'elyra-filter';
 const FILTER_BUTTON = 'elyra-filter-btn';
+const FILTER_EMPTY = 'elyra-filter-empty';
 
 export class FilterTools extends React.Component<
   IFilterMetadataProps,
@@ -85,6 +86,13 @@ export class FilterTools extends React.Component<
   }
 
   renderTags(): JSX.Element {
+    if (!this.props.tags.length) {
+      return (
+        <div className={FILTER_TAGS}>
+          <p className={FILTER_EMPTY}>No tags defined</p>
+        </div>
+      );
+    }
     return (
       <div className={FILTER_TAGS}>
         {this.props.tags.sort().map((tag: string, index: number) => {

--- a/packages/metadata-common/style/index.css
+++ b/packages/metadata-common/style/index.css
@@ -237,6 +237,10 @@ button.elyra-filter-tag {
   font-size: var(--jp-ui-font-size1);
 }
 
+.elyra-filter-empty {
+  font-size: var(--jp-ui-font-size1);
+}
+
 .elyra-tools {
   border-bottom: var(--jp-border-width) solid var(--jp-border-color1);
 }


### PR DESCRIPTION
Closes #1396 
Similar to empty runtimes list, an empty list of code snippets now displays the message:
![image](https://user-images.githubusercontent.com/25207344/115764787-f9a77580-a373-11eb-99f5-a4e861c09114.png)

This PR also indicates when no tags are defined
![image](https://user-images.githubusercontent.com/25207344/115786366-b60e3500-a38e-11eb-9342-fa2fab1d6eaf.png)

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

