### PR TITLE
Fix exporting generic pipelines to python script

### DIFF
--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -328,14 +328,12 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
 
             description = f'Created with Elyra {__version__} pipeline editor using {pipeline.source}.'
 
-            for key, operation in defined_pipeline.items():
-                self.log.debug("component:\n "
-                               "container op name : %s \n "
-                               "inputs : %s \n "
-                               "outputs : %s \n ",
-                               operation.name,
-                               operation.inputs,
-                               operation.outputs)
+            if self.log.isEnabledFor(logging.DEBUG):
+                for key, operation in defined_pipeline.items():
+                    self.log.debug("component:\n "
+                                   f"container op name : {operation.name} \n "
+                                   f"inputs : {operation.inputs} \n "
+                                   f"outputs : {operation.outputs} \n ")
 
             # The exported pipeline is by default associated with
             # an experiment.

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -330,9 +330,10 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
             description = f'Created with Elyra {__version__} pipeline editor using {pipeline.source}.'
 
             if self.log.isEnabledFor(logging.DEBUG):
+                self.log.debug(f"Exporting pipeline {pipeline_name} with components: \n")
                 for key, operation in defined_pipeline.items():
                     self.log.debug("component:\n "
-                                   f"container op name : {operation.name} \n "
+                                   f"operation name : {operation.name} \n "
                                    f"inputs : {operation.inputs} \n "
                                    f"outputs : {operation.outputs} \n ")
 

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -16,6 +16,7 @@
 import ast
 from datetime import datetime
 import json
+import logging
 import os
 import re
 import tempfile

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -329,8 +329,6 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
             description = f'Created with Elyra {__version__} pipeline editor using {pipeline.source}.'
 
             for key, operation in defined_pipeline.items():
-                if operation.classifier not in ["execute-notebook-node", "execute-python-node", "execute-r-node"]:
-                    continue
                 self.log.debug("component:\n "
                                "container op name : %s \n "
                                "inputs : %s \n "


### PR DESCRIPTION
Remove the check fot 'operation.classifier' during export
as the classifier concept is not available in KFP operation

Fixes #1922

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
