### PR TITLE
Fix custom notebook/script code fonts with ligatures

### DIFF
--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -635,3 +635,8 @@ input.elyra-Dialog-checkbox.jp-mod-styled {
 .toolbar-overflow-menu-item button:hover {
   background-color: var(--jp-border-color1);
 }
+
+/* fix font ligatures */
+.lsp-completer-theme-vscode {
+  letter-spacing: normal;
+}


### PR DESCRIPTION
Fixes #1549 
Fix custom notebook code fonts with ligatures from breaking when pipeline extension is installed.
![image](https://user-images.githubusercontent.com/25207344/116128807-5918c480-a697-11eb-8503-f471160c2911.png)
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

