### PR TITLE
Ensure MetadataManager.get() has a value for 'name'

### DIFF
--- a/elyra/metadata/manager.py
+++ b/elyra/metadata/manager.py
@@ -92,6 +92,8 @@ class MetadataManager(LoggingConfigurable):
 
     def get(self, name: str) -> Metadata:
         """Returns the metadata instance corresponding to the given name"""
+        if name is None:
+            raise ValueError("The 'name' parameter requires a value.")
         instance_list = self.metadata_store.fetch_instances(name=name)
         metadata_dict = instance_list[0]
         metadata = Metadata.from_dict(self.namespace, metadata_dict)

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -196,14 +196,9 @@ def test_manager_get_all(tests_manager):
 
 
 def test_manager_get_none(tests_manager, namespace_location):
-    # Delete the namespace contents and attempt listing metadata
-    _remove_namespace(tests_manager.metadata_store, namespace_location)
-    assert tests_manager.namespace_exists() is False
-    _create_namespace(tests_manager.metadata_store, namespace_location)
-    assert tests_manager.namespace_exists()
-
-    metadata_list = tests_manager.get_all()
-    assert len(metadata_list) == 0
+    # Attempt to get a metadata instance using `None` (error expected)
+    with pytest.raises(ValueError, match="The 'name' parameter requires a value."):
+        tests_manager.get(name=None)
 
 
 def test_manager_get_all_none(tests_manager, namespace_location):


### PR DESCRIPTION
### What changes were proposed in this pull request?

Added a check to ensure `MetadataManager.get(name)` has a value for `name`.  If no value is detected a `ValueError` is raised.

### How was this pull request tested?
The existing `test_manager_get_none` test was a duplicate of `test_manager_get_all_none` (probably due to a copy/paste that was never followed up), so I repurposed the test to assert the appropriate error is raised with a matching message.

Fixes #1777

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
