### PR TITLE
Fix script editor output prompt alignment

### DIFF
--- a/packages/script-editor/style/index.css
+++ b/packages/script-editor/style/index.css
@@ -26,8 +26,8 @@
 .elyra-ScriptEditor-OutputArea-prompt {
   flex: 0 0 37px;
   border-right: 1px solid var(--jp-border-color2);
-  padding: unset;
-  text-align: center;
+  display: flex;
+  justify-content: center;
 }
 
 .elyra-ScriptEditor-OutputArea-output {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adjusts the misalignment of the script editor's output prompt , as shown below before changes:
![image](https://user-images.githubusercontent.com/25207344/118889051-88070c80-b8ca-11eb-9700-66265762e61d.png)

After changes:
![image](https://user-images.githubusercontent.com/25207344/118889074-8f2e1a80-b8ca-11eb-94c0-c5472fd39f66.png)

### How was this pull request tested?
Manual tests with one + multiple output lines.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
