### PR TITLE
Allow secure connections to s3 object storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 
 SHELL:=/bin/bash
 
-AIRFLOW_NOTEBOOK_VERSION:=0.0.4
+AIRFLOW_NOTEBOOK_VERSION:=0.0.6
 
 TAG:=dev
 IMAGE=elyra/elyra:$(TAG)

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup_args = dict(
         'websocket-client',
         'yaspin',
         # KFP runtime dependencies
-        'kfp-notebook~=0.22.0',
+        'kfp-notebook~=0.23.0',
         'kfp==1.3.0',
         'kfp-tekton==0.6.0',
         # Airflow runtime dependencies


### PR DESCRIPTION
When the cos_endpoint has a secure scheme specified (https)
in pipeline runtime configuration use minio secure client
during pipeline execution.
Bumps kfp-notebook and airflow-notebook packages to version
with support for this

Dependent on 
https://github.com/elyra-ai/airflow-notebook/pull/6 and
https://github.com/elyra-ai/kfp-notebook/pull/95

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

