### PR TITLE
Bump kfp and kfp-tekton versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,8 +91,8 @@ setup_args = dict(
         'yaspin',
         # KFP runtime dependencies
         'kfp-notebook~=0.23.0',
-        'kfp==1.3.0',
-        'kfp-tekton==0.6.0',
+        'kfp==1.4.0',
+        'kfp-tekton==0.7.0',
         # Airflow runtime dependencies
         'pygithub',
         'black'


### PR DESCRIPTION
This PR requires more recent versions of `kfp` and `kfp-tekton`. Going forward we should consider removing the explicit `kfp` dependency altogether because `kfp-tekton` requires that package.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

