### PR TITLE
Add pipeline loader

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -831,7 +831,7 @@ const PipelineWrapper: React.FC<IProps> = ({
   };
 
   if (loading || nodeDefs === undefined) {
-    return <div>loading</div>;
+    return <div className="elyra-loader"></div>;
   }
 
   return (

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -443,6 +443,17 @@ span.bx--list-box__label {
   background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" viewBox="0 0 24 24"> <path class="jp-icon3 jp-icon-selectable" d="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"/> </svg>');
 }
 
+.elyra-loader {
+  display: block;
+  position: absolute;
+  left: -200px;
+  width: 200px;
+  height: 4px;
+  border-radius: 4px;
+  background-color: var(--jp-brand-color1);
+  animation: loading 2s linear infinite;
+}
+
 /* context menu */
 
 .d3-node-ellipsis-group {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR adds a loader animation when the pipeline editor is loading its contents.
The blue horizontal line is consistent with an existing loader used in JupyterLab (eg. when refreshing extension list in the extension manager)

Before: 
![image](https://user-images.githubusercontent.com/25207344/122476803-c3adf880-cf94-11eb-97e8-a9b25b865e2a.png)

After:
![loader](https://user-images.githubusercontent.com/25207344/122477091-361ed880-cf95-11eb-9c09-334697b5f9dd.gif)

### How was this pull request tested?
Manual testing: open a pipeline and reload the page to see the changes

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
