### PR TITLE
Add configuration instruction for KF 1.3

### DIFF
--- a/docs/source/recipes/using-elyra-with-kubeflow-notebook-server.md
+++ b/docs/source/recipes/using-elyra-with-kubeflow-notebook-server.md
@@ -43,7 +43,9 @@ In this example we will show how to launch Elyra using [Kubeflow's Notebook Serv
 1. Choose a `name` for your notebook server, and under `Image` check the box labeled `Custom Image`.   
   
    ![Elyra](../images/elyra-with-kf-notebook-config-1.png)  
-  
+
+1. In _Kubeflow version 1.3 (and later)_ choose `jupyterlab` as image type.
+
 1. As `Custom Image` enter `elyra/kf-notebook:<ELYRA_VERSION>`, replacing `<ELYRA_VERSION>` with the desired image tag, e.g. `2.1.0`.   
   
    ![Elyra](../images/elyra-with-kf-notebook-image-config.png)


### PR DESCRIPTION
 This PR updates the [Using Elyra with the Kubeflow Notebook Server](https://elyra.readthedocs.io/en/latest/recipes/using-elyra-with-kubeflow-notebook-server.html) recipe for Kubeflow v1.3. The existing screen captures from the previous release are retained (for now), since it's the most commonly used version in the wild.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

