### PR TITLE
Fix icon related console warnings and errors

### DIFF
--- a/packages/ui-components/src/icons.tsx
+++ b/packages/ui-components/src/icons.tsx
@@ -113,11 +113,21 @@ export class IconUtil {
     return 'data:image/svg+xml;utf8,' + encodeURIComponent(icon.svgstr);
   }
 
+  private static colorizedIcons: { [key: string]: LabIcon } = {};
+
   static colorize(
     icon: LabIcon,
     fillColor?: string,
     strokeColor?: string
   ): LabIcon {
+    const iconName = `${icon.name}${fillColor ? ':' + fillColor : ''}${
+      strokeColor ? ':' + strokeColor : ''
+    }`;
+
+    if (this.colorizedIcons[iconName]) {
+      return this.colorizedIcons[iconName];
+    }
+
     let svgstr = icon.svgstr;
 
     if (fillColor) {
@@ -130,13 +140,15 @@ export class IconUtil {
       );
     }
 
-    return LabIcon.resolve({
+    const coloredIcon = LabIcon.resolve({
       icon: {
-        name: `${icon.name}${fillColor ? ':' + fillColor : ''}${
-          strokeColor ? ':' + strokeColor : ''
-        }`,
+        name: iconName,
         svgstr: svgstr
       }
     });
+
+    this.colorizedIcons[iconName] = coloredIcon;
+
+    return coloredIcon;
   }
 }

--- a/packages/ui-components/style/icons/clear-pipeline.svg
+++ b/packages/ui-components/style/icons/clear-pipeline.svg
@@ -1,3 +1,3 @@
-<svg class="icon" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" width="16" height="16" viewBox="0 0 32 32" aria-hidden="true">
+<svg focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" fill="currentColor" width="16" height="16" viewBox="0 0 32 32" aria-hidden="true">
   <path d="M7 27H30V29H7zM27.38 10.51L19.45 2.59a2 2 0 00-2.83 0l-14 14a2 2 0 000 2.83L7.13 24h9.59L27.38 13.34A2 2 0 0027.38 10.51zM15.89 22H8L4 18l6.31-6.31 7.93 7.92zm3.76-3.76l-7.92-7.93L18 4 26 11.93z"></path>
 </svg>

--- a/packages/ui-components/style/icons/container.svg
+++ b/packages/ui-components/style/icons/container.svg
@@ -1,4 +1,4 @@
-<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
     <path class="jp-icon3" fill="#231F20"  d="M28,12H20V4h8Zm-6-2h4V6H22Z"/>
     <path class="jp-icon3" fill="#231F20"  d="M17,15V9H9V23H23V15Zm-6-4h4v4H11Zm4,10H11V17h4Zm6,0H17V17h4Z"/>
     <path class="jp-icon3" fill="#231F20"  d="M26,28H6a2.0023,2.0023,0,0,1-2-2V6A2.0023,2.0023,0,0,1,6,4H16V6H6V26H26V16h2V26A2.0023,2.0023,0,0,1,26,28Z"/>

--- a/packages/ui-components/style/icons/export-pipeline.svg
+++ b/packages/ui-components/style/icons/export-pipeline.svg
@@ -1,4 +1,4 @@
-<svg class="icon" fill="currentColor" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32" aria-hidden="true">
+<svg fill="currentColor" focusable="false" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32" aria-hidden="true">
 	<path d="M13 21L26.17 21 23.59 23.59 25 25 30 20 25 15 23.59 16.41 26.17 19 13 19 13 21z"></path>
 	<path d="M22,14V10a1,1,0,0,0-.29-.71l-7-7A1,1,0,0,0,14,2H4A2,2,0,0,0,2,4V28a2,2,0,0,0,2,2H20a2,2,0,0,0,2-2V26H20v2H4V4h8v6a2,2,0,0,0,2,2h6v2Zm-8-4V4.41L19.59,10Z"></path>
 </svg>

--- a/packages/ui-components/style/icons/runtimes.svg
+++ b/packages/ui-components/style/icons/runtimes.svg
@@ -1,4 +1,4 @@
-<svg class="icon" xmlns="http://www.w3.org/2000/svg" fill="currentColor" width="32" height="32" viewBox="0 0 32 32">
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" width="32" height="32" viewBox="0 0 32 32">
     <g>
         <rect class="jp-icon3" x="20" y="20" width="10" height="2"/>
         <rect class="jp-icon3" x="20" y="24" width="10" height="2"/>


### PR DESCRIPTION
IconUtil.colorize leverages a jupyterlab function that doesn't check
for duplicates before creating a new LabIcon, this adds caching to
prevent the duplicate LabIcon warning. This previously didn't matter
since we stoped using the util soon after I wrote it, but some new
code has leveraged it again.

class is an invalid attribute when using react to render, but
className is an invalid attribute for svg. Since we don't reference
the class of our svg anyway I removed it to get rid of the error

Found, fixed, and tested while working on #1860

Fixes #1895
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
