### PR TITLE
Do not show iconLabel in Palette

### DIFF
--- a/packages/pipeline-editor/src/index.ts
+++ b/packages/pipeline-editor/src/index.ts
@@ -165,7 +165,9 @@ const extension: JupyterFrontEndPlugin<void> = {
           ? `${args.runtime?.display_name} Pipeline Editor`
           : 'Generic Pipeline Editor',
       iconLabel: (args: any) =>
-        args.runtime?.display_name
+        args['isPalette']
+          ? ''
+          : args.runtime?.display_name
           ? `${args.runtime?.display_name} Pipeline Editor`
           : 'Generic Pipeline Editor',
       icon: (args: any) => {


### PR DESCRIPTION
When an icon is undefined for a command it uses the iconLabel.

The icon is intentionally undefined for the palette though and the
iconLabel should also not be used.

Fixes #1763

### How was this pull request tested?

Tested manually
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
