### PR TITLE
Log and skip components with invalid specification location

### DIFF
--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -255,7 +255,7 @@ class FilesystemComponentReader(ComponentReader):
     def read_component_definition(self, registry_entry: dict) -> str:
         if not os.path.exists(registry_entry.location):
             self.log.error(f'Invalid location for component: {registry_entry.id} -> {registry_entry.location}')
-            raise FileNotFoundError(f'Invalid location for component: {registry_entry.id} -> {registry_entry.location}')
+            return None
 
         with open(registry_entry.location, 'r') as f:
             return f.read()
@@ -271,7 +271,7 @@ class UrlComponentReader(ComponentReader):
         res = requests.get(registry_entry.location)
         if res.status_code != HTTPStatus.OK:
             self.log.error (f'Invalid location for component: {registry_entry.id} -> {registry_entry.location} (HTTP code {res.status_code})')  # noqa: E211 E501
-            raise FileNotFoundError (f'Invalid location for component: {registry_entry.id} -> {registry_entry.location} (HTTP code {res.status_code})')  # noqa: E211 E501
+            return None
 
         return res.text
 

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -252,9 +252,9 @@ class FilesystemComponentReader(ComponentReader):
     """
     type = 'filename'
 
-    def read_component_definition(self, registry_entry: dict) -> str:
+    def read_component_definition(self, registry_entry: dict) -> Optional[str]:
         if not os.path.exists(registry_entry.location):
-            self.log.error(f'Invalid location for component: {registry_entry.id} -> {registry_entry.location}')
+            self.log.warning(f"Invalid location for component: {registry_entry.id} -> {registry_entry.location}")
             return None
 
         with open(registry_entry.location, 'r') as f:
@@ -267,10 +267,17 @@ class UrlComponentReader(ComponentReader):
     """
     type = 'url'
 
-    def read_component_definition(self, registry_entry: dict) -> str:
-        res = requests.get(registry_entry.location)
+    def read_component_definition(self, registry_entry: dict) -> Optional[str]:
+        try:
+            res = requests.get(registry_entry.location)
+        except Exception as e:
+            self.log.warning(f"Failed to connect to URL for component: {registry_entry.id} -> " +
+                             f"{registry_entry.location}: {str(e)}")
+            return None
+
         if res.status_code != HTTPStatus.OK:
-            self.log.error (f'Invalid location for component: {registry_entry.id} -> {registry_entry.location} (HTTP code {res.status_code})')  # noqa: E211 E501
+            self.log.warning(f"Invalid location for component: {registry_entry.id} -> {registry_entry.location} " +
+                             f"(HTTP code {res.status_code})")
             return None
 
         return res.text

--- a/elyra/pipeline/component_parser_airflow.py
+++ b/elyra/pipeline/component_parser_airflow.py
@@ -38,6 +38,8 @@ class AirflowComponentParser(ComponentParser):
         components: List[Component] = list()
 
         component_definition = self._read_component_definition(registry_entry)
+        if not component_definition:
+            return None
 
         # If id is prepended with elyra_op_, only parse for the class specified in the id.
         # Else, parse the component definition for all classes

--- a/elyra/pipeline/component_parser_airflow.py
+++ b/elyra/pipeline/component_parser_airflow.py
@@ -16,6 +16,7 @@
 import ast
 import re
 from typing import List
+from typing import Optional
 
 from elyra.pipeline.component import Component
 from elyra.pipeline.component import ComponentParser
@@ -34,7 +35,7 @@ class AirflowComponentParser(ComponentParser):
         # must be adjusted to match the id expected in the component_entry catalog.
         return component_id.split('_')[0]
 
-    def parse(self, registry_entry) -> List[Component]:
+    def parse(self, registry_entry) -> Optional[List[Component]]:
         components: List[Component] = list()
 
         component_definition = self._read_component_definition(registry_entry)

--- a/elyra/pipeline/component_parser_kfp.py
+++ b/elyra/pipeline/component_parser_kfp.py
@@ -33,6 +33,8 @@ class KfpComponentParser(ComponentParser):
 
     def parse(self, registry_entry) -> List[Component]:
         component_yaml = self._read_component_yaml(registry_entry)
+        if not component_yaml:
+            return None
 
         description = ""
         if component_yaml.get('description'):
@@ -132,8 +134,8 @@ class KfpComponentParser(ComponentParser):
             component_definition = reader.read_component_definition(registry_entry)
 
             return yaml.safe_load(component_definition)
-        except yaml.YAMLError as e:
-            raise RuntimeError from e
+        except Exception:
+            return None
 
     def _get_adjusted_parameter_fields(self,
                                        component_body,

--- a/elyra/pipeline/component_parser_kfp.py
+++ b/elyra/pipeline/component_parser_kfp.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 from typing import List
+from typing import Optional
 
 import yaml
 
@@ -31,7 +32,7 @@ class KfpComponentParser(ComponentParser):
     def get_adjusted_component_id(self, component_id):
         return component_id
 
-    def parse(self, registry_entry) -> List[Component]:
+    def parse(self, registry_entry) -> Optional[List[Component]]:
         component_yaml = self._read_component_yaml(registry_entry)
         if not component_yaml:
             return None
@@ -134,7 +135,8 @@ class KfpComponentParser(ComponentParser):
             component_definition = reader.read_component_definition(registry_entry)
 
             return yaml.safe_load(component_definition)
-        except Exception:
+        except Exception as e:
+            self.log.debug(f"Could not read definition for component: {registry_entry.id} -> {str(e)}")
             return None
 
     def _get_adjusted_parameter_fields(self,

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -91,7 +91,9 @@ class ComponentRegistry(LoggingConfigurable):
         if adjusted_id != component_id:
             component_entry.adjusted_id = component_id
 
-        component = self._parser.parse(component_entry)[0]
+        component = self._parser.parse(component_entry)
+        if component:
+            component = next(iter(component), None)
         return component
 
     @staticmethod

--- a/elyra/pipeline/handlers.py
+++ b/elyra/pipeline/handlers.py
@@ -103,7 +103,7 @@ class PipelineComponentHandler(HttpErrorMixin, APIHandler):
 
     @web.authenticated
     async def get(self, processor):
-        self.log.info(f'Retrieving pipeline components for: {processor} runtime')
+        self.log.debug(f'Retrieving pipeline components for: {processor} runtime')
 
         if PipelineProcessorManager.instance().is_supported_runtime(processor) is False:
             raise web.HTTPError(400, f"Invalid processor name '{processor}'")
@@ -120,7 +120,7 @@ class PipelineComponentPropertiesHandler(HttpErrorMixin, APIHandler):
 
     @web.authenticated
     async def get(self, processor, component_id):
-        self.log.info(f'Retrieving pipeline component properties for component: {component_id}')
+        self.log.debug(f'Retrieving pipeline component properties for component: {component_id}')
 
         if PipelineProcessorManager.instance().is_supported_runtime(processor) is False:
             raise web.HTTPError(400, f"Invalid processor name '{processor}'")

--- a/elyra/pipeline/tests/resources/components/airflow_component_catalog_invalid.json
+++ b/elyra/pipeline/tests/resources/components/airflow_component_catalog_invalid.json
@@ -1,0 +1,22 @@
+{
+  "components": {
+    "bash-operator": {
+      "name": "Bash Operator",
+      "location": {
+        "url": "https://nourl.py"
+      }
+    },
+    "email-operator": {
+      "name": "Email Operator",
+      "location": {
+        "filename": "/path/to/invalid.py"
+      }
+    },
+    "http-operator": {
+      "name": "HTTP Operator",
+      "location": {
+        "filename": "/path/to/invalid.py"
+      }
+    }
+  }
+}

--- a/elyra/pipeline/tests/resources/components/kfp_component_catalog_invalid.json
+++ b/elyra/pipeline/tests/resources/components/kfp_component_catalog_invalid.json
@@ -1,0 +1,22 @@
+{
+  "components": {
+    "run-notebook-using-papermill": {
+      "name": "Run Notebook Using Papermill",
+      "location": {
+        "filename": "/path/to/invalid.yaml"
+      }
+    },
+    "filter-text": {
+      "name": "Filter text",
+      "location": {
+        "filename": "/path/to/invalid.yaml"
+      }
+    },
+    "kubeflow-serve-model-using-kfserving": {
+      "name": "Serve Model using KFServing",
+      "location": {
+        "filename": "/path/to/invalid.yaml"
+      }
+    }
+  }
+}

--- a/elyra/pipeline/tests/test_component_parser_airflow.py
+++ b/elyra/pipeline/tests/test_component_parser_airflow.py
@@ -24,7 +24,7 @@ from elyra.pipeline.component import UrlComponentReader
 from elyra.pipeline.component_parser_airflow import AirflowComponentParser
 from elyra.pipeline.component_registry import ComponentRegistry
 
-COMPONENT_CATALOG_DIRECORY = os.path.join(jupyter_core.paths.ENV_JUPYTER_PATH[0], 'components')
+COMPONENT_CATALOG_DIRECTORY = os.path.join(jupyter_core.paths.ENV_JUPYTER_PATH[0], 'components')
 
 
 def _get_resource_path(filename):
@@ -35,7 +35,7 @@ def _get_resource_path(filename):
 
 
 def test_component_registry_can_load_components_from_catalog():
-    component_registry_location = os.path.join(COMPONENT_CATALOG_DIRECORY, 'airflow_component_catalog.json')
+    component_registry_location = os.path.join(COMPONENT_CATALOG_DIRECTORY, 'airflow_component_catalog.json')
     component_parser = AirflowComponentParser()
     component_registry = ComponentRegistry(component_registry_location, component_parser)
 
@@ -95,3 +95,23 @@ def test_parse_airflow_component_url():
     assert properties_json['current_parameters']['xcom_push'] is False
     assert properties_json['current_parameters']['env'] == ''  # {}
     assert properties_json['current_parameters']['output_encoding'] == 'utf-8'
+
+
+async def test_parse_components_invalid_location():
+    # Ensure a component with an invalid location is not returned
+    component_registry_location = os.path.join(os.path.dirname(__file__),
+                                               'resources/components',
+                                               'airflow_component_catalog_invalid.json')
+    component_parser = AirflowComponentParser()
+    component_registry = ComponentRegistry(component_registry_location, component_parser)
+
+    components = component_registry.get_all_components()
+    assert len(components) == 0
+
+    palette = ComponentRegistry.to_canvas_palette(components)
+    palette_json = json.loads(palette)
+    empty_palette = {
+        "version": "3.0",
+        "categories": []
+    }
+    assert palette_json == empty_palette

--- a/elyra/pipeline/tests/test_component_parser_kfp.py
+++ b/elyra/pipeline/tests/test_component_parser_kfp.py
@@ -24,7 +24,7 @@ from elyra.pipeline.component import UrlComponentReader
 from elyra.pipeline.component_parser_kfp import KfpComponentParser
 from elyra.pipeline.component_registry import ComponentRegistry
 
-COMPONENT_CATALOG_DIRECORY = os.path.join(jupyter_core.paths.ENV_JUPYTER_PATH[0], 'components')
+COMPONENT_CATALOG_DIRECTORY = os.path.join(jupyter_core.paths.ENV_JUPYTER_PATH[0], 'components')
 
 
 def _get_resource_path(filename):
@@ -35,7 +35,7 @@ def _get_resource_path(filename):
 
 
 def test_component_registry_can_load_components_from_catalog():
-    component_registry_location = os.path.join(COMPONENT_CATALOG_DIRECORY, 'kfp_component_catalog.json')
+    component_registry_location = os.path.join(COMPONENT_CATALOG_DIRECTORY, 'kfp_component_catalog.json')
     component_parser = KfpComponentParser()
     component_registry = ComponentRegistry(component_registry_location, component_parser)
 
@@ -94,3 +94,23 @@ def test_parse_kfp_component_url():
     assert properties_json['current_parameters']['parameters'] == '{}'
     assert properties_json['current_parameters']['packages_to_install'] == ''  # {}
     assert properties_json['current_parameters']['input_data'] == ''
+
+
+async def test_parse_components_invalid_location():
+    # Ensure a component with an invalid location is not returned
+    component_registry_location = os.path.join(os.path.dirname(__file__),
+                                               'resources/components',
+                                               'kfp_component_catalog_invalid.json')
+    component_parser = KfpComponentParser()
+    component_registry = ComponentRegistry(component_registry_location, component_parser)
+
+    components = component_registry.get_all_components()
+    assert len(components) == 0
+
+    palette = ComponentRegistry.to_canvas_palette(components)
+    palette_json = json.loads(palette)
+    empty_palette = {
+        "version": "3.0",
+        "categories": []
+    }
+    assert palette_json == empty_palette


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixes #1869, fixes #1870. When attempting to read a component at an invalid location, `None` is returned rather than raising an Exception. In a later PR, this error will be indicated to the user in some way visually in the pipeline editor rather than just through logging.

Adds a test that covers the case where an invalid component location is entered (both filename and url).

Also fixes #1879.


### How was this pull request tested?
Tested manually via the below methods.

#1869-related tests:

- Enter an invalid location in the component catalog
- Start JupyterLab
- Open a pipeline of the relevant type
- Results:
  - No error popup is displayed on the pipeline editor
  - Does not display the relevant component
  - Logs at error level (example below):
```
Invalid location for component: kubeflow-serve-model-using-kfserving -> https://raw.githubusercontent.com/kubeflow/pipelines/1.4.1/components/kubeflow/kfserving/component.yamlz (HTTP code 404)
```

#1870-related tests:
- Enter a valid location in the component catalog
- Start JupyterLab
- Open a pipeline of the relevant type
- Delete or move the component spec file from it's given location
- Results:
  - No error popup is displayed on the pipeline editor
  - Removes the relevant component from the palette
  - Logs at error level (example below):
```
Invalid location for component: slack-operator -> /path/to/component/slack_operator.py
```
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
