### PR TITLE
CI Enhancements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install
-        run: |
+        # Note: Tests fail if we don't install `wheel` for some reason.
+        run: | 
           python -m pip install --upgrade pip wheel
           pip install -q -r test_requirements.txt
           pip install --use-deprecated=legacy-resolver .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
         run: |
           yarn install
           python -m pip install --upgrade pip
-          pip install --use-deprecated=legacy-resolver .
+          pip install .
       - name: Test
         run: yarn test:unit
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,9 +85,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install
         run: |
-          pip install wheel
-          python setup.py bdist_wheel
-          pip install dist/elyra-*-py3-none-any.whl
+          pip install -q --upgrade pip --user
+          pip --version
+          pip install .
       - name: Test
         run: pytest -v elyra
 
@@ -112,9 +112,9 @@ jobs:
       - name: Install
         run: |
           yarn install
-          pip install wheel
-          python setup.py bdist_wheel
-          pip install dist/elyra-*-py3-none-any.whl
+          pip install -q --upgrade pip --user
+          pip --version
+          pip install .
       - name: Test
         run: yarn test:unit
 
@@ -141,9 +141,9 @@ jobs:
         # TODO: `make install` also lints and things, so we should break this down more.
         run: |
           yarn install
-          pip install wheel
-          python setup.py bdist_wheel
-          pip install dist/elyra-*-py3-none-any.whl
+          pip install -q --upgrade pip --user
+          pip --version
+          pip install .
       - name: Build
         run: yarn lerna run build
       - name: Install Elyra into JupyterLab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,90 +15,131 @@
 #
 name: Elyra Tests
 on:
-  push:
-    branches: '*'
-  pull_request:
-    branches: '*'
+  push: # all branches
+  pull_request: # all branches
   schedule:
     # once a day at 3 am (UTC) (7 pm (PST))
     - cron:  '0 3 * * *'
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [ '3.6', '3.7', '3.8' ]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        clean: true
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: 'x64'
-    - name: Set up Node
-      uses: actions/setup-node@v2
-      with:
-         node-version: '*'
-    - name: Create npm configuration for authentication
-      run: |
-        echo "scripts-prepend-node-path=true" >> ~/.npmrc
-        echo "prefix=~/.npm-global" >> ~/.npmrc
-        mkdir -p ~/.npm-global
-    - name: Install Python dependencies
-      run: |
-        python -m pip install --upgrade pip wheel jupyter_server
-        python -m pip install --upgrade jupyterlab
-    - name: Install NPM dependencies
-      run: |
-        sudo apt install yarn
-        npm install -g lerna@3.22.1
-        npm install -g rimraf@3.0.2
-        npm install -g typescript@4.1.3
-        npm install -g yarn@1.22.4
-    - name: Log current build tools version
-      run: |
-        python --version
-        node --version
-        npm --version
-        yarn --version
-        lerna --version
-        pip --version
-    - name: Log current Python dependencies version
-      run: |
-        pip freeze
-    - name: Build
-      run: |
-        export PATH=~/.npm-global/bin:$PATH
-        # make sure nothing was manually added to the package.json
-        yarn install --frozen-lockfile
-        make install
-    - name: Documentation
-      run: |
-        make docs
-    - name: Test
-      run: |
-        make test
-    - name: Collect logs
-      uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        path: |
-          ${{ github.workspace }}/build/cypress-tests/*.log
-          ${{ github.workspace }}/build/cypress-tests/screenshots//**/*
-          ${{ github.workspace }}/build/cypress-tests/videos//**/*
-          /home/runner/.npm/_logs/*.log
-  image_validation:
+  prepare-yarn-cache:
+    name: Prepare Cache
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        clean: true
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "*"
+      - uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+            /home/runner/.cache/Cypress
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Install
+        run: yarn install --frozen-lockfile
+
+  lint-server:
+    name: Lint Server
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install
+        run: pip install -q -r test_requirements.txt
+      - name: Lint
+        run: flake8 elyra
+
+  lint-ui:
+    name: Lint UI
+    needs: prepare-yarn-cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "*"
+      - uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Install
+        run: yarn install
+      - name: Lint
+        run: yarn eslint:check --max-warnings=0
+      - name: Check format
+        run: yarn prettier:check
+
+  test-server:
+    name: Test Server
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Test
+        run: pytest -v elyra
+
+  test-ui:
+    name: Test UI
+    needs: prepare-yarn-cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2 # Install dependencies with latest node version
+        with:
+          node-version: "*"
+      - uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Install
+        run: yarn install
+      - name: Test
+        run: yarn test:unit
+
+  test-integration:
+    name: Run Integration Tests
+    needs: prepare-yarn-cache
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "*"
+      - uses: actions/cache@v2
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+            /home/runner/.cache/Cypress
+          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+      - name: Install
+        # TODO: `make install` also lints and things, so we should break this down more.
+        run: make install
+      - name: Cypress
+        run: yarn test:integration
+
+  # TODO: Why are building? this should be named accordingly
+  build-documentation:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build
+        run: make docs
+
+  validate-images:
+    name: Validate Images
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
     - name: Validate runtime images
       run: make REMOVE_RUNTIME_IMAGE=1 validate-runtime-images

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,20 +25,6 @@ env:
   FORCE_COLOR: true
 
 jobs:
-  debug:
-    name: Debug
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '*'
-      - name: Debug
-        run: |
-          python -m pip install --upgrade pip wheel jupyter_server jupyterlab
-          jupyter lab path
-          jupyter lab path | grep "Application directory:" | sed -e "s/^Application directory:   //"
-
   prepare-yarn-cache:
     name: Prepare Cache
     runs-on: ubuntu-latest
@@ -183,6 +169,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-default-
             ${{ runner.os }}-pip-
+      - name: Get JupyterLab directory
+        id: jupyterlab-cache
+        run: |
+          echo "::set-output name=dir::$(jupyter lab path | grep 'Application directory:' | sed -e 's/^Application directory:   //')"
+      - name: Cache JupyterLab
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.jupyterlab-cache.outputs.dir }}
+          key: ${{ runner.os }}-jupyterlab
       - name: Install
         run: |
           yarn install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,11 +89,11 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'test_requirements.txt') }}
+      # - name: Cache pip
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ${{ env.pythonLocation }}
+      #     key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'test_requirements.txt') }}
       - name: Install
         run: |
           python -m pip install --upgrade pip wheel jupyter_server jupyterlab
@@ -122,11 +122,11 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'test_requirements.txt') }}
+      # - name: Cache pip
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ${{ env.pythonLocation }}
+      #     key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'test_requirements.txt') }}
       - name: Install
         run: |
           yarn install
@@ -155,11 +155,11 @@ jobs:
             */*/node_modules
             /home/runner/.cache/Cypress
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'test_requirements.txt') }}
+      # - name: Cache pip
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ${{ env.pythonLocation }}
+      #     key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'test_requirements.txt') }}
       - name: Install
         run: |
           yarn install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,9 +85,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install
         run: |
-          python -m pip install --upgrade pip wheel jupyter_server
-          python -m pip install --upgrade jupyterlab
-          make install-server
+          pip install wheel
+          python setup.py bdist_wheel
+          pip install dist/elyra-*-py3-none-any.whl
       - name: Test
         run: pytest -v elyra
 
@@ -110,12 +110,11 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install
-        run: yarn install
-      - name: Install
         run: |
-          python -m pip install --upgrade pip wheel jupyter_server
-          python -m pip install --upgrade jupyterlab
-          make install-server
+          yarn install
+          pip install wheel
+          python setup.py bdist_wheel
+          pip install dist/elyra-*-py3-none-any.whl
       - name: Test
         run: yarn test:unit
 
@@ -141,10 +140,16 @@ jobs:
       - name: Install
         # TODO: `make install` also lints and things, so we should break this down more.
         run: |
-          python -m pip install --upgrade pip wheel jupyter_server
-          python -m pip install --upgrade jupyterlab
-          make install-server
-          make install
+          yarn install
+          pip install wheel
+          python setup.py bdist_wheel
+          pip install dist/elyra-*-py3-none-any.whl
+      - name: Build
+        run: yarn lerna run build
+      - name: Install Elyra into JupyterLab
+        run: |
+          make install-ui-x
+          jupyter lab build
       - name: Cypress
         run: yarn test:integration
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,9 @@ jobs:
       - uses: actions/setup-node@v2 # Install dependencies with latest node version
         with:
           node-version: "*"
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "*"
       - uses: actions/cache@v2
         with:
           path: |
@@ -112,7 +115,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel jupyter_server
           python -m pip install --upgrade jupyterlab
-          make install-servermake install-server
+          make install-server
       - name: Test
         run: yarn test:unit
 
@@ -125,6 +128,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "*"
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "*"
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,8 +64,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "*"
-      - name: Cache node_modules
-        uses: actions/cache@v2
+      - uses: actions/cache@v2
         with:
           path: |
             node_modules
@@ -89,11 +88,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      # - name: Cache pip
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ${{ env.pythonLocation }}
-      #     key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'test_requirements.txt') }}
       - name: Install
         run: |
           python -m pip install --upgrade pip wheel jupyter_server jupyterlab
@@ -109,24 +103,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2 # Install dependencies with latest node version
+      - uses: actions/setup-node@v2
         with:
           node-version: "*"
       - uses: actions/setup-python@v2
         with:
           python-version: "*"
-      - name: Cache node_modules
-        uses: actions/cache@v2
+      - uses: actions/cache@v2
         with:
           path: |
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      # - name: Cache pip
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ${{ env.pythonLocation }}
-      #     key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'test_requirements.txt') }}
       - name: Install
         run: |
           yarn install
@@ -147,19 +135,13 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "*"
-      - name: Cache node_modules
-        uses: actions/cache@v2
+      - uses: actions/cache@v2
         with:
           path: |
             node_modules
             */*/node_modules
             /home/runner/.cache/Cypress
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      # - name: Cache pip
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ${{ env.pythonLocation }}
-      #     key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'test_requirements.txt') }}
       - name: Install
         run: |
           yarn install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ on:
     # once a day at 3 am (UTC) (7 pm (PST))
     - cron:  '0 3 * * *'
 
+env:
+  FORCE_COLOR: true
+
 jobs:
   prepare-yarn-cache:
     name: Prepare Cache
@@ -85,12 +88,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install
         run: |
-          pip install -q -r test_requirements.txt
-          pip install --use-deprecated=legacy-resolver .
+          python -m pip install --upgrade pip wheel jupyter_server
+          python -m pip install --upgrade jupyterlab
+          make install-server
       - name: Test
         run: pytest -v elyra
-        env:
-          FORCE_COLOR: true
 
   test-ui:
     name: Test UI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,18 @@ env:
   FORCE_COLOR: true
 
 jobs:
+  debug:
+    name: Debug
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "*"
+      - name: Debug
+        run: |
+          echo ${{ env.pythonLocation }}
+
   prepare-yarn-cache:
     name: Prepare Cache
     runs-on: ubuntu-latest
@@ -169,15 +181,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-default-
             ${{ runner.os }}-pip-
-      - name: Get JupyterLab directory
-        id: jupyterlab-cache
-        run: |
-          echo "::set-output name=dir::$(jupyter lab path | grep 'Application directory:' | sed -e 's/^Application directory:   //')"
-      - name: Cache JupyterLab
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.jupyterlab-cache.outputs.dir }}
-          key: ${{ runner.os }}-jupyterlab
+      # - name: Get JupyterLab directory
+      #   id: jupyterlab-cache
+      #   run: |
+      #     echo "::set-output name=dir::$(jupyter lab path | grep 'Application directory:' | sed -e 's/^Application directory:   //')"
+      # - name: Cache JupyterLab
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: ${{ steps.jupyterlab-cache.outputs.dir }}
+      #     key: ${{ runner.os }}-jupyterlab
       - name: Install
         run: |
           yarn install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install
-        run: make yarn-install
+        run: yarn install
       - name: Lint
         run: yarn eslint:check --max-warnings=0
       - name: Check format
@@ -92,7 +92,7 @@ jobs:
         # Note: Tests fail if we don't install `wheel` for some reason.
         run: | 
           python -m pip install --upgrade pip wheel
-          make install-server
+          pip install --use-deprecated=legacy-resolver .
           make test-dependencies
       - name: Test
         run: pytest -v elyra
@@ -117,8 +117,9 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install
         run: |
-          make yarn-install
-          make install-server
+          yarn install
+          python -m pip install --upgrade pip
+          pip install --use-deprecated=legacy-resolver .
       - name: Test
         run: yarn test:unit
 
@@ -143,8 +144,9 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install
         run: |
-          make yarn-install
-          make install-server
+          yarn install
+          python -m pip install --upgrade pip
+          pip install --use-deprecated=legacy-resolver .
       - name: Build
         run: yarn lerna run build --stream
       - name: Setup JupyterLab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install
-        run: make lint-dependencies
+        run: make lint-server-dependencies
       - name: Lint
         run: make flake
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,9 +49,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install
-        run: make lint-server-dependencies
+        run: make test-dependencies
       - name: Lint
-        run: make flake
+        run: make lint-server
 
   lint-ui:
     name: Lint UI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install
         run: |
-          pip install --use-deprecated=legacy-resolver ".[test]"
+          pip install --use-deprecated=legacy-resolver -r test_requirements.txt .
       - name: Test
         run: pytest -v elyra
 
@@ -139,10 +139,10 @@ jobs:
           yarn install
           pip install --use-deprecated=legacy-resolver .
       - name: Build
-        run: yarn lerna run build
-      - name: Install Elyra into JupyterLab
+        run: yarn lerna run build --stream
+      - name: Setup JupyterLab
         run: |
-          make install-ui-x
+          yarn lerna run lab:install --stream
           jupyter lab build
       - name: Cypress
         run: yarn test:integration

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,19 +41,15 @@ jobs:
             /home/runner/.cache/Cypress
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install
-        run: yarn install --frozen-lockfile
+        run: make yarn-install YARN_ARGS="--frozen-lockfile"
 
   lint-server:
     name: Lint Server
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install
-        run: |
-          python -m pip install --upgrade pip
-          pip install flake8
       - name: Lint
-        run: flake8 elyra
+        run: make lint-server
 
   lint-ui:
     name: Lint UI
@@ -71,11 +67,11 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install
-        run: yarn install
+        run: make yarn-install
       - name: Lint
-        run: yarn eslint:check --max-warnings=0
+        run: make lint-ui
       - name: Check format
-        run: yarn prettier:check
+        run: make prettier-ui
 
   test-server:
     name: Test Server
@@ -88,14 +84,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install
-        # Note: Tests fail if we don't install `wheel` for some reason.
-        run: | 
-          python -m pip install --upgrade pip wheel
-          pip install --use-deprecated=legacy-resolver .
-          make test-dependencies
       - name: Test
-        run: pytest -v elyra
+        run: make test-server
 
   test-ui:
     name: Test UI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
             node_modules
             */*/node_modules
             /home/runner/.cache/Cypress
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install
         run: yarn install --frozen-lockfile
 
@@ -49,7 +49,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install
-        run: pip install -q -r test_requirements.txt
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
       - name: Lint
         run: flake8 elyra
 
@@ -67,7 +69,7 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install
         run: yarn install
       - name: Lint
@@ -86,10 +88,15 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py', 'test_requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install
         run: |
-          python -m pip install --upgrade pip wheel jupyter_server
-          python -m pip install --upgrade jupyterlab
+          python -m pip install --upgrade pip wheel jupyter_server jupyterlab
           make install-server
       - name: Test
         run: pytest -v elyra
@@ -111,7 +118,7 @@ jobs:
           path: |
             node_modules
             */*/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install
         run: |
           yarn install
@@ -137,7 +144,13 @@ jobs:
             node_modules
             */*/node_modules
             /home/runner/.cache/Cypress
-          key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py', 'test_requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install
         # TODO: `make install` also lints and things, so we should break this down more.
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install
         run: |
-          python -m pip install --upgrade pip jupyter_server jupyterlab
+          python -m pip install --upgrade pip wheel
           pip install -q -r test_requirements.txt
           pip install --use-deprecated=legacy-resolver .
       - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,18 +25,6 @@ env:
   FORCE_COLOR: true
 
 jobs:
-  debug:
-    name: Debug
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "*"
-      - name: Debug
-        run: |
-          echo ${{ env.pythonLocation }}
-
   prepare-yarn-cache:
     name: Prepare Cache
     runs-on: ubuntu-latest
@@ -104,11 +92,8 @@ jobs:
       - name: Cache pip
         uses: actions/cache@v2
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py', 'test_requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}
-            ${{ runner.os }}-pip-
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'test_requirements.txt') }}
       - name: Install
         run: |
           python -m pip install --upgrade pip wheel jupyter_server jupyterlab
@@ -140,11 +125,8 @@ jobs:
       - name: Cache pip
         uses: actions/cache@v2
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-default-${{ hashFiles('setup.py', 'test_requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-default-
-            ${{ runner.os }}-pip-
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'test_requirements.txt') }}
       - name: Install
         run: |
           yarn install
@@ -176,20 +158,8 @@ jobs:
       - name: Cache pip
         uses: actions/cache@v2
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-default-${{ hashFiles('setup.py', 'test_requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-default-
-            ${{ runner.os }}-pip-
-      # - name: Get JupyterLab directory
-      #   id: jupyterlab-cache
-      #   run: |
-      #     echo "::set-output name=dir::$(jupyter lab path | grep 'Application directory:' | sed -e 's/^Application directory:   //')"
-      # - name: Cache JupyterLab
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ${{ steps.jupyterlab-cache.outputs.dir }}
-      #     key: ${{ runner.os }}-jupyterlab
+          path: ${{ env.pythonLocation }}
+          key: ${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('setup.py', 'test_requirements.txt') }}
       - name: Install
         run: |
           yarn install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install
+        run: pip install .
       - name: Test
         run: pytest -v elyra
 
@@ -133,6 +135,7 @@ jobs:
     name: Build Documentation
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Build
         run: make docs
 
@@ -140,6 +143,6 @@ jobs:
     name: Validate Images
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Validate runtime images
-      run: make REMOVE_RUNTIME_IMAGE=1 validate-runtime-images
+      - uses: actions/checkout@v2
+      - name: Validate runtime images
+        run: make REMOVE_RUNTIME_IMAGE=1 validate-runtime-images

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install
         run: |
-          python -m pip install --upgrade pip jupyter_server
+          python -m pip install --upgrade pip jupyterlab
           pip install -q -r test_requirements.txt
           pip install --use-deprecated=legacy-resolver .
       - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,12 @@ jobs:
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py', 'test_requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install
         run: |
           yarn install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip wheel jupyter_server jupyterlab
+          pip install -q -r test_requirements.txt
           python setup.py bdist_wheel sdist
           pip install --upgrade --upgrade-strategy only-if-needed --use-deprecated=legacy-resolver dist/elyra-*-py3-none-any.whl
       - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,9 +85,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install
         run: |
-          pip install -q --upgrade pip --user
-          pip --version
-          pip install .
+          pip install --use-deprecated=legacy-resolver .
       - name: Test
         run: pytest -v elyra
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install
-        run: pip install .
+        run: make install-server
       - name: Test
         run: pytest -v elyra
 
@@ -105,6 +105,8 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install
         run: yarn install
+      - name: Install
+        run: make install-server
       - name: Test
         run: yarn test:unit
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
             */*/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install
-        run: yarn install
+        run: make yarn-install
       - name: Lint
         run: yarn eslint:check --max-warnings=0
       - name: Check format
@@ -92,8 +92,8 @@ jobs:
         # Note: Tests fail if we don't install `wheel` for some reason.
         run: | 
           python -m pip install --upgrade pip wheel
-          pip install -q -r test_requirements.txt
-          pip install --use-deprecated=legacy-resolver .
+          make install-server
+          make test-dependencies
       - name: Test
         run: pytest -v elyra
 
@@ -117,9 +117,8 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install
         run: |
-          yarn install
-          python -m pip install --upgrade pip
-          pip install --use-deprecated=legacy-resolver .
+          make yarn-install
+          make install-server
       - name: Test
         run: yarn test:unit
 
@@ -144,9 +143,8 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install
         run: |
-          yarn install
-          python -m pip install --upgrade pip
-          pip install --use-deprecated=legacy-resolver .
+          make yarn-install
+          make install-server
       - name: Build
         run: yarn lerna run build --stream
       - name: Setup JupyterLab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "*"
-      - uses: actions/cache@v2
+      - name: Cache node_modules
+        uses: actions/cache@v2
         with:
           path: |
             node_modules
@@ -88,16 +89,19 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: actions/cache@v2
+      - name: Cache pip
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py', 'test_requirements.txt') }}
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py', 'test_requirements.txt') }}
           restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}
             ${{ runner.os }}-pip-
       - name: Install
         run: |
           python -m pip install --upgrade pip wheel jupyter_server jupyterlab
-          make install-server
+          python setup.py bdist_wheel sdist
+          pip install --upgrade --upgrade-strategy only-if-needed --use-deprecated=legacy-resolver dist/elyra-*-py3-none-any.whl
       - name: Test
         run: pytest -v elyra
 
@@ -113,21 +117,25 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "*"
-      - uses: actions/cache@v2
+      - name: Cache node_modules
+        uses: actions/cache@v2
         with:
           path: |
             node_modules
             */*/node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v2
+      - name: Cache pip
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py', 'test_requirements.txt') }}
+          key: ${{ runner.os }}-pip-default-${{ hashFiles('setup.py', 'test_requirements.txt') }}
           restore-keys: |
+            ${{ runner.os }}-pip-default-
             ${{ runner.os }}-pip-
       - name: Install
         run: |
           yarn install
+          python -m pip install --upgrade pip
           pip install --use-deprecated=legacy-resolver .
       - name: Test
         run: yarn test:unit
@@ -144,23 +152,26 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "*"
-      - uses: actions/cache@v2
+      - name: Cache node_modules
+        uses: actions/cache@v2
         with:
           path: |
             node_modules
             */*/node_modules
             /home/runner/.cache/Cypress
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      - uses: actions/cache@v2
+      - name: Cache pip
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('setup.py', 'test_requirements.txt') }}
+          key: ${{ runner.os }}-pip-default-${{ hashFiles('setup.py', 'test_requirements.txt') }}
           restore-keys: |
+            ${{ runner.os }}-pip-default-
             ${{ runner.os }}-pip-
       - name: Install
-        # TODO: `make install` also lints and things, so we should break this down more.
         run: |
           yarn install
+          python -m pip install --upgrade pip
           pip install --use-deprecated=legacy-resolver .
       - name: Build
         run: yarn lerna run build --stream
@@ -171,7 +182,7 @@ jobs:
       - name: Cypress
         run: yarn test:integration
 
-  # TODO: Why are building? this should be named accordingly
+  # TODO: Why are building? Is this just a test that it successfully builds? this should be named accordingly
   build-documentation:
     name: Build Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install
-        run: make test-dependencies
       - name: Lint
         run: make lint-server
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade pip jupyter_server
           pip install -q -r test_requirements.txt
           pip install --use-deprecated=legacy-resolver .
       - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,20 @@ env:
   FORCE_COLOR: true
 
 jobs:
+  debug:
+    name: Debug
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '*'
+      - name: Debug
+        run: |
+          python -m pip install --upgrade pip wheel jupyter_server jupyterlab
+          jupyter lab path
+          jupyter lab path | grep "Application directory:" | sed -e "s/^Application directory:   //"
+
   prepare-yarn-cache:
     name: Prepare Cache
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install
-        run: make install-server
+        run: |
+          python -m pip install --upgrade pip wheel jupyter_server
+          python -m pip install --upgrade jupyterlab
+          make install-server
       - name: Test
         run: pytest -v elyra
 
@@ -106,7 +109,10 @@ jobs:
       - name: Install
         run: yarn install
       - name: Install
-        run: make install-server
+        run: |
+          python -m pip install --upgrade pip wheel jupyter_server
+          python -m pip install --upgrade jupyterlab
+          make install-servermake install-server
       - name: Test
         run: yarn test:unit
 
@@ -128,7 +134,11 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install
         # TODO: `make install` also lints and things, so we should break this down more.
-        run: make install
+        run: |
+          python -m pip install --upgrade pip wheel jupyter_server
+          python -m pip install --upgrade jupyterlab
+          make install-server
+          make install
       - name: Cypress
         run: yarn test:integration
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install
         run: |
-          python -m pip install --upgrade pip jupyterlab
+          python -m pip install --upgrade pip jupyter_server jupyterlab
           pip install -q -r test_requirements.txt
           pip install --use-deprecated=legacy-resolver .
       - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,8 +92,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip wheel jupyter_server jupyterlab
           pip install -q -r test_requirements.txt
-          python setup.py bdist_wheel sdist
-          pip install --upgrade --upgrade-strategy only-if-needed --use-deprecated=legacy-resolver dist/elyra-*-py3-none-any.whl
+          pip install --use-deprecated=legacy-resolver .
       - name: Test
         run: pytest -v elyra
 
@@ -119,7 +118,7 @@ jobs:
         run: |
           yarn install
           python -m pip install --upgrade pip
-          pip install .
+          pip install --use-deprecated=legacy-resolver .
       - name: Test
         run: yarn test:unit
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,9 +85,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install
         run: |
-          pip install --use-deprecated=legacy-resolver -r test_requirements.txt .
+          pip install -q -r test_requirements.txt
+          pip install --use-deprecated=legacy-resolver .
       - name: Test
         run: pytest -v elyra
+        env:
+          FORCE_COLOR: true
 
   test-ui:
     name: Test UI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install
         run: |
-          python -m pip install --upgrade pip wheel jupyter_server jupyterlab
+          python -m pip install --upgrade pip
           pip install -q -r test_requirements.txt
           pip install --use-deprecated=legacy-resolver .
       - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Install
         # Note: Tests fail if we don't install `wheel` for some reason.
         run: |
-          make build-server install-server-package
+          make only-install-server
           make test-dependencies
       - name: Test
         run: make pytest
@@ -115,7 +115,7 @@ jobs:
       - name: Install
         run: |
           make yarn-install
-          make build-server install-server-package
+          make only-install-server
       - name: Test
         run: make test-ui-unit
 
@@ -141,7 +141,7 @@ jobs:
       - name: Install
         run: |
           make yarn-install
-          make build-server install-server-package
+          make only-install-server
       - name: Build
         run: make build-ui
       - name: Setup JupyterLab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,15 +41,17 @@ jobs:
             /home/runner/.cache/Cypress
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install
-        run: make yarn-install YARN_ARGS="--frozen-lockfile"
+        run: yarn install --frozen-lockfile
 
   lint-server:
     name: Lint Server
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install
+        run: make lint-dependencies
       - name: Lint
-        run: make lint-server
+        run: make flake
 
   lint-ui:
     name: Lint UI
@@ -69,7 +71,7 @@ jobs:
       - name: Install
         run: make yarn-install
       - name: Lint
-        run: make lint-ui
+        run: make eslint-ui
       - name: Check format
         run: make prettier-ui
 
@@ -84,8 +86,13 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install
+        # Note: Tests fail if we don't install `wheel` for some reason.
+        run: |
+          make build-server install-server-package
+          make test-dependencies
       - name: Test
-        run: make test-server
+        run: make pytest
 
   test-ui:
     name: Test UI
@@ -107,11 +114,10 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install
         run: |
-          yarn install
-          python -m pip install --upgrade pip
-          pip install --use-deprecated=legacy-resolver .
+          make yarn-install
+          make build-server install-server-package
       - name: Test
-        run: yarn test:unit
+        run: make test-ui-unit
 
   test-integration:
     name: Run Integration Tests
@@ -134,17 +140,16 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Install
         run: |
-          yarn install
-          python -m pip install --upgrade pip
-          pip install --use-deprecated=legacy-resolver .
+          make yarn-install
+          make build-server install-server-package
       - name: Build
-        run: yarn lerna run build --stream
+        run: make build-ui
       - name: Setup JupyterLab
         run: |
-          yarn lerna run lab:install --stream
-          jupyter lab build
+          make install-extensions
+          make build-jupyterlab
       - name: Cypress
-        run: yarn test:integration
+        run: make test-integration
 
   # TODO: Why are building? Is this just a test that it successfully builds? this should be named accordingly
   build-documentation:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install
         run: |
-          pip install --use-deprecated=legacy-resolver .
+          pip install --use-deprecated=legacy-resolver ".[test]"
       - name: Test
         run: pytest -v elyra
 
@@ -110,9 +110,7 @@ jobs:
       - name: Install
         run: |
           yarn install
-          pip install -q --upgrade pip --user
-          pip --version
-          pip install .
+          pip install --use-deprecated=legacy-resolver .
       - name: Test
         run: yarn test:unit
 
@@ -139,9 +137,7 @@ jobs:
         # TODO: `make install` also lints and things, so we should break this down more.
         run: |
           yarn install
-          pip install -q --upgrade pip --user
-          pip --version
-          pip install .
+          pip install --use-deprecated=legacy-resolver .
       - name: Build
         run: yarn lerna run build
       - name: Install Elyra into JupyterLab

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ KF_NOTEBOOK_IMAGE=elyra/kf-notebook:$(TAG)
 REQUIRED_RUNTIME_IMAGE_COMMANDS?="curl python3"
 REMOVE_RUNTIME_IMAGE?=0  # Invoke `make REMOVE_RUNTIME_IMAGE=1 validate-runtime-images` to have images removed after validation
 UPGRADE_STRATEGY?=only-if-needed
+YARN_ARGS?=""
 
 help:
 # http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
@@ -83,11 +84,13 @@ test-dependencies:
 lint-server: test-dependencies
 	flake8 elyra
 
-lint-ui:
-	yarn run prettier
-	yarn run eslint
+prettier-ui:
+	yarn prettier:check
 
-lint: lint-ui lint-server ## Run linters
+lint-ui:
+	yarn eslint:check --max-warnings=0
+
+lint: lint-ui prettier-ui lint-server ## Run linters
 
 dev-link:
 	yarn link @elyra/pipeline-services
@@ -96,7 +99,7 @@ dev-link:
 	cd node_modules/@elyra/pipeline-services && jupyter labextension link --no-build .
 
 yarn-install:
-	yarn install
+	yarn install $(YARN_ARGS)
 
 build-ui: yarn-install # Build packages
 	yarn lerna run build

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ build-jupyterlab:
 install-server: lint-server build-server install-server-package # Install backend
 
 install-server-package:
-	pip install --upgrade pip
+	pip install --upgrade pip wheel
 	pip install --upgrade --upgrade-strategy $(UPGRADE_STRATEGY) --use-deprecated=legacy-resolver dist/elyra-*-py3-none-any.whl
 
 install: install-server install-ui check-install ## Build and install

--- a/Makefile
+++ b/Makefile
@@ -78,16 +78,11 @@ uninstall:
 clean: purge uninstall ## Make a clean source tree and uninstall extensions
 
 test-dependencies:
+	python -m pip install --upgrade pip
 	@pip install -q -r test_requirements.txt
 
-lint-server-dependencies:
-	python -m pip install --upgrade pip
-	pip install flake8
-
-flake:
+lint-server: test-dependencies
 	flake8 elyra
-
-lint-server: lint-server-dependencies flake
 
 prettier-ui:
 	yarn prettier:check

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 
 .PHONY: help purge install uninstall clean test-dependencies lint-server lint-ui lint yarn-install eslint-ui prettier-ui flake lint-server-dependencies
-.PHONY: build-ui build-server install-server watch install-extensions build-jupyterlab install-server-package check-install
+.PHONY: build-ui build-server install-server watch install-extensions build-jupyterlab install-server-package check-install only-install-server
 .PHONY: test-server test-ui test-integration test-integration-debug test docs-dependencies docs dist-ui release pytest
 .PHONY: validate-runtime-images elyra-image publish-elyra-image kf-notebook-image
 .PHONY: publish-kf-notebook-image airflow-image publish-airflow-image container-images publish-container-images
@@ -124,10 +124,14 @@ install-extensions:
 build-jupyterlab:
 	jupyter lab build
 
-install-server: lint-server build-server install-server-package # Install backend
+prepare-server:
+	pip install --upgrade pip wheel
+
+only-install-server: prepare-server build-server install-server-package
+
+install-server: lint-server only-install-server # Install backend
 
 install-server-package:
-	pip install --upgrade pip wheel
 	pip install --upgrade --upgrade-strategy $(UPGRADE_STRATEGY) --use-deprecated=legacy-resolver dist/elyra-*-py3-none-any.whl
 
 install: install-server install-ui check-install ## Build and install

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ purge:
 	rm -rf $$(find . -name .pytest_cache)
 	rm -rf $(yarn cache dir)
 
+# NOTE: We can't use "lerna run lab:uninstall" because we may have deleted node_modules.
 uninstall:
 	$(call UNLINK_LAB_EXTENSION,@elyra/services)
 	$(call UNLINK_LAB_EXTENSION,@elyra/ui-components)
@@ -106,28 +107,7 @@ build-server: lint-server # Build backend
 build: build-server build-ui
 
 install-ui: build-ui # Install packages
-	$(call LINK_LAB_EXTENSION,services)
-	$(call LINK_LAB_EXTENSION,ui-components)
-	$(call LINK_LAB_EXTENSION,metadata-common)
-	$(call LINK_LAB_EXTENSION,script-editor)
-	$(call INSTALL_LAB_EXTENSION,theme)
-	$(call INSTALL_LAB_EXTENSION,code-snippet)
-	$(call INSTALL_LAB_EXTENSION,metadata)
-	$(call INSTALL_LAB_EXTENSION,pipeline-editor)
-	$(call INSTALL_LAB_EXTENSION,python-editor)
-	$(call INSTALL_LAB_EXTENSION,r-editor)
-
-install-ui-x:
-	$(call LINK_LAB_EXTENSION,services)
-	$(call LINK_LAB_EXTENSION,ui-components)
-	$(call LINK_LAB_EXTENSION,metadata-common)
-	$(call LINK_LAB_EXTENSION,script-editor)
-	$(call INSTALL_LAB_EXTENSION,theme)
-	$(call INSTALL_LAB_EXTENSION,code-snippet)
-	$(call INSTALL_LAB_EXTENSION,metadata)
-	$(call INSTALL_LAB_EXTENSION,pipeline-editor)
-	$(call INSTALL_LAB_EXTENSION,python-editor)
-	$(call INSTALL_LAB_EXTENSION,r-editor)
+	yarn lerna run lab:install --stream
 
 install-server: build-server # Install backend
 	pip install --upgrade pip
@@ -250,16 +230,8 @@ define UNLINK_LAB_EXTENSION
 	- jupyter labextension unlink --no-build $1
 endef
 
-define LINK_LAB_EXTENSION
-	cd packages/$1 && jupyter labextension link --no-build .
-endef
-
 define UNINSTALL_LAB_EXTENSION
 	- jupyter labextension uninstall --no-build $1
-endef
-
-define INSTALL_LAB_EXTENSION
-	cd packages/$1 && jupyter labextension install --no-build .
 endef
 
 define PACKAGE_LAB_EXTENSION

--- a/Makefile
+++ b/Makefile
@@ -96,12 +96,12 @@ dev-link:
 	cd node_modules/@elyra/pipeline-services && jupyter labextension link --no-build .
 
 yarn-install:
-	yarn
+	yarn install
 
-build-ui: yarn-install lint-ui # Build packages
-	export PATH=$$(pwd)/node_modules/.bin:$$PATH && lerna run build
+build-ui: yarn-install # Build packages
+	yarn lerna run build
 
-build-server: lint-server # Build backend
+build-server: # Build backend
 	python setup.py bdist_wheel sdist
 
 build: build-server build-ui
@@ -120,21 +120,21 @@ install: install-server install-ui ## Build and install
 	jupyter labextension list
 
 watch: ## Watch packages. For use alongside jupyter lab --watch
-	export PATH=$$(pwd)/node_modules/.bin:$$PATH && lerna run watch --parallel
+	yarn lerna run watch --parallel
 
-test-server: install-server # Run unit tests
+test-server: lint-server install-server # Run unit tests
 	pytest -v elyra
 
 test-ui: lint-ui test-ui-unit test-integration # Run frontend tests
 
 test-ui-unit: # Run frontend jest unit tests
-	npm run test:unit
+	yarn test:unit
 
 test-integration: # Run frontend cypress integration tests
-	npm run test:integration
+	yarn test:integration
 
 test-integration-debug: # Open cypress integration test debugger
-	npm run test:integration:debug
+	yarn test:integration:debug
 
 test: test-server test-ui ## Run all tests (backend, frontend and cypress integration tests)
 
@@ -235,5 +235,5 @@ define UNINSTALL_LAB_EXTENSION
 endef
 
 define PACKAGE_LAB_EXTENSION
-	export PATH=$$(pwd)/node_modules/.bin:$$PATH && cd packages/$1 && npm run dist && mv *.tgz ../../dist
+	cd packages/$1 && yarn dist && mv *.tgz ../../dist
 endef

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,18 @@ install-ui: build-ui # Install packages
 	$(call INSTALL_LAB_EXTENSION,python-editor)
 	$(call INSTALL_LAB_EXTENSION,r-editor)
 
+install-ui-x:
+	$(call LINK_LAB_EXTENSION,services)
+	$(call LINK_LAB_EXTENSION,ui-components)
+	$(call LINK_LAB_EXTENSION,metadata-common)
+	$(call LINK_LAB_EXTENSION,script-editor)
+	$(call INSTALL_LAB_EXTENSION,theme)
+	$(call INSTALL_LAB_EXTENSION,code-snippet)
+	$(call INSTALL_LAB_EXTENSION,metadata)
+	$(call INSTALL_LAB_EXTENSION,pipeline-editor)
+	$(call INSTALL_LAB_EXTENSION,python-editor)
+	$(call INSTALL_LAB_EXTENSION,r-editor)
+
 install-server: build-server # Install backend
 	pip install --upgrade pip
 	pip install --upgrade --upgrade-strategy $(UPGRADE_STRATEGY) --use-deprecated=legacy-resolver dist/elyra-*-py3-none-any.whl

--- a/packages/code-snippet/package.json
+++ b/packages/code-snippet/package.json
@@ -29,7 +29,9 @@
     "clean": "rimraf lib",
     "dist": "npm pack .",
     "prepare": "npm run build",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "lab:install": "jupyter labextension install --no-build",
+    "lab:uninstall": "jupyter labextension uninstall --no-build"
   },
   "dependencies": {
     "@elyra/metadata-common": "^2.3.0-dev",

--- a/packages/metadata-common/package.json
+++ b/packages/metadata-common/package.json
@@ -28,7 +28,9 @@
     "clean": "rimraf lib",
     "dist": "npm pack .",
     "prepare": "npm run build",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "lab:install": "jupyter labextension link --no-build",
+    "lab:uninstall": "jupyter labextension unlink --no-build"
   },
   "dependencies": {
     "@elyra/services": "^2.3.0-dev",

--- a/packages/metadata/package.json
+++ b/packages/metadata/package.json
@@ -29,7 +29,9 @@
     "clean": "rimraf lib",
     "dist": "npm pack .",
     "prepare": "npm run build",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "lab:install": "jupyter labextension install --no-build",
+    "lab:uninstall": "jupyter labextension uninstall --no-build"
   },
   "dependencies": {
     "@elyra/metadata-common": "^2.3.0-dev",

--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -31,7 +31,9 @@
     "dist": "npm pack .",
     "prepare": "npm run build ",
     "test": "jest --passWithNoTests",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "lab:install": "jupyter labextension install --no-build",
+    "lab:uninstall": "jupyter labextension uninstall --no-build"
   },
   "dependencies": {
     "@elyra/metadata-common": "^2.3.0-dev",

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -132,15 +132,17 @@ const PipelineWrapper: React.FC<IProps> = ({
   const [pipeline, setPipeline] = useState<any>(null);
   const [panelOpen, setPanelOpen] = React.useState(false);
   const [alert, setAlert] = React.useState('');
-  const pipelineRuntime = pipeline?.pipelines?.[0]?.app_data?.runtime
-    ? {
-        name: pipeline?.pipelines?.[0]?.app_data?.runtime,
-        display_name:
-          pipeline?.pipelines?.[0]?.app_data?.ui_data?.runtime?.display_name
-      }
-    : null;
+  // const pipelineRuntime = pipeline?.pipelines?.[0]?.app_data?.runtime
+  //   ? {
+  //       name: pipeline?.pipelines?.[0]?.app_data?.runtime,
+  //       display_name:
+  //         pipeline?.pipelines?.[0]?.app_data?.ui_data?.runtime?.display_name
+  //     }
+  //   : null;
 
   const pipelineRuntimeName = pipeline?.pipelines?.[0]?.app_data?.runtime;
+  const pipelineRuntimeDisplayName =
+    pipeline?.pipelines?.[0]?.app_data?.ui_data?.runtime?.display_name;
 
   const { data: nodeDefs, error: nodeDefsError } = useNodeDefs(
     pipelineRuntimeName
@@ -383,17 +385,20 @@ const PipelineWrapper: React.FC<IProps> = ({
     );
 
     let title = 'Export pipeline';
-    if (pipelineRuntime) {
-      title = `Export pipeline for ${pipelineRuntime.display_name}`;
+    if (
+      pipelineRuntimeDisplayName !== undefined &&
+      pipelineRuntimeName !== undefined
+    ) {
+      title = `Export pipeline for ${pipelineRuntimeDisplayName}`;
       const filteredRuntimeOptions = PipelineService.filterRuntimes(
         runtimes,
-        pipelineRuntime.name
+        pipelineRuntimeName
       );
       if (filteredRuntimeOptions.length === 0) {
         const runtimes = await RequestErrors.noMetadataError(
           'runtime',
           'export pipeline.',
-          pipelineRuntime.display_name
+          pipelineRuntimeDisplayName
         );
         if (Utils.isDialogResult(runtimes)) {
           if (runtimes.button.label.includes(RUNTIMES_NAMESPACE)) {
@@ -411,7 +416,7 @@ const PipelineWrapper: React.FC<IProps> = ({
       body: formDialogWidget(
         <PipelineExportDialog
           runtimes={runtimes}
-          runtime={pipelineRuntime?.name}
+          runtime={pipelineRuntimeName}
           schema={schema}
         />
       ),
@@ -472,7 +477,14 @@ const PipelineWrapper: React.FC<IProps> = ({
       pipelineJson.pipelines[0],
       contextRef.current.path
     );
-  }, [cleanNullProperties, context.model, nodeDefs, pipelineRuntime, shell]);
+  }, [
+    cleanNullProperties,
+    context.model,
+    nodeDefs,
+    pipelineRuntimeDisplayName,
+    pipelineRuntimeName,
+    shell
+  ]);
 
   const handleRunPipeline = useCallback(async (): Promise<void> => {
     const pipelineJson: any = context.model.toJSON();
@@ -532,17 +544,20 @@ const PipelineWrapper: React.FC<IProps> = ({
     schema.unshift(JSON.parse(JSON.stringify(localSchema)));
 
     let title = 'Run pipeline';
-    if (pipelineRuntime) {
-      title = `Run pipeline on ${pipelineRuntime.display_name}`;
+    if (
+      pipelineRuntimeDisplayName !== undefined &&
+      pipelineRuntimeName !== undefined
+    ) {
+      title = `Run pipeline on ${pipelineRuntimeDisplayName}`;
       const filteredRuntimeOptions = PipelineService.filterRuntimes(
         runtimes,
-        pipelineRuntime.name
+        pipelineRuntimeName
       );
       if (filteredRuntimeOptions.length === 0) {
         const runtimes = await RequestErrors.noMetadataError(
           'runtime',
           'run pipeline.',
-          pipelineRuntime.display_name
+          pipelineRuntimeDisplayName
         );
         if (Utils.isDialogResult(runtimes)) {
           if (runtimes.button.label.includes(RUNTIMES_NAMESPACE)) {
@@ -561,7 +576,7 @@ const PipelineWrapper: React.FC<IProps> = ({
         <PipelineSubmissionDialog
           name={pipelineName}
           runtimes={runtimes}
-          runtime={pipelineRuntime?.name}
+          runtime={pipelineRuntimeName}
           schema={schema}
         />
       ),
@@ -607,7 +622,14 @@ const PipelineWrapper: React.FC<IProps> = ({
       pipelineJson.pipelines[0],
       contextRef.current.path
     );
-  }, [cleanNullProperties, context.model, nodeDefs, pipelineRuntime, shell]);
+  }, [
+    cleanNullProperties,
+    context.model,
+    nodeDefs,
+    pipelineRuntimeDisplayName,
+    pipelineRuntimeName,
+    shell
+  ]);
 
   const handleClearPipeline = useCallback(async (data: any): Promise<any> => {
     return showDialog({
@@ -719,15 +741,15 @@ const PipelineWrapper: React.FC<IProps> = ({
     rightBar: [
       {
         action: '',
-        label: `Runtime: ${pipelineRuntime?.display_name ?? 'Generic'}`,
+        label: `Runtime: ${pipelineRuntimeDisplayName ?? 'Generic'}`,
         incLabelWithIcon: 'before',
         enable: false,
         kind: 'tertiary',
         // TODO: use getRuntimeIcon
         iconEnabled: IconUtil.encode(
-          pipelineRuntime?.name === 'kfp'
+          pipelineRuntimeName === 'kfp'
             ? kubeflowIcon
-            : pipelineRuntime?.name === 'airflow'
+            : pipelineRuntimeName === 'airflow'
             ? airflowIcon
             : pipelineIcon
         )

--- a/packages/python-editor/package.json
+++ b/packages/python-editor/package.json
@@ -29,7 +29,9 @@
     "clean": "rimraf lib",
     "dist": "npm pack .",
     "prepare": "npm run build",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "lab:install": "jupyter labextension install --no-build",
+    "lab:uninstall": "jupyter labextension uninstall --no-build"
   },
   "dependencies": {
     "@elyra/script-editor": "^2.3.0-dev",

--- a/packages/r-editor/package.json
+++ b/packages/r-editor/package.json
@@ -29,7 +29,9 @@
     "clean": "rimraf lib",
     "dist": "npm pack .",
     "prepare": "npm run build",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "lab:install": "jupyter labextension install --no-build",
+    "lab:uninstall": "jupyter labextension uninstall --no-build"
   },
   "dependencies": {
     "@elyra/script-editor": "^2.3.0-dev",

--- a/packages/script-editor/package.json
+++ b/packages/script-editor/package.json
@@ -28,7 +28,9 @@
     "clean": "rimraf lib",
     "dist": "npm pack .",
     "prepare": "npm run build",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "lab:install": "jupyter labextension link --no-build",
+    "lab:uninstall": "jupyter labextension unlink --no-build"
   },
   "dependencies": {
     "@elyra/ui-components": "^2.3.0-dev",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -30,7 +30,9 @@
     "dist": "npm pack .",
     "prepare": "npm run build",
     "test": "jest",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "lab:install": "jupyter labextension link --no-build",
+    "lab:uninstall": "jupyter labextension unlink --no-build"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^3.0.0",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -29,7 +29,9 @@
     "clean": "rimraf lib",
     "dist": "npm pack .",
     "prepare": "npm run build",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "lab:install": "jupyter labextension install --no-build",
+    "lab:uninstall": "jupyter labextension uninstall --no-build"
   },
   "dependencies": {
     "@elyra/ui-components": "^2.3.0-dev",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -28,7 +28,9 @@
     "clean": "rimraf lib",
     "dist": "npm pack .",
     "prepare": "npm run build",
-    "watch": "tsc -w"
+    "watch": "tsc -w",
+    "lab:install": "jupyter labextension link --no-build",
+    "lab:uninstall": "jupyter labextension unlink --no-build"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^3.0.0",


### PR DESCRIPTION
This PR update CI to:
- cache yarn dependencies (I tried caching pip but it didn't really make a difference)
- parallelize validation tasks (linting server, testing server, linting UI, testing UI, and integration tests can all run independently)

<img width="1792" alt="Screen Shot 2021-05-21 at 12 46 01 PM" src="https://user-images.githubusercontent.com/4212769/119171427-9112ed80-ba32-11eb-8b2a-65dfe99c4e61.png">

I was going to update this to be one make target per step, but most steps are just a single command.

@lresende should I create make targets for all of these or any other suggestions?

A couple other questions:

- What does "Build Documentation" do? Should we rename it to "Validate Documentation Build" or something?
- Do I need to run `python -m pip install --upgrade pip` before every pip install?
- What is the difference between `python setup.py bdist_wheel sdist && pip install dist/elyra-*-py3-none-any.whl` and `pip install .`
- Why does not using `--use-deprecated=legacy-resolver` take infinity years to install?

<!--
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
-->