### PR TITLE
Add descriptions to component types in palette

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -109,7 +109,7 @@ const createPalette = (categories: any[]): any => {
 
   for (const category of categories) {
     for (const i in category.node_types) {
-      const { op, label, image, ...rest } = category.node_types[i];
+      const { op, label, image, description, ...rest } = category.node_types[i];
       category.node_types[i] = {
         op,
         id: op,
@@ -150,6 +150,7 @@ const createPalette = (categories: any[]): any => {
           ...rest,
           ui_data: {
             label,
+            description,
             image: image ?? '',
             x_pos: 0,
             y_pos: 0


### PR DESCRIPTION
Follow-up to moving palette to the left - adds description field to components:
Before:
![image](https://user-images.githubusercontent.com/6673460/125526863-969d60ec-1390-4704-bd45-66276a45b270.png)

After:
![image](https://user-images.githubusercontent.com/6673460/125526806-37710fbd-d8bf-4da3-9596-486b3a733b96.png)

Note: requires some backend changes to add descriptions to some custom components so those components remain the same:
![image](https://user-images.githubusercontent.com/6673460/125526945-757d20ca-b09d-4a02-aa2c-8590401e6630.png)


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
