### PR TITLE
Add make graph generation script

### DIFF
--- a/etc/scripts/generate-make-graph.ts
+++ b/etc/scripts/generate-make-graph.ts
@@ -20,7 +20,7 @@ import path from 'path';
 
 import chalk from 'chalk';
 
-const makeDir = path.join(__dirname, '..');
+const makeDir = path.join(__dirname, '..', '..');
 
 const cmd = process.argv[2];
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     ]
   },
   "scripts": {
+    "graph": "ts-node scripts/generate-make-graph.ts",
     "cy:open": "npx cypress open",
     "cy:run": "npx cypress run",
     "eslint": "eslint . --fix --ignore-path .gitignore --ext .ts,.tsx,.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     ]
   },
   "scripts": {
-    "graph": "ts-node scripts/generate-make-graph.ts",
+    "graph": "ts-node etc/scripts/generate-make-graph.ts",
     "cy:open": "npx cypress open",
     "cy:run": "npx cypress run",
     "eslint": "eslint . --fix --ignore-path .gitignore --ext .ts,.tsx,.js",

--- a/scripts/generate-make-graph.ts
+++ b/scripts/generate-make-graph.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018-2021 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { spawn } from 'child_process';
+
+import path from 'path';
+
+import chalk from 'chalk';
+
+const makeDir = path.join(__dirname, '..');
+
+const cmd = process.argv[2];
+
+const make = spawn('make', [cmd, '-Bnd'], { cwd: makeDir });
+
+interface ITarget {
+  type: 'target';
+  name: string;
+  depth: number;
+}
+
+interface ICode {
+  type: 'code';
+  value: string;
+  depth: number;
+}
+
+interface IEnd {
+  type: 'end';
+  depth: number;
+}
+
+const graph: (ITarget | ICode | IEnd)[] = [];
+
+let depth: number | undefined = undefined;
+
+make.stdout.on('data', (data: Buffer) => {
+  const msgs = data.toString().split('\n');
+  for (const msg of msgs) {
+    if (msg === '') {
+      continue;
+    }
+
+    if (msg.includes('Considering target file')) {
+      const [depthString, rest] = msg.split('Considering target file `');
+      const [name] = rest.split("'.");
+      if (name === 'Makefile') {
+        continue;
+      }
+      graph.push({
+        type: 'target',
+        name,
+        depth: depthString.length / 2
+      });
+      continue;
+    }
+
+    if (msg.includes('Must remake target')) {
+      const [depthString] = msg.split('Must remake target `');
+      depth = depthString.length / 2;
+      continue;
+    }
+
+    if (msg.includes('Successfully remade target file')) {
+      const [depthString] = msg.split('Successfully remade target file `');
+      depth = depthString.length / 2;
+      graph.push({
+        type: 'end',
+        depth
+      });
+      depth = undefined;
+      continue;
+    }
+
+    if (depth !== undefined) {
+      graph.push({
+        type: 'code',
+        value: msg.toString(),
+        depth
+      });
+      continue;
+    }
+  }
+});
+
+const MAX_WIDTH = 120;
+const printGraph = (): void => {
+  for (const g of graph) {
+    const padLeft = '│ '.repeat(g.depth);
+    const padRight = ' │'.repeat(g.depth);
+    const cellWidth = MAX_WIDTH - (padLeft.length + padRight.length + 4);
+    const bar = '─'.repeat(cellWidth);
+    if (g.type === 'target') {
+      const spacer = ' '.repeat(cellWidth - g.name.length - 2);
+      console.log(`${padLeft}┌${bar}┐${padRight}`);
+      console.log(
+        `${padLeft}│ ${chalk.cyan.bold(g.name)}${spacer} |${padRight}`
+      );
+      continue;
+    }
+
+    if (g.type === 'code') {
+      let value = g.value;
+      if (value.length > cellWidth + 2) {
+        value = value.slice(0, cellWidth - 5) + '...';
+      }
+      const spacer = ' '.repeat(Math.max(0, cellWidth - value.length - 2));
+      console.log(`${padLeft}│ ${value}${spacer} |${padRight}`);
+      continue;
+    }
+
+    if (g.type === 'end') {
+      console.log(`${padLeft}└${bar}┘${padRight}`);
+      continue;
+    }
+  }
+};
+
+make.stdout.on('end', () => {
+  printGraph();
+});


### PR DESCRIPTION
Since the handmade graph of the makefile targets seemed useful, I quickly made a script that generates something similar:

![image](https://user-images.githubusercontent.com/4212769/119707235-ea12c500-be28-11eb-93a7-6791fd09d8bf.png)


Usage:
```
yarn graph <make-target>
```

Example:
```
yarn graph install
```

(I'm not sure how to pass arguments with `make` to do something like `make graph install` )

<!-- 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
-->