### PR TITLE
Avoid using null default values for component parameters

### DIFF
--- a/elyra/pipeline/registry.py
+++ b/elyra/pipeline/registry.py
@@ -219,9 +219,9 @@ class ComponentParser(SingletonConfigurable):
 
     def get_custom_control_id(self, parameter_type):
         # This may not be applicable in every case
-        if parameter_type in ["number", "integer"]:
+        if parameter_type in ['int', 'integer', 'float', 'number']:
             return "NumberControl"
-        elif parameter_type in ["bool", "boolean"]:
+        elif parameter_type in ['bool', 'boolean']:
             return "BooleanControl"
         # elif "array" in parameter_type:
         #     return "StringArrayControl"
@@ -531,7 +531,7 @@ class AirflowComponentParser(ComponentParser):
 
                     # TODO: Fix default values that wrap lines or consider omitting altogether.
                     # Default information could also potentially go in the description instead.
-                    default_value = None
+                    default_value = ''
                     if '=' in arg:
                         arg, default_value = arg.split('=', 1)[:2]
                         default_value = ast.literal_eval(default_value)
@@ -544,15 +544,23 @@ class AirflowComponentParser(ComponentParser):
                             component_parameter_format = new_parameter_info['data']['format']
                             if component_parameter_format:
                                 if component_parameter_format == 'str' or component_parameter_format == 'string':
-                                    if default_value is None:
+                                    if not default_value:
                                         default_value = ''
                                 elif component_parameter_format == 'int':
-                                    if default_value is None:
+                                    if not default_value:
                                         default_value = 0
                                 elif component_parameter_format == 'bool' or component_parameter_format == 'Boolean':
-                                    if default_value is None:
+                                    if not default_value:
                                         default_value = False
+                                elif component_parameter_format == 'dict' or component_parameter_format == 'Dictionary':
+                                    if not default_value:
+                                        default_value = ''
+                                elif component_parameter_format.lower() == 'list':
+                                    if not default_value:
+                                        default_value = ''
                     component_parameters['current_parameters'][new_parameter_info['parameter_ref']] = default_value
+
+                    # print(f'>>>Processing parameter: {arg} ==> Value [{default_value}] type {type(default_value)}')
 
                     # Add to existing parameter info list
                     component_parameters['uihints']['parameter_info'].append(new_parameter_info)

--- a/elyra/pipeline/registry.py
+++ b/elyra/pipeline/registry.py
@@ -538,6 +538,20 @@ class AirflowComponentParser(ComponentParser):
 
                     new_parameter_info = self.build_parameter(arg, class_name, class_content)
 
+                    component_parameters['parameters'].append({"id": new_parameter_info['parameter_ref']})
+                    if 'data' in new_parameter_info:
+                        if 'format' in new_parameter_info['data']:
+                            component_parameter_format = new_parameter_info['data']['format']
+                            if component_parameter_format:
+                                if component_parameter_format == 'str' or component_parameter_format == 'string':
+                                    if default_value is None:
+                                        default_value = ''
+                                elif component_parameter_format == 'int':
+                                    if default_value is None:
+                                        default_value = 0
+                                elif component_parameter_format == 'bool' or component_parameter_format == 'Boolean':
+                                    if default_value is None:
+                                        default_value = False
                     component_parameters['current_parameters'][new_parameter_info['parameter_ref']] = default_value
 
                     # Add to existing parameter info list

--- a/elyra/pipeline/tests/resources/components/airflow_test_operator.py
+++ b/elyra/pipeline/tests/resources/components/airflow_test_operator.py
@@ -27,6 +27,10 @@ class TestOperator(BaseOperator):
     :type test_bool_default: bool
     :param test_int_default: The test command int description
     :type test_int_default: int
+    :param test_dict_default: The test command dict description
+    :type test_dict_default: dict
+    :param test_list_default: The test command list description
+    :type test_list_default: list
     :param test_string_default_value: The test command description
     :type test_string_default_value: str
     :param test_string_default_empty: The test command description
@@ -46,6 +50,8 @@ class TestOperator(BaseOperator):
                  test_string_no_default,
                  test_bool_default,
                  test_int_default,
+                 test_dict_default,
+                 test_list_default,
                  test_string_default_value='default',
                  test_string_default_empty=None,
                  test_bool_false=False,

--- a/elyra/pipeline/tests/test_registry.py
+++ b/elyra/pipeline/tests/test_registry.py
@@ -43,17 +43,22 @@ def test_parse_airflow_component_file():
     properties = parser.parse_component_properties(airflow_component, test_filename)
 
     assert properties['current_parameters']['testoperator_test_string_no_default'] == ''
+    assert properties['current_parameters']['testoperator_test_bool_default'] is False
+    assert properties['current_parameters']['testoperator_elyra_int_test_int_default'] == 0
+    assert properties['current_parameters']['testoperator_elyra_dict_test_dict_default'] == ''  # {}
+    assert properties['current_parameters']['testoperator_test_list_default'] == ''  # []
+
     assert properties['current_parameters']['testoperator_test_string_default_value'] == 'default'
     assert properties['current_parameters']['testoperator_test_string_default_empty'] == ''
-    assert properties['current_parameters']['testoperator_test_bool_default'] is False
+
     assert properties['current_parameters']['testoperator_test_bool_false'] is False
     assert properties['current_parameters']['testoperator_test_bool_true'] is True
-    assert properties['current_parameters']['testoperator_elyra_int_test_int_default'] == 0
+
     assert properties['current_parameters']['testoperator_elyra_int_test_int_zero'] == 0
     assert properties['current_parameters']['testoperator_elyra_int_test_int_non_zero'] == 1
 
 
-def test_parse_airflow_component_url():
+def test_parse_airflow_bash_component_url():
     parser = AirflowComponentParser()
 
     test_url = 'https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/bash_operator.py'
@@ -64,5 +69,23 @@ def test_parse_airflow_component_url():
 
     assert properties['current_parameters']['bashoperator_bash_command'] == ''
     assert properties['current_parameters']['bashoperator_xcom_push'] is False
-    assert properties['current_parameters']['bashoperator_elyra_dict_env'] is None
+    assert properties['current_parameters']['bashoperator_elyra_dict_env'] == ''  # {}
     assert properties['current_parameters']['bashoperator_output_encoding'] == 'utf-8'
+
+
+def test_parse_all_airflow_sample_components():
+    components = {
+        'bash_operator.py': 'https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/bash_operator.py',  # noqa: E501
+        'email_operator.py': 'https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/email_operator.py',  # noqa: E501
+        'http_operator.py': 'https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/http_operator.py',  # noqa: E501
+        'spark_jdbc_operator.py': 'https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/contrib/operators/spark_jdbc_operator.py',  # noqa: E501
+        'spark_sql_operator.py': 'https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/contrib/operators/spark_sql_operator.py',  # noqa: E501
+        'spark_submit_operator.py': 'https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/contrib/operators/spark_submit_operator.py',  # noqa: E501
+    }
+    parser = AirflowComponentParser()
+
+    for component_file_name, component_url in components.items():
+        component = _read_component_resource_from_url(component_url)
+        properties = parser.parse_component_properties(component, component_file_name)
+
+        assert len(properties['current_parameters']) > 0

--- a/elyra/pipeline/tests/test_registry.py
+++ b/elyra/pipeline/tests/test_registry.py
@@ -62,7 +62,7 @@ def test_parse_airflow_component_url():
 
     properties = parser.parse_component_properties(airflow_component, test_filename)
 
-    assert properties['current_parameters']['bashoperator_bash_command'] is None
+    assert properties['current_parameters']['bashoperator_bash_command'] == ''
     assert properties['current_parameters']['bashoperator_xcom_push'] is False
     assert properties['current_parameters']['bashoperator_elyra_dict_env'] is None
     assert properties['current_parameters']['bashoperator_output_encoding'] == 'utf-8'

--- a/elyra/pipeline/tests/test_registry.py
+++ b/elyra/pipeline/tests/test_registry.py
@@ -42,13 +42,13 @@ def test_parse_airflow_component_file():
 
     properties = parser.parse_component_properties(airflow_component, test_filename)
 
-    assert properties['current_parameters']['testoperator_test_string_no_default'] is None
+    assert properties['current_parameters']['testoperator_test_string_no_default'] == ''
     assert properties['current_parameters']['testoperator_test_string_default_value'] == 'default'
-    assert properties['current_parameters']['testoperator_test_string_default_empty'] is None
-    assert properties['current_parameters']['testoperator_test_bool_default'] is None
+    assert properties['current_parameters']['testoperator_test_string_default_empty'] == ''
+    assert properties['current_parameters']['testoperator_test_bool_default'] is False
     assert properties['current_parameters']['testoperator_test_bool_false'] is False
     assert properties['current_parameters']['testoperator_test_bool_true'] is True
-    assert properties['current_parameters']['testoperator_elyra_int_test_int_default'] is None
+    assert properties['current_parameters']['testoperator_elyra_int_test_int_default'] == 0
     assert properties['current_parameters']['testoperator_elyra_int_test_int_zero'] == 0
     assert properties['current_parameters']['testoperator_elyra_int_test_int_non_zero'] == 1
 


### PR DESCRIPTION
This is a follow up on #1764 avoiding usage of empty/null
default values and reverting to use empty strings, 0 or False
as default values for different types.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
