### PR TITLE
Fix pipeline editor CI timeout failures

### DIFF
--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -152,7 +152,7 @@ describe('Pipeline Editor tests', () => {
     cy.findByRole('button', { name: /save pipeline/i }).click();
 
     // can take a moment to register as saved in ci
-    cy.wait(300);
+    cy.wait(1000);
 
     cy.findByRole('button', { name: /run pipeline/i }).click();
 

--- a/tests/support/commands.ts
+++ b/tests/support/commands.ts
@@ -81,7 +81,8 @@ Cypress.Commands.add('addFileToPipeline', (name: string): void => {
 
 Cypress.Commands.add('openFile', (name: string): void => {
   cy.findByRole('listitem', {
-    name: (n, _el) => n.includes(name)
+    name: (n, _el) => n.includes(name),
+    timeout: 50000
   }).dblclick();
 });
 


### PR DESCRIPTION
Adds a longer timeout for a couple of tests that are timing out in the CI tests for the pipeline editor. 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
