### PR TITLE
Add runtime images button to pipeline editor toolbar

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -25,6 +25,7 @@ import {
   savePipelineIcon,
   showBrowseFileDialog,
   runtimesIcon,
+  containerIcon,
   Dropzone,
   RequestErrors,
   showFormDialog,
@@ -61,7 +62,8 @@ import {
   IRuntime,
   ISchema,
   PipelineService,
-  RUNTIMES_NAMESPACE
+  RUNTIMES_NAMESPACE,
+  RUNTIME_IMAGES_NAMESPACE
 } from './PipelineService';
 import { PipelineSubmissionDialog } from './PipelineSubmissionDialog';
 import { theme } from './theme';
@@ -680,6 +682,9 @@ const PipelineWrapper: React.FC<IProps> = ({
         case 'openRuntimes':
           shell.activateById(`elyra-metadata:${RUNTIMES_NAMESPACE}`);
           break;
+        case 'openRuntimeImages':
+          shell.activateById(`elyra-metadata:${RUNTIME_IMAGES_NAMESPACE}`);
+          break;
         case 'openFile':
           commands.execute(commandIDs.openDocManager, { path: args.payload });
           break;
@@ -731,6 +736,13 @@ const PipelineWrapper: React.FC<IProps> = ({
         enable: true,
         iconEnabled: IconUtil.encode(runtimesIcon),
         iconDisabled: IconUtil.encode(runtimesIcon)
+      },
+      {
+        action: 'openRuntimeImages',
+        label: 'Open Runtime Images',
+        enable: true,
+        iconEnabled: IconUtil.encode(containerIcon),
+        iconDisabled: IconUtil.encode(containerIcon)
       },
       { action: 'undo', label: 'Undo' },
       { action: 'redo', label: 'Redo' },

--- a/packages/pipeline-editor/src/PipelineService.tsx
+++ b/packages/pipeline-editor/src/PipelineService.tsx
@@ -24,6 +24,7 @@ import * as React from 'react';
 
 export const KFP_SCHEMA = 'kfp';
 export const RUNTIMES_NAMESPACE = 'runtimes';
+export const RUNTIME_IMAGES_NAMESPACE = 'runtime-images';
 export const COMPONENTS_NAMESPACE = 'components';
 
 export interface IRuntime {


### PR DESCRIPTION
Adds a button similar to the runtimes button in the pipeline editor toolbar to open the runtime images display in the left panel. 
![image](https://user-images.githubusercontent.com/6673460/124186322-c70bae80-da81-11eb-9846-908826bfa5c6.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
