### PR TITLE
Change casting of dictionary values to use literal_eval instead in pipeline/parser.py

### DIFF
--- a/elyra/pipeline/parser.py
+++ b/elyra/pipeline/parser.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import ast
 import json
 from traitlets.config import LoggingConfigurable
 from typing import Any, Dict, List, Optional
@@ -272,7 +273,7 @@ class PipelineParser(LoggingConfigurable):
                     # display error
                     if "elyra_dict_" in key:
                         key = key.replace("elyra_dict_", "")
-                        value = dict(value)
+                        value = ast.literal_eval(value)
                     elif "elyra_int_" in key:
                         key = key.replace("elyra_int_", "")
                         value = int(value)


### PR DESCRIPTION
This is a followup to PR #1620 to fix a bug in handling dictionary values for Airflow parameters.

### What changes were proposed in this pull request?
In discussion with @ptitzler, it became clear that casting dictionary parameter values using `dict()` was not the correct way to handle this. A `literal_eval` is now used instead.

### How was this pull request tested?
The Airflow BashOperator was used to test the change where `bash_command` is set as `echo "here is the message: $message"` and `{"message":"hello"}` as the `env` value. The operation succeeded. A screenshot of log excerpt is below:

<img width="669" alt="Screen Shot 2021-06-15 at 4 06 52 PM" src="https://user-images.githubusercontent.com/31816267/122123550-b86f9700-cdf3-11eb-9cda-5429c53d36cd.png">

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
