### PR TITLE
Set system-owned envs after user-provided envs

### DIFF
--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -141,7 +141,7 @@ class Operation(object):
         """
         Operation stores environment variables in a list of name=value pairs, while
         subprocess.run() requires a dictionary - so we must convert.  If no envs are
-        configured on the Operation, an empty dictionary is return, otherwise envs
+        configured on the Operation, an empty dictionary is returned, otherwise envs
         configured on the Operation are converted to dictionary entries and returned.
         """
         envs = {}

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -141,8 +141,8 @@ class Operation(object):
         """
         Operation stores environment variables in a list of name=value pairs, while
         subprocess.run() requires a dictionary - so we must convert.  If no envs are
-        configured on the Operation, the existing env is returned, otherwise envs
-        configured on the Operation are overlayed on the existing env.
+        configured on the Operation, an empty dictionary is return, otherwise envs
+        configured on the Operation are converted to dictionary entries and returned.
         """
         envs = {}
         for nv in self.env_vars:
@@ -150,11 +150,10 @@ class Operation(object):
                 nv_pair = nv.split("=")
                 if len(nv_pair) == 2 and nv_pair[0].strip():
                     envs[nv_pair[0]] = nv_pair[1]
+                elif logger:
+                    logger.warning(f"Could not process environment variable entry `{nv}`, skipping...")
                 else:
-                    if logger:
-                        logger.warning(f"Could not process environment variable entry `{nv}`, skipping...")
-                    else:
-                        print(f"Could not process environment variable entry `{nv}`, skipping...")
+                    print(f"Could not process environment variable entry `{nv}`, skipping...")
         return envs
 
     @property

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -146,15 +146,33 @@ class Operation(object):
         """
         envs = {}
         for nv in self.env_vars:
-            if nv and len(nv) > 0:
-                nv_pair = nv.split("=")
+            if nv:
+                nv_pair = nv.split("=", 1)
                 if len(nv_pair) == 2 and nv_pair[0].strip():
-                    envs[nv_pair[0]] = nv_pair[1]
-                elif logger:
-                    logger.warning(f"Could not process environment variable entry `{nv}`, skipping...")
+                    if len(nv_pair[1]) > 0:
+                        envs[nv_pair[0]] = nv_pair[1]
+                    else:
+                        Operation._log_info(f"Skipping inclusion of environment variable: "
+                                            f"`{nv_pair[0]}` has no value...",
+                                            logger=logger)
                 else:
-                    print(f"Could not process environment variable entry `{nv}`, skipping...")
+                    Operation._log_warning(f"Could not process environment variable entry `{nv}`, skipping...",
+                                           logger=logger)
         return envs
+
+    @staticmethod
+    def _log_info(msg: str, logger: Optional[Logger] = None):
+        if logger:
+            logger.info(msg)
+        else:
+            print(msg)
+
+    @staticmethod
+    def _log_warning(msg: str, logger: Optional[Logger] = None):
+        if logger:
+            logger.warning(msg)
+        else:
+            print(f"WARNING: {msg}")
 
     @property
     def inputs(self):

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -337,6 +337,9 @@ class RuntimePipelineProcess(PipelineProcessor):
         if 'cos_secret' not in kwargs or not kwargs['cos_secret']:
             envs['AWS_ACCESS_KEY_ID'] = kwargs['cos_username']
             envs['AWS_SECRET_ACCESS_KEY'] = kwargs['cos_password']
+        else:  # ensure the "access-key" envs are NOT present...
+            envs.pop('AWS_ACCESS_KEY_ID', None)
+            envs.pop('AWS_SECRET_ACCESS_KEY', None)
 
         # Convey pipeline logging enablement to operation
         envs['ELYRA_ENABLE_PIPELINE_INFO'] = str(self.enable_pipeline_info)

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -420,9 +420,6 @@ class KfpPipelineProcessor(RuntimePipelineProcess):
                                                cos_username=cos_username,
                                                cos_password=cos_password)
 
-            # Include any envs set on the operation
-            pipeline_envs.update(operation.env_vars_as_dict(logger=self.log))
-
             sanitized_operation_name = self._sanitize_operation_name(operation.name)
 
             # create pipeline operation

--- a/elyra/pipeline/processor_local.py
+++ b/elyra/pipeline/processor_local.py
@@ -118,8 +118,8 @@ class OperationProcessor(ABC):
     @staticmethod
     def _collect_envs(operation: Operation) -> Dict:
         envs = os.environ.copy()  # Make sure this process's env is "available" in the kernel subprocess
-        envs['ELYRA_RUNTIME_ENV'] = "local"  # Special case
         envs.update(operation.env_vars_as_dict())
+        envs['ELYRA_RUNTIME_ENV'] = "local"  # Special case
         return envs
 
 

--- a/elyra/pipeline/tests/resources/node_util/node.ipynb
+++ b/elyra/pipeline/tests/resources/node_util/node.ipynb
@@ -24,6 +24,7 @@
     "os.getenv(\"NODE_FILENAME\")\n",
     "os.getenv(\"INPUT_FILENAMES\")\n",
     "os.getenv(\"OUTPUT_FILENAMES\")\n",
+    "os.getenv(\"ELYRA_RUNTIME_ENV\")\n",
     "# Execute the node\n",
     "NotebookNode().run()"
    ]

--- a/elyra/pipeline/tests/resources/node_util/node.py
+++ b/elyra/pipeline/tests/resources/node_util/node.py
@@ -39,5 +39,6 @@ from node_util import PythonNode
 os.getenv("NODE_FILENAME")
 os.getenv("INPUT_FILENAMES")
 os.getenv("OUTPUT_FILENAMES")
+os.getenv("ELYRA_RUNTIME_ENV")
 # Execute the node
 PythonNode().run()

--- a/elyra/pipeline/tests/test_airflow_processor.py
+++ b/elyra/pipeline/tests/test_airflow_processor.py
@@ -302,11 +302,18 @@ def test_pipeline_tree_creation(parsed_ordered_dict, sample_metadata, sample_ima
 def test_collect_envs(processor):
     pipelines_test_file = 'elyra/pipeline/tests/resources/archive/test.ipynb'
 
+    # add system-owned envs with bogus values to ensure they get set to system-derived values
+    system_owned_envs = ['ELYRA_RUNTIME_ENV="bogus_runtime"',
+                         'ELYRA_ENABLE_PIPELINE_INFO="bogus_pipeline"',
+                         'AWS_ACCESS_KEY_ID="bogus_key"',
+                         'AWS_SECRET_ACCESS_KEY="bogus_secret"']
+
     test_operation = Operation(id='this-is-a-test-id',
                                type='execution-node',
                                classifier='airflow',
                                name='test',
                                filename=pipelines_test_file,
+                               env_vars=system_owned_envs,
                                runtime_image='tensorflow/tensorflow:latest')
 
     envs = processor._collect_envs(test_operation, cos_secret=None, cos_username='Alice', cos_password='secret')

--- a/elyra/pipeline/tests/test_airflow_processor.py
+++ b/elyra/pipeline/tests/test_airflow_processor.py
@@ -302,18 +302,23 @@ def test_pipeline_tree_creation(parsed_ordered_dict, sample_metadata, sample_ima
 def test_collect_envs(processor):
     pipelines_test_file = 'elyra/pipeline/tests/resources/archive/test.ipynb'
 
-    # add system-owned envs with bogus values to ensure they get set to system-derived values
-    system_owned_envs = ['ELYRA_RUNTIME_ENV="bogus_runtime"',
-                         'ELYRA_ENABLE_PIPELINE_INFO="bogus_pipeline"',
-                         'AWS_ACCESS_KEY_ID="bogus_key"',
-                         'AWS_SECRET_ACCESS_KEY="bogus_secret"']
+    # add system-owned envs with bogus values to ensure they get set to system-derived values,
+    # and include some user-provided edge cases
+    operation_envs = ['ELYRA_RUNTIME_ENV="bogus_runtime"',
+                      'ELYRA_ENABLE_PIPELINE_INFO="bogus_pipeline"',
+                      'ELYRA_WRITABLE_CONTAINER_DIR=',  # simulate operation reference in pipeline
+                      'AWS_ACCESS_KEY_ID="bogus_key"',
+                      'AWS_SECRET_ACCESS_KEY="bogus_secret"',
+                      'USER_EMPTY_VALUE=  ',
+                      'USER_TWO_EQUALS=KEY=value',
+                      'USER_NO_VALUE=']
 
     test_operation = Operation(id='this-is-a-test-id',
                                type='execution-node',
                                classifier='airflow',
                                name='test',
                                filename=pipelines_test_file,
-                               env_vars=system_owned_envs,
+                               env_vars=operation_envs,
                                runtime_image='tensorflow/tensorflow:latest')
 
     envs = processor._collect_envs(test_operation, cos_secret=None, cos_username='Alice', cos_password='secret')
@@ -323,6 +328,9 @@ def test_collect_envs(processor):
     assert envs['AWS_SECRET_ACCESS_KEY'] == 'secret'
     assert envs['ELYRA_ENABLE_PIPELINE_INFO'] == 'True'
     assert 'ELYRA_WRITABLE_CONTAINER_DIR' not in envs
+    assert envs['USER_EMPTY_VALUE'] == '  '
+    assert envs['USER_TWO_EQUALS'] == 'KEY=value'
+    assert 'USER_NO_VALUE' not in envs
 
     # Repeat with non-None secret - ensure user and password envs are not present, but others are
     envs = processor._collect_envs(test_operation, cos_secret='secret', cos_username='Alice', cos_password='secret')
@@ -332,3 +340,6 @@ def test_collect_envs(processor):
     assert 'AWS_SECRET_ACCESS_KEY' not in envs
     assert envs['ELYRA_ENABLE_PIPELINE_INFO'] == 'True'
     assert 'ELYRA_WRITABLE_CONTAINER_DIR' not in envs
+    assert envs['USER_EMPTY_VALUE'] == '  '
+    assert envs['USER_TWO_EQUALS'] == 'KEY=value'
+    assert 'USER_NO_VALUE' not in envs

--- a/elyra/pipeline/tests/test_kfp_processor.py
+++ b/elyra/pipeline/tests/test_kfp_processor.py
@@ -117,19 +117,23 @@ def test_get_dependency_archive_name(processor):
 def test_collect_envs(processor):
     pipelines_test_file = 'elyra/pipeline/tests/resources/archive/test.ipynb'
 
-    # add system-owned envs with bogus values to ensure they get set to system-derived values
-    system_owned_envs = ['ELYRA_RUNTIME_ENV="bogus_runtime"',
-                         'ELYRA_ENABLE_PIPELINE_INFO="bogus_pipeline"',
-                         'ELYRA_WRITABLE_CONTAINER_DIR=""',  # simulate operation reference in pipeline
-                         'AWS_ACCESS_KEY_ID="bogus_key"',
-                         'AWS_SECRET_ACCESS_KEY="bogus_secret"']
+    # add system-owned envs with bogus values to ensure they get set to system-derived values,
+    # and include some user-provided edge cases
+    operation_envs = ['ELYRA_RUNTIME_ENV="bogus_runtime"',
+                      'ELYRA_ENABLE_PIPELINE_INFO="bogus_pipeline"',
+                      'ELYRA_WRITABLE_CONTAINER_DIR=',  # simulate operation reference in pipeline
+                      'AWS_ACCESS_KEY_ID="bogus_key"',
+                      'AWS_SECRET_ACCESS_KEY="bogus_secret"',
+                      'USER_EMPTY_VALUE=  ',
+                      'USER_TWO_EQUALS=KEY=value',
+                      'USER_NO_VALUE=']
 
     test_operation = Op(id='this-is-a-test-id',
                         type='execution-node',
                         classifier='kfp',
                         name='test',
                         filename=pipelines_test_file,
-                        env_vars=system_owned_envs,
+                        env_vars=operation_envs,
                         runtime_image='tensorflow/tensorflow:latest')
 
     envs = processor._collect_envs(test_operation, cos_secret=None, cos_username='Alice', cos_password='secret')
@@ -139,8 +143,12 @@ def test_collect_envs(processor):
     assert envs['AWS_SECRET_ACCESS_KEY'] == 'secret'
     assert envs['ELYRA_ENABLE_PIPELINE_INFO'] == 'True'
     assert envs['ELYRA_WRITABLE_CONTAINER_DIR'] == '/tmp'
+    assert envs['USER_EMPTY_VALUE'] == '  '
+    assert envs['USER_TWO_EQUALS'] == 'KEY=value'
+    assert 'USER_NO_VALUE' not in envs
 
-    # Repeat with non-None secret - ensure user and password envs are not present, but others are
+
+# Repeat with non-None secret - ensure user and password envs are not present, but others are
     envs = processor._collect_envs(test_operation, cos_secret='secret', cos_username='Alice', cos_password='secret')
 
     assert envs['ELYRA_RUNTIME_ENV'] == 'kfp'
@@ -148,3 +156,6 @@ def test_collect_envs(processor):
     assert 'AWS_SECRET_ACCESS_KEY' not in envs
     assert envs['ELYRA_ENABLE_PIPELINE_INFO'] == 'True'
     assert envs['ELYRA_WRITABLE_CONTAINER_DIR'] == '/tmp'
+    assert envs['USER_EMPTY_VALUE'] == '  '
+    assert envs['USER_TWO_EQUALS'] == 'KEY=value'
+    assert 'USER_NO_VALUE' not in envs

--- a/elyra/pipeline/tests/test_kfp_processor.py
+++ b/elyra/pipeline/tests/test_kfp_processor.py
@@ -117,11 +117,19 @@ def test_get_dependency_archive_name(processor):
 def test_collect_envs(processor):
     pipelines_test_file = 'elyra/pipeline/tests/resources/archive/test.ipynb'
 
+    # add system-owned envs with bogus values to ensure they get set to system-derived values
+    system_owned_envs = ['ELYRA_RUNTIME_ENV="bogus_runtime"',
+                         'ELYRA_ENABLE_PIPELINE_INFO="bogus_pipeline"',
+                         'ELYRA_WRITABLE_CONTAINER_DIR=""',  # simulate operation reference in pipeline
+                         'AWS_ACCESS_KEY_ID="bogus_key"',
+                         'AWS_SECRET_ACCESS_KEY="bogus_secret"']
+
     test_operation = Op(id='this-is-a-test-id',
                         type='execution-node',
                         classifier='kfp',
                         name='test',
                         filename=pipelines_test_file,
+                        env_vars=system_owned_envs,
                         runtime_image='tensorflow/tensorflow:latest')
 
     envs = processor._collect_envs(test_operation, cos_secret=None, cos_username='Alice', cos_password='secret')

--- a/elyra/pipeline/tests/test_pipeline_constructor.py
+++ b/elyra/pipeline/tests/test_pipeline_constructor.py
@@ -280,8 +280,9 @@ def test_fail_pipelines_are_equal(good_pipeline):
 
 
 def test_env_list_to_dict_function():
-    env_variables = ['FOO=Bar', 'BAR=Foo', None, '', '  =Dog', 'DOG=  ']
-    env_variables_dict = {"FOO": "Bar", "BAR": "Foo", "DOG": "  "}
+    env_variables = ['KEY=value', None, '', '  =empty_key', '=no_key', 'EMPTY_VALUE=  ',
+                     'NO_VALUE=', 'KEY2=value2', 'TWO_EQUALS=KEY=value', '==']
+    env_variables_dict = {"KEY": "value", "KEY2": "value2", "EMPTY_VALUE": "  ", "TWO_EQUALS": "KEY=value"}
 
     test_operation = Operation(id='test-id',
                                type='test',

--- a/elyra/pipeline/tests/util.py
+++ b/elyra/pipeline/tests/util.py
@@ -79,6 +79,9 @@ class NodeBase(object):
         if self.outputs:
             self.env_vars.append(f"OUTPUT_FILENAMES={';'.join(self.outputs)}")
 
+        # Add system-owned here with bogus or no value...
+        self.env_vars.append("ELYRA_RUNTIME_ENV=bogus_runtime")
+
         return Operation(self.id, 'execution_node', self.name, self.classifier, self.filename, self.image_name or "NA",
                          dependencies=self.dependencies, env_vars=self.env_vars,
                          inputs=self.inputs, outputs=self.outputs,


### PR DESCRIPTION
The changes introduced in #1668 to indicate the runtime name within an operation failed when an operation referenced `ELYRA_RUNTIME_ENV` on KFP and Local runtimes (Airflow was fine).  This corrects those issues and addresses test cases to better handle that scenario - since that _is_ the use case that is being addressed.

### How was this pull request tested?
Extended the tests to include cases where the system-owned variables are set in the operation to ensure the system values are properly reflected.  Ran a test against KFP since the unit tests test this functionality at a lower level for the Kfp and Airflow processors.  (The local test can address this since it includes an end-to-end operation.)

Fixes: #1696

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
