### PR TITLE
Add integration tests for pipeline export options

### DIFF
--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -72,7 +72,7 @@ describe('Pipeline Editor tests', () => {
   // });
 
   it('populated editor should have enabled buttons', () => {
-    cy.createGenericPipeline();
+    cy.createPipeline();
 
     cy.checkTabMenuOptions('Pipeline');
 
@@ -99,7 +99,7 @@ describe('Pipeline Editor tests', () => {
   });
 
   it('should open notebook on double-click', () => {
-    cy.createGenericPipeline();
+    cy.createPipeline();
 
     cy.addFileToPipeline('helloworld.ipynb'); // add Notebook
 
@@ -112,9 +112,8 @@ describe('Pipeline Editor tests', () => {
   });
 
   it('should save runtime configuration', () => {
-    cy.createGenericPipeline();
-    // Open runtimes sidebar
-    cy.findByRole('button', { name: /open runtimes/i }).click();
+    cy.createPipeline();
+
     // Create runtime configuration
     cy.createRuntimeConfig();
 
@@ -135,7 +134,7 @@ describe('Pipeline Editor tests', () => {
   });
 
   it('should run pipeline after adding runtime image', () => {
-    cy.createGenericPipeline();
+    cy.createPipeline();
 
     cy.addFileToPipeline('helloworld.ipynb'); // add Notebook
 
@@ -151,7 +150,7 @@ describe('Pipeline Editor tests', () => {
       cy.findByRole('option', { name: /anaconda/i }).click();
     });
 
-    cy.findByRole('button', { name: /save pipeline/i }).click();
+    cy.savePipeline();
 
     // can take a moment to register as saved in ci
     cy.wait(1000);
@@ -208,8 +207,6 @@ describe('Pipeline Editor tests', () => {
   });
 
   it('should export pipeline', () => {
-    cy.findByRole('tab', { name: /runtimes/i }).click();
-
     // Create runtime configuration
     cy.createRuntimeConfig({ type: 'kfp' });
 
@@ -277,7 +274,7 @@ describe('Pipeline Editor tests', () => {
   });
 
   it('kfp pipeline should display custom components', () => {
-    cy.createKFPPipeline();
+    cy.createPipeline({ type: 'kfp' });
     cy.openPalette();
 
     const kfpCustomComponents = ['papermill', 'filter text', 'kfserving'];
@@ -288,11 +285,9 @@ describe('Pipeline Editor tests', () => {
   });
 
   it('kfp pipeline should display expected export options', () => {
-    cy.createKFPPipeline();
+    cy.createPipeline({ type: 'kfp' });
+    cy.savePipeline();
 
-    // Open runtimes sidebar
-    cy.findByRole('button', { name: /open runtimes/i }).click();
-    // Create runtime configuration
     cy.createRuntimeConfig({ type: 'kfp' });
 
     // Validate all export options are available
@@ -300,12 +295,12 @@ describe('Pipeline Editor tests', () => {
     cy.findByRole('option', { name: /yaml/i }).should('have.value', 'yaml');
     cy.findByRole('option', { name: /python/i }).should('not.exist');
 
-    // dismiss dialog
+    // Dismiss dialog
     cy.findByRole('button', { name: /cancel/i }).click();
   });
 
   it('airflow pipeline should display custom components', () => {
-    cy.createAirflowPipeline();
+    cy.createPipeline({ type: 'airflow' });
     cy.openPalette();
 
     const airflowCustomComponents = [
@@ -323,11 +318,9 @@ describe('Pipeline Editor tests', () => {
   });
 
   it('airflow pipeline should display expected export options', () => {
-    cy.createAirflowPipeline();
+    cy.createPipeline({ type: 'airflow' });
+    cy.savePipeline();
 
-    // Open runtimes sidebar
-    cy.findByRole('button', { name: /open runtimes/i }).click();
-    // Create runtime configuration
     cy.createRuntimeConfig();
 
     // Validate all export options are available
@@ -335,7 +328,7 @@ describe('Pipeline Editor tests', () => {
     cy.findByRole('option', { name: /python/i }).should('have.value', 'py');
     cy.findByRole('option', { name: /yaml/i }).should('not.exist');
 
-    // dismiss dialog
+    // Dismiss dialog
     cy.findByRole('button', { name: /cancel/i }).click();
   });
 });

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -71,35 +71,6 @@ describe('Pipeline Editor tests', () => {
   //   closePipelineEditor();
   // });
 
-  it('kfp pipeline should display custom components', () => {
-    cy.createKFPPipeline();
-    cy.openPalette();
-
-    const kfpCustomComponents = ['papermill', 'filter text', 'kfserving'];
-
-    kfpCustomComponents.forEach(component => {
-      cy.findByText(new RegExp(component, 'i')).should('exist');
-    });
-  });
-
-  it('airflow pipeline should display custom components', () => {
-    cy.createAirflowPipeline();
-    cy.openPalette();
-
-    const airflowCustomComponents = [
-      'bash',
-      'email',
-      'HTTP',
-      'spark JDBC',
-      'spark sql',
-      'spark submit'
-    ];
-
-    airflowCustomComponents.forEach(component => {
-      cy.findByText(new RegExp(component, 'i')).should('exist');
-    });
-  });
-
   it('populated editor should have enabled buttons', () => {
     cy.createGenericPipeline();
 
@@ -303,6 +274,59 @@ describe('Pipeline Editor tests', () => {
 
       cy.findByText('BAD=two').should('exist');
     });
+  });
+
+  it('kfp pipeline should display custom components', () => {
+    cy.createKFPPipeline();
+    cy.openPalette();
+
+    const kfpCustomComponents = ['papermill', 'filter text', 'kfserving'];
+
+    kfpCustomComponents.forEach(component => {
+      cy.findByText(new RegExp(component, 'i')).should('exist');
+    });
+  });
+
+  it('kfp pipeline should display expected export options', () => {
+    cy.createKFPPipeline();
+    cy.findByRole('button', { name: /export pipeline/i }).click();
+
+    // Validate all export options are available
+    cy.findByRole('option', { name: /yaml/i }).should('have.value', 'yaml');
+    cy.findByRole('option', { name: /python/i }).should('not.exist');
+
+    // dismiss dialog
+    cy.findByRole('button', { name: /cancel/i }).click();
+  });
+
+  it('airflow pipeline should display custom components', () => {
+    cy.createAirflowPipeline();
+    cy.openPalette();
+
+    const airflowCustomComponents = [
+      'bash',
+      'email',
+      'HTTP',
+      'spark JDBC',
+      'spark sql',
+      'spark submit'
+    ];
+
+    airflowCustomComponents.forEach(component => {
+      cy.findByText(new RegExp(component, 'i')).should('exist');
+    });
+  });
+
+  it('airflow pipeline should display expected export options', () => {
+    cy.createAirflowPipeline();
+    cy.findByRole('button', { name: /export pipeline/i }).click();
+
+    // Validate all export options are available
+    cy.findByRole('option', { name: /python/i }).should('have.value', 'py');
+    cy.findByRole('option', { name: /yaml/i }).should('not.exist');
+
+    // dismiss dialog
+    cy.findByRole('button', { name: /cancel/i }).click();
   });
 });
 

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -289,9 +289,14 @@ describe('Pipeline Editor tests', () => {
 
   it('kfp pipeline should display expected export options', () => {
     cy.createKFPPipeline();
-    cy.findByRole('button', { name: /export pipeline/i }).click();
+
+    // Open runtimes sidebar
+    cy.findByRole('button', { name: /open runtimes/i }).click();
+    // Create runtime configuration
+    cy.createRuntimeConfig({ type: 'kfp' });
 
     // Validate all export options are available
+    cy.findByRole('button', { name: /export pipeline/i }).click();
     cy.findByRole('option', { name: /yaml/i }).should('have.value', 'yaml');
     cy.findByRole('option', { name: /python/i }).should('not.exist');
 
@@ -319,9 +324,14 @@ describe('Pipeline Editor tests', () => {
 
   it('airflow pipeline should display expected export options', () => {
     cy.createAirflowPipeline();
-    cy.findByRole('button', { name: /export pipeline/i }).click();
+
+    // Open runtimes sidebar
+    cy.findByRole('button', { name: /open runtimes/i }).click();
+    // Create runtime configuration
+    cy.createRuntimeConfig();
 
     // Validate all export options are available
+    cy.findByRole('button', { name: /export pipeline/i }).click();
     cy.findByRole('option', { name: /python/i }).should('have.value', 'py');
     cy.findByRole('option', { name: /yaml/i }).should('not.exist');
 

--- a/tests/integration/scripteditor.ts
+++ b/tests/integration/scripteditor.ts
@@ -58,8 +58,6 @@ describe('Script Editor tests', () => {
   });
 
   it('click the Run as Pipeline button should display dialog', () => {
-    // Open runtimes sidebar
-    cy.findByRole('tab', { name: /runtimes/i }).click();
     // Create runtime configuration
     cy.createRuntimeConfig();
     // Validate it is now available

--- a/tests/integration/submitnotebookbutton.ts
+++ b/tests/integration/submitnotebookbutton.ts
@@ -37,8 +37,6 @@ describe('Submit Notebook Button tests', () => {
   });
 
   it('click the "Run as Pipeline" button should display dialog', () => {
-    // Open runtimes sidebar
-    cy.findByRole('tab', { name: /runtimes/i }).click();
     // Create runtime configuration
     cy.createRuntimeConfig();
 

--- a/tests/support/commands.ts
+++ b/tests/support/commands.ts
@@ -19,6 +19,7 @@ import '@testing-library/cypress/add-commands';
 // TODO: we shouldn't have to fill out the form for any test that isn't specifically
 // testing filling out forms.
 Cypress.Commands.add('createRuntimeConfig', ({ type } = {}): void => {
+  cy.findByRole('tab', { name: /runtimes/i }).click();
   cy.findByRole('button', { name: /create new runtime/i }).click();
 
   if (type === 'kfp') {
@@ -62,36 +63,27 @@ Cypress.Commands.add('deleteFile', (name: string): void => {
   });
 });
 
-Cypress.Commands.add('createGenericPipeline', (): void => {
-  // TODO: find a better way to access this.
-  cy.get(
-    '.jp-LauncherCard[data-category="Elyra"][title="Generic Pipeline Editor"]'
-  ).click();
-  cy.get('.common-canvas-drop-div');
-  // wait an additional 300ms for the list of items to settle
-  cy.wait(300);
-});
-
-Cypress.Commands.add('createKFPPipeline', (): void => {
-  cy.get(
-    '.jp-LauncherCard[data-category="Elyra"][title="Kubeflow Pipelines Pipeline Editor"]'
-  ).click();
-  cy.get('.common-canvas-drop-div');
-  // wait an additional 1000ms for the list of items and custom components to settle
-  cy.wait(1000);
-  // pipeline toolbar label should be kfp
-  cy.get('.toolbar-icon-label').contains('Runtime: Kubeflow Pipelines');
-});
-
-Cypress.Commands.add('createAirflowPipeline', (): void => {
-  cy.get(
-    '.jp-LauncherCard[data-category="Elyra"][title="Apache Airflow Pipeline Editor"]'
-  ).click();
-  cy.get('.common-canvas-drop-div');
-  // wait an additional 1000ms for the list of items and custom components to settle
-  cy.wait(1000);
-  // pipeline toolbar label should be airflow
-  cy.get('.toolbar-icon-label').contains('Runtime: Apache Airflow');
+Cypress.Commands.add('createPipeline', ({ type } = {}): void => {
+  switch (type) {
+    case 'kfp':
+      cy.get(
+        '.jp-LauncherCard[data-category="Elyra"][title="Kubeflow Pipelines Pipeline Editor"]'
+      ).click();
+      cy.get('.toolbar-icon-label').contains('Runtime: Kubeflow Pipelines');
+      break;
+    case 'airflow':
+      cy.get(
+        '.jp-LauncherCard[data-category="Elyra"][title="Apache Airflow Pipeline Editor"]'
+      ).click();
+      cy.get('.toolbar-icon-label').contains('Runtime: Apache Airflow');
+      break;
+    default:
+      cy.get(
+        '.jp-LauncherCard[data-category="Elyra"][title="Generic Pipeline Editor"]'
+      ).click();
+      cy.get('.toolbar-icon-label').contains('Runtime: Generic');
+      break;
+  }
 });
 
 Cypress.Commands.add('addFileToPipeline', (name: string): void => {
@@ -99,6 +91,12 @@ Cypress.Commands.add('addFileToPipeline', (name: string): void => {
     name: (n, _el) => n.includes(name)
   }).rightclick();
   cy.findByRole('menuitem', { name: /add file to pipeline/i }).click();
+});
+
+Cypress.Commands.add('savePipeline', (): void => {
+  cy.findByRole('button', { name: /save pipeline/i }).click();
+  // can take a moment to register as saved in ci
+  cy.wait(1000);
 });
 
 Cypress.Commands.add('openFile', (name: string): void => {

--- a/tests/support/index.d.ts
+++ b/tests/support/index.d.ts
@@ -19,13 +19,14 @@ declare namespace Cypress {
     createRuntimeConfig(options?: { type?: 'kfp' }): Chainable<void>;
     deleteFile(fileName: string): Chainable<void>;
     addFileToPipeline(fileName: string): Chainable<void>;
-    createGenericPipeline(): Chainable<void>;
-    createKFPPipeline(): Chainable<void>;
-    createAirflowPipeline(): Chainable<void>;
+    createPipeline(options?: {
+      type?: 'kfp' | 'airflow' | 'generic';
+    }): Chainable<void>;
+    savePipeline(): Chainable<void>;
     openFile(fileName: string): Chainable<void>;
     bootstrapFile(fileName: string): Chainable<void>;
     resetJupyterLab(): Chainable<void>;
     checkTabMenuOptions(fileType: string): Chainable<void>;
-    OpenPalette(): Chainable<void>;
+    openPalette(): Chainable<void>;
   }
 }


### PR DESCRIPTION
This PR adds integration tests to check expected export options in pipelines specific to runtimes.

It also enhances existing code:
- moves  the action to open runtime widget as part of `createRuntimeConfig` command + updates it where applicable

and as suggested in #1792 :
- simplifies `createPipeline` command to receive a `type` parameter, removing the need for a separate command for each pipeline type
- adds `savePipeline` command + updates the call where applicable
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
