### PR TITLE
Remove KFP Python DSL export option as temporary workaround

### DIFF
--- a/packages/pipeline-editor/src/PipelineExportDialog.tsx
+++ b/packages/pipeline-editor/src/PipelineExportDialog.tsx
@@ -75,6 +75,7 @@ export class PipelineExportDialog extends React.Component<IProps, IState> {
       return new Array<Record<string, string>>();
     } else if (platformSelection === KFP_SCHEMA) {
       // TODO: remove temporary workaround for KFP Python DSL export option
+      // See https://github.com/elyra-ai/elyra/issues/1760 for context.
       if (this.props.runtime === KFP_SCHEMA) {
         return [KFP_FILE_TYPES[1]];
       }

--- a/packages/pipeline-editor/src/PipelineExportDialog.tsx
+++ b/packages/pipeline-editor/src/PipelineExportDialog.tsx
@@ -24,7 +24,7 @@ import {
 } from './PipelineService';
 
 const KFP_FILE_TYPES = [
-  // { label: 'KFP domain-specific language Python code', key: 'py' },
+  { label: 'KFP domain-specific language Python code', key: 'py' },
   { label: 'KFP static configuration file (YAML formatted)', key: 'yaml' }
 ];
 
@@ -74,6 +74,10 @@ export class PipelineExportDialog extends React.Component<IProps, IState> {
     if (!platformSelection) {
       return new Array<Record<string, string>>();
     } else if (platformSelection === KFP_SCHEMA) {
+      // TODO: remove temporary workaround for KFP Python DSL export option
+      if (this.props.runtime === KFP_SCHEMA) {
+        return [KFP_FILE_TYPES[1]];
+      }
       return KFP_FILE_TYPES;
     }
     return AIRFLOW_FILE_TYPES;

--- a/packages/pipeline-editor/src/PipelineExportDialog.tsx
+++ b/packages/pipeline-editor/src/PipelineExportDialog.tsx
@@ -24,7 +24,7 @@ import {
 } from './PipelineService';
 
 const KFP_FILE_TYPES = [
-  { label: 'KFP domain-specific language Python code', key: 'py' },
+  // { label: 'KFP domain-specific language Python code', key: 'py' },
   { label: 'KFP static configuration file (YAML formatted)', key: 'yaml' }
 ];
 


### PR DESCRIPTION
This would be a temporary workaround for #1756 and #1760. More discussion needed.

### What changes were proposed in this pull request?
EDITED: It removes the option to export a KFP pipeline in Python DSL format **in Kubeflow specific pipelines** to avoid errors such as those encountered in the above-mentioned issues. 

Kubeflow Pipeline export dialog
Before:
<img width="394" alt="Screen Shot 2021-06-15 at 1 38 10 PM" src="https://user-images.githubusercontent.com/31816267/122105959-f615f500-cdde-11eb-8f4c-3c8222440082.png">

After:
<img width="391" alt="Screen Shot 2021-06-15 at 1 37 59 PM" src="https://user-images.githubusercontent.com/31816267/122105982-fa421280-cdde-11eb-89c1-6f3636d612f1.png">

Generic Pipeline export dialog remains the same:
![image](https://user-images.githubusercontent.com/25207344/122279847-85daa280-ceb6-11eb-8f77-586b9739ccba.png)


### How was this pull request tested?
Tests not added due to the temporary nature of this PR.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
