### PR TITLE
Add ‘extensions’ key/value pair to palette.json for generic components

### DIFF
--- a/elyra/pipeline/resources/palette.json
+++ b/elyra/pipeline/resources/palette.json
@@ -6,6 +6,7 @@
       "image": "",
       "id": "notebooks",
       "description": "Run notebook file",
+      "extensions": [".ipynb"],
       "node_types": [
         {
           "id": "",

--- a/elyra/pipeline/resources/palette.json
+++ b/elyra/pipeline/resources/palette.json
@@ -57,6 +57,7 @@
       "image": "",
       "id": "python-script",
       "description": "Run Python script",
+      "extensions": [".py"],
       "node_types": [
         {
           "id": "",
@@ -108,6 +109,7 @@
       "image": "",
       "id": "r-script",
       "description": "Run R script",
+      "extensions": [".r"],
       "node_types": [
         {
           "id": "",

--- a/elyra/templates/components/canvas_palette_template.jinja2
+++ b/elyra/templates/components/canvas_palette_template.jinja2
@@ -10,6 +10,9 @@
     {% if component.runtime %}
       "runtime": "{{ component.runtime }}",
     {% endif %}
+    {% if component.extension %}
+      "extensions": ["{{ component.extension }}"],
+    {% endif %}
       "node_types": [
         {
           "id": "",

--- a/packages/pipeline-editor/src/pipeline-hooks.ts
+++ b/packages/pipeline-editor/src/pipeline-hooks.ts
@@ -74,6 +74,7 @@ interface IRuntimeComponent {
     outputs: { app_data: any }[];
     app_data: any;
   }[];
+  extensions?: string[];
 }
 
 interface IComponentPropertiesResponse {
@@ -109,6 +110,7 @@ interface INodeDef {
   description: string;
   runtime?: string;
   properties: IComponentPropertiesResponse;
+  extensions?: string[];
 }
 
 const componentFetcher = async (
@@ -136,6 +138,7 @@ const componentFetcher = async (
       label: component.label,
       description: component.description,
       runtime: component.runtime,
+      extensions: component.extensions,
       properties: prop
     };
   });


### PR DESCRIPTION
### What changes were proposed in this pull request?
For the generic file-based components, an `extensions` key is added to the palette JSON. @marthacryan feel free to comment to add details and motivation

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
