### PR TITLE
Add back artifacts for cypress tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,6 +148,15 @@ jobs:
           make build-jupyterlab
       - name: Cypress
         run: make test-integration
+      - name: Collect logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          path: |
+            ${{ github.workspace }}/build/cypress-tests/*.log
+            ${{ github.workspace }}/build/cypress-tests/screenshots//**/*
+            ${{ github.workspace }}/build/cypress-tests/videos//**/*
+            /home/runner/.npm/_logs/*.log
 
   # TODO: Why are building? Is this just a test that it successfully builds? this should be named accordingly
   build-documentation:


### PR DESCRIPTION
#1671 Accidentally removed the artifacts upload step for cypress tests. This enables viewing screenshots of failing tests. 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
