### PR TITLE
Add R kernel installation to clean script

### DIFF
--- a/docs/source/developer_guide/development-workflow.md
+++ b/docs/source/developer_guide/development-workflow.md
@@ -102,12 +102,12 @@ You can build and install all Elyra packages with:
 make clean install
 ```
 
-You can check that the notebook server extension was successful installed with:
+You can check that the notebook server extension was successfully installed with:
 ```bash
 jupyter serverextension list
 ```
 
-You can check that the JupyterLab extension was successful installed with:
+You can check that the JupyterLab extension was successfully installed with:
 ```bash
 jupyter labextension list
 ```

--- a/docs/source/user_guide/enhanced-script-support.md
+++ b/docs/source/user_guide/enhanced-script-support.md
@@ -63,7 +63,7 @@ then enable it on Jupyter:
 > IRkernel::installspec()
 ```
 
-You can check that the R kernel was successful installed with:
+You can check that the R kernel was successfully installed with:
 ```bash
 jupyter kernelspec list
 ```

--- a/docs/source/user_guide/enhanced-script-support.md
+++ b/docs/source/user_guide/enhanced-script-support.md
@@ -33,7 +33,7 @@ In the JupyterLab Launcher, click the `Python Editor` icon to create a new Pytho
 
 ![Open Python Editor](../images/launcher-python-editor.png)
 
-When used in conjunction with `Jupyter Enterprise Gateway`, the dropdown will be populated with more kernel options,
+When used in conjunction with `Jupyter Enterprise Gateway`, the dropdown in the editor's toolbar will be populated with more kernel options,
 allowing users to run their scripts with remote kernels with more specialized resources.
 
 To run your script locally, select the `Python 3` option in the dropdown menu, and click the `Run` icon.
@@ -55,12 +55,17 @@ Alternatively, you can install it via [CRAN](https://cran.r-project.org/) on an 
 NOTE: You will need to have R installed and available prior to using this method of installing the R kernel.
 
 In an R interactive console,
-```
+```bash
 > install.packages('IRkernel')
 ```
 then enable it on Jupyter:
-```
+```bash
 > IRkernel::installspec()
+```
+
+You can check that the R kernel was successful installed with:
+```bash
+jupyter kernelspec list
 ```
 
 To run the script, from the Script editor toolbar, select the `R` option in the kernel selection drop-down, and click the `Run` icon.

--- a/etc/scripts/clean-jupyterlab.sh
+++ b/etc/scripts/clean-jupyterlab.sh
@@ -57,7 +57,8 @@ echo " "
 set -e
 echo "Uninstalling old packages and kernels"
 conda uninstall -y xeus-python -c conda-forge || true;
-conda uninstall -y r-irkernel || true;
+conda uninstall -y r r-essentials r-irkernel || true;
+conda uninstall -y r-languageserver -c conda-forge || true;
 pip uninstall -y elyra || true;
 pip uninstall -y jupyterlab-git || true;
 pip uninstall -y jupyterlab-server || true;
@@ -90,8 +91,9 @@ else
 fi
 echo " "
 
-echo "Installing R kernel"
-conda install -y r-irkernel
+echo "Installing R kernel and language server"
+conda install -y r r-essentials r-irkernel
+conda install -y -c conda-forge r-languageserver
 echo " "
 
 jupyter --version

--- a/etc/scripts/clean-jupyterlab.sh
+++ b/etc/scripts/clean-jupyterlab.sh
@@ -55,8 +55,9 @@ echo "Anaconda env......: $CONDA_DEFAULT_ENV"
 echo " "
 
 set -e
-echo "Uninstalling old packages"
+echo "Uninstalling old packages and kernels"
 conda uninstall -y xeus-python -c conda-forge || true;
+conda uninstall -y r-irkernel || true;
 pip uninstall -y elyra || true;
 pip uninstall -y jupyterlab-git || true;
 pip uninstall -y jupyterlab-server || true;
@@ -89,7 +90,13 @@ else
 fi
 echo " "
 
+echo "Installing R kernel"
+conda install -y r-irkernel
+echo " "
+
 jupyter --version
+echo " "
+jupyter kernelspec list
 echo " "
 jupyter serverextension list
 echo " "


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR
- Adds install/uninstall commands to `clean-jupyterlab.sh` script for the packages 
`r r-essentials r-irkernel r-languageserver`, in order to help dev environment setup
- Updates documentation for r script support and dev workflow

### How was this pull request tested?
Manual testing:
- Run `clean-jupyterlab.sh` script, make sure R kernel is installed and listed in the logs.
- Open R editor + notebook and make sure R kernel  and R language server are available.
- Execute R scripts from notebook and R editor.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
