### PR TITLE
Move note on pip version to top of pip section

### DIFF
--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -35,6 +35,8 @@ The instructions below are installing the latest release.
 
 ### pip
 
+**NOTE:** On November 2020, a new version of PIP (20.3) was released with a new, "2020" resolver. This resolver does not yet work with Elyra and might lead to errors in installation. In order to install Elyra, you need to either downgrade pip to version 20.2.4 `pip install --upgrade pip==20.2.4` or, in case you use pip 20.3 (or later), you need to add option `--use-deprecated legacy-resolver` to your pip install command.
+
 If you use `pip`, install Elyra with:
 
 ```bash
@@ -68,9 +70,6 @@ If desired, you can install these Elyra extensions independently:
    ```bash
    pip install --upgrade elyra-r-editor-extension && jupyter lab build
    ```
-
-**NOTE:** On November 2020, a new version of PIP (20.3) was released with a new, "2020" resolver. This resolver does not yet work with Elyra and might lead to errors in installation. In order to install Elyra, you need to either downgrade pip to version 20.2.4 `pip install --upgrade pip==20.2.4` or, in case you use pip 20.3 (or later), you need to add option `--use-deprecated legacy-resolver` to your pip install command.
-
 
 ### conda
 


### PR DESCRIPTION
While installing Elyra using the installation instructions, I encountered the issue on pip version (which is found towards the end of the section on installation using pip) so it might be better to put the note on the pip version at the top. I merely changed the location of the "NOTE". Also, this is my introductory contribution. Thanks!
