### PR TITLE
Use unittest mock module instead of third party module for flake8 failure

### DIFF
--- a/elyra/pipeline/tests/test_airflow_processor.py
+++ b/elyra/pipeline/tests/test_airflow_processor.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 import github
-import mock
 import os
 import pytest
 import tempfile
@@ -25,6 +24,7 @@ from elyra.pipeline.tests.test_pipeline_parser import _read_pipeline_resource
 from elyra.metadata.metadata import Metadata
 from elyra.util import git
 from pathlib import Path
+from unittest import mock
 
 PIPELINE_FILE = 'resources/sample_pipelines/pipeline_dependency_complex.json'
 


### PR DESCRIPTION
Use unittest mock module instead of third party module for flake8 failure

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

