### PR TITLE
Set 'required' attribute default to True for KFP properties

### DIFF
--- a/elyra/pipeline/component_parser_kfp.py
+++ b/elyra/pipeline/component_parser_kfp.py
@@ -70,10 +70,11 @@ class KfpComponentParser(ComponentParser):
             if "description" in param:
                 description = param.get('description')
 
-            # Determine whether parameter is optional
-            required = False
-            if "optional" in param and not param.get('optional'):
-                required = True
+            # KFP components default to being required unless otherwise stated.
+            # Reference: https://www.kubeflow.org/docs/components/pipelines/reference/component-spec/#interface
+            required = True
+            if "optional" in param and param.get('optional') is True:
+                required = False
 
             # Assign type, default to string
             type = "string"

--- a/elyra/pipeline/tests/resources/components/kfp_test_operator.yaml
+++ b/elyra/pipeline/tests/resources/components/kfp_test_operator.yaml
@@ -11,6 +11,9 @@ inputs:
 - {name: test_int_non_zero, description: 'The test command description', type: Integer, default: '1'}
 - {name: test_dict_default, description: 'The test command description', type: Dict}
 - {name: test_list_default, description: 'The test command description', type: List}
+- {name: test_required_property, description: 'The test command description', type: String, optional: false}
+- {name: test_optional_property, description: 'The test command description', type: String, optional: true}
+- {name: test_required_property_default, description: 'The test command description', type: String}
 outputs:
 - {name: Filtered text}
 implementation:

--- a/elyra/pipeline/tests/test_component_parser_kfp.py
+++ b/elyra/pipeline/tests/test_component_parser_kfp.py
@@ -74,6 +74,20 @@ def test_parse_kfp_component_file():
     assert properties_json['current_parameters']['test_dict_default'] == ''  # {}
     assert properties_json['current_parameters']['test_list_default'] == ''  # []
 
+    # Ensure that the 'required' attribute was set correctly. KFP components default to required
+    # unless explicitly marked otherwise in component YAML.
+    required_property = next(prop for prop in properties_json['uihints']['parameter_info'] \
+                            if prop.get('parameter_ref') == 'test_required_property')
+    assert required_property['data']['required'] is True
+
+    optional_property = next(prop for prop in properties_json['uihints']['parameter_info'] \
+                            if prop.get('parameter_ref') == 'test_optional_property')
+    assert optional_property['data']['required'] is False
+
+    default_required_property = next(prop for prop in properties_json['uihints']['parameter_info'] \
+                                    if prop.get('parameter_ref') == 'test_required_property_default')
+    assert default_required_property['data']['required'] is True
+
 
 def test_parse_kfp_component_url():
     entry = {

--- a/elyra/pipeline/tests/test_component_parser_kfp.py
+++ b/elyra/pipeline/tests/test_component_parser_kfp.py
@@ -76,16 +76,16 @@ def test_parse_kfp_component_file():
 
     # Ensure that the 'required' attribute was set correctly. KFP components default to required
     # unless explicitly marked otherwise in component YAML.
-    required_property = next(prop for prop in properties_json['uihints']['parameter_info'] \
-                            if prop.get('parameter_ref') == 'test_required_property')
+    required_property = next(prop for prop in properties_json['uihints']['parameter_info']
+                             if prop.get('parameter_ref') == 'test_required_property')
     assert required_property['data']['required'] is True
 
-    optional_property = next(prop for prop in properties_json['uihints']['parameter_info'] \
-                            if prop.get('parameter_ref') == 'test_optional_property')
+    optional_property = next(prop for prop in properties_json['uihints']['parameter_info']
+                             if prop.get('parameter_ref') == 'test_optional_property')
     assert optional_property['data']['required'] is False
 
-    default_required_property = next(prop for prop in properties_json['uihints']['parameter_info'] \
-                                    if prop.get('parameter_ref') == 'test_required_property_default')
+    default_required_property = next(prop for prop in properties_json['uihints']['parameter_info']
+                                     if prop.get('parameter_ref') == 'test_required_property_default')
     assert default_required_property['data']['required'] is True
 
 


### PR DESCRIPTION
Fixes #1896. 

### What changes were proposed in this pull request?
Changes the default value for KFP `ComponentProperty`'s `required` attribute to `True` during component parsing according to the following source: https://www.kubeflow.org/docs/components/pipelines/reference/component-spec/#interface

### How was this pull request tested?
Adds new logic to an existing test to check against this case. Three new properties are added to the test component YAML, one of which is explicitly required, one of which is explicitly optional, and one of which does not specify and should therefore be set as required.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
