### PR TITLE
Add indicator for runtime in toolbar

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -27,7 +27,9 @@ import {
   runtimesIcon,
   Dropzone,
   RequestErrors,
-  showFormDialog
+  showFormDialog,
+  kubeflowIcon,
+  airflowIcon
 } from '@elyra/ui-components';
 import { ILabShell } from '@jupyterlab/application';
 import { Dialog, ReactWidget, showDialog } from '@jupyterlab/apputils';
@@ -130,6 +132,7 @@ const PipelineWrapper: React.FC<IProps> = ({
   const [panelOpen, setPanelOpen] = React.useState(false);
   const [alert, setAlert] = React.useState(null);
   const [updatedNodes, setUpdatedNodes] = React.useState(nodes);
+  const pipelineRuntime = pipeline?.pipelines?.[0]?.app_data?.ui_data?.runtime;
 
   const contextRef = useRef(context);
   useEffect(() => {
@@ -340,8 +343,6 @@ const PipelineWrapper: React.FC<IProps> = ({
       RequestErrors.serverError(error)
     );
 
-    const pipelineRuntime =
-      pipeline?.pipelines?.[0]?.app_data?.ui_data?.runtime;
     let title = 'Export pipeline';
     if (pipelineRuntime) {
       title = `Export pipeline for ${pipelineRuntime.display_name}`;
@@ -492,8 +493,6 @@ const PipelineWrapper: React.FC<IProps> = ({
     schema.unshift(JSON.parse(JSON.stringify(localSchema)));
 
     let title = 'Run pipeline';
-    const pipelineRuntime =
-      pipeline?.pipelines?.[0]?.app_data?.ui_data?.runtime;
     if (pipelineRuntime) {
       title = `Run pipeline on ${pipelineRuntime.display_name}`;
       const filteredRuntimeOptions = PipelineService.filterRuntimes(
@@ -680,6 +679,21 @@ const PipelineWrapper: React.FC<IProps> = ({
       }
     ],
     rightBar: [
+      {
+        action: '',
+        label: `Runtime: ${pipelineRuntime?.display_name ?? 'Generic'}`,
+        incLabelWithIcon: 'before',
+        enable: false,
+        kind: 'tertiary',
+        // TODO: use getRuntimeIcon
+        iconEnabled: IconUtil.encode(
+          pipelineRuntime?.name === 'kfp'
+            ? kubeflowIcon
+            : pipelineRuntime?.name === 'airflow'
+            ? airflowIcon
+            : pipelineIcon
+        )
+      },
       {
         action: 'toggleOpenPanel',
         label: 'Open panel',

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -433,7 +433,7 @@ const PipelineWrapper: React.FC<IProps> = ({
       pipelineJson.pipelines[0],
       contextRef.current.path
     );
-  }, [context.model, cleanNullProperties, shell, pipeline?.pipelines]);
+  }, [context.model, pipelineRuntime, cleanNullProperties, shell]);
 
   const handleRunPipeline = useCallback(async (): Promise<void> => {
     const pipelineJson: any = context.model.toJSON();
@@ -568,7 +568,7 @@ const PipelineWrapper: React.FC<IProps> = ({
       pipelineJson.pipelines[0],
       contextRef.current.path
     );
-  }, [context.model, cleanNullProperties, shell, pipeline?.pipelines]);
+  }, [context.model, pipelineRuntime, cleanNullProperties, shell]);
 
   const handleClearPipeline = useCallback(async (data: any): Promise<any> => {
     return showDialog({

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -683,6 +683,14 @@ input.elyra-Dialog-checkbox.jp-mod-styled {
   margin-left: 5px;
 }
 
+.elyra-PipelineEditor .toolbar-item.tertiary button:disabled,
+.elyra-PipelineEditor .toolbar-item.tertiary button:disabled:hover {
+  background-color: var(--jp-border-color2);
+  color: var(--jp-content-font-color1);
+  border: none;
+  cursor: initial;
+}
+
 /* fix font ligatures */
 .lsp-completer-theme-vscode {
   letter-spacing: normal;


### PR DESCRIPTION
Fixes #1680. 
Generic pipeline:
![image](https://user-images.githubusercontent.com/6673460/119039283-b09a0f80-b979-11eb-9d98-6b1330aed0dc.png)
![image](https://user-images.githubusercontent.com/6673460/119039311-bb54a480-b979-11eb-8c3b-863fe9b4efa1.png)
![image](https://user-images.githubusercontent.com/6673460/119039331-c0b1ef00-b979-11eb-9de0-2d081e2ddf42.png)

Cursor and style are the same when hovering over the button. 
 
**Note**: There is a TODO comment because #1620 will introduce a function that provides a runtime icon given a runtime name, so if this gets merged before that it'll be good to rebase that PR and use that function instead. 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
