### PR TITLE
Bump material-ui/core version and fix console error

### DIFF
--- a/packages/metadata-common/package.json
+++ b/packages/metadata-common/package.json
@@ -42,7 +42,7 @@
     "@lumino/algorithm": "^1.3.3",
     "@lumino/messaging": "^1.4.3",
     "@lumino/widgets": "^1.17.0",
-    "@material-ui/core": "^4.1.2",
+    "@material-ui/core": "^4.12.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@jupyterlab/apputils": "^3.0.0",
     "@jupyterlab/ui-components": "^3.0.0",
-    "@material-ui/core": "^4.1.2",
+    "@material-ui/core": "^4.12.1",
     "@material-ui/icons": "^4.2.1",
     "@material-ui/lab": "^4.0.0-alpha.18",
     "react": "^17.0.1",

--- a/packages/ui-components/src/ThemeProvider.tsx
+++ b/packages/ui-components/src/ThemeProvider.tsx
@@ -18,7 +18,7 @@ import { IThemeManager } from '@jupyterlab/apputils';
 
 import {
   StylesProvider,
-  createMuiTheme,
+  createTheme,
   ThemeProvider as MuiThemeProvider
 } from '@material-ui/core';
 
@@ -101,7 +101,7 @@ const overrides = {
 };
 
 if (window.ELYRA_darkTheme === undefined) {
-  window.ELYRA_darkTheme = createMuiTheme({
+  window.ELYRA_darkTheme = createTheme({
     palette: {
       type: 'dark'
     },
@@ -110,7 +110,7 @@ if (window.ELYRA_darkTheme === undefined) {
 }
 
 if (window.ELYRA_lightTheme === undefined) {
-  window.ELYRA_lightTheme = createMuiTheme({
+  window.ELYRA_lightTheme = createTheme({
     palette: {
       type: 'light'
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3280,15 +3280,15 @@
     "@lumino/signaling" "^1.4.3"
     "@lumino/virtualdom" "^1.8.0"
 
-"@material-ui/core@^4.1.2":
-  version "4.11.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.3.tgz#f22e41775b0bd075e36a7a093d43951bf7f63850"
-  integrity sha512-Adt40rGW6Uds+cAyk3pVgcErpzU/qxc7KBR94jFHBYretU4AtWZltYcNsbeMn9tXL86jjVL1kuGcIHsgLgFGRw==
+"@material-ui/core@^4.12.1":
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.12.1.tgz#ac8f081498047aa02bb6ee70b77c5dad6a2a6e73"
+  integrity sha512-C6hYsjkWCTfBx9FaqxhCZCITBagh7fyCKFtHyvO3tTOcBw6NJaktdhNZ2n82jQdQdgfFvg6OOxi7OOzsAdAcBQ==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@material-ui/styles" "^4.11.3"
-    "@material-ui/system" "^4.11.3"
-    "@material-ui/types" "^5.1.0"
+    "@material-ui/styles" "^4.11.4"
+    "@material-ui/system" "^4.12.1"
+    "@material-ui/types" "5.1.0"
     "@material-ui/utils" "^4.11.2"
     "@types/react-transition-group" "^4.2.0"
     clsx "^1.0.4"
@@ -3316,14 +3316,14 @@
     prop-types "^15.7.2"
     react-is "^16.8.0 || ^17.0.0"
 
-"@material-ui/styles@^4.11.3":
-  version "4.11.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.3.tgz#1b8d97775a4a643b53478c895e3f2a464e8916f2"
-  integrity sha512-HzVzCG+PpgUGMUYEJ2rTEmQYeonGh41BYfILNFb/1ueqma+p1meSdu4RX6NjxYBMhf7k+jgfHFTTz+L1SXL/Zg==
+"@material-ui/styles@^4.11.4":
+  version "4.11.4"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.4.tgz#eb9dfccfcc2d208243d986457dff025497afa00d"
+  integrity sha512-KNTIZcnj/zprG5LW0Sao7zw+yG3O35pviHzejMdcSGCdWbiO8qzRgOYL8JAxAsWBKOKYwVZxXtHWaB5T2Kvxew==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@emotion/hash" "^0.8.0"
-    "@material-ui/types" "^5.1.0"
+    "@material-ui/types" "5.1.0"
     "@material-ui/utils" "^4.11.2"
     clsx "^1.0.4"
     csstype "^2.5.2"
@@ -3338,17 +3338,17 @@
     jss-plugin-vendor-prefixer "^10.5.1"
     prop-types "^15.7.2"
 
-"@material-ui/system@^4.11.3":
-  version "4.11.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.11.3.tgz#466bc14c9986798fd325665927c963eb47cc4143"
-  integrity sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==
+"@material-ui/system@^4.12.1":
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.12.1.tgz#2dd96c243f8c0a331b2bb6d46efd7771a399707c"
+  integrity sha512-lUdzs4q9kEXZGhbN7BptyiS1rLNHe6kG9o8Y307HCvF4sQxbCgpL2qi+gUk+yI8a2DNk48gISEQxoxpgph0xIw==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@material-ui/utils" "^4.11.2"
     csstype "^2.5.2"
     prop-types "^15.7.2"
 
-"@material-ui/types@^5.1.0":
+"@material-ui/types@5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"
   integrity sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==


### PR DESCRIPTION
Fixes #1871 

### What changes were proposed in this pull request?
This PR updates `material-ui/core` version to 4.12.1 (latest stable), 
and updates deprecated function name `createMuiTheme` to `createTheme` used in `ThemeProvider`,
removing the error logged in the browser console.

### How was this pull request tested?
Manual testing - console error is gone in browser dev tools

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
