### PR TITLE
Fix Open File command for pipeline nodes

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -881,7 +881,12 @@ const PipelineWrapper: React.FC<IProps> = ({
           shell.activateById(`elyra-metadata:${RUNTIME_IMAGES_NAMESPACE}`);
           break;
         case 'openFile':
-          commands.execute(commandIDs.openDocManager, { path: args.payload });
+          commands.execute(commandIDs.openDocManager, {
+            path: PipelineService.getWorkspaceRelativeNodePath(
+              contextRef.current.path,
+              args.payload
+            )
+          });
           break;
         default:
           break;

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -254,17 +254,77 @@ describe('Pipeline Editor tests', () => {
     cy.readFile('build/cypress-tests/simple.pipeline').matchesSnapshot();
   });
 
-  it('should open notebook on double-click', () => {
-    cy.createPipeline();
+  it('should open notebook on double-clicking the node', () => {
+    // Open a pipeline in root directory
+    cy.openFile('helloworld.pipeline');
 
-    cy.addFileToPipeline('helloworld.ipynb'); // add Notebook
-
-    // Open notebook with double-click
+    // Open notebook node with double-click
     cy.get('#jp-main-dock-panel').within(() => {
       cy.findByText('helloworld.ipynb').dblclick();
     });
 
     cy.findAllByRole('tab', { name: 'helloworld.ipynb' }).should('exist');
+
+    cy.closeTab();
+    // dismiss 'save your work' dialog
+    cy.findByRole('button', { name: /discard/i }).click();
+
+    // Open a pipeline in a subfolder
+    cy.bootstrapFile('pipelines/producer.ipynb');
+    cy.openDirectory('pipelines');
+    cy.writeFile('build/cypress-tests/pipelines/complex.pipeline', '');
+    cy.openFile('complex.pipeline');
+    cy.get('.common-canvas-drop-div');
+    cy.wait(300);
+    cy.addFileToPipeline('producer.ipynb');
+
+    // Open notebook node with double-click
+    cy.get('#jp-main-dock-panel').within(() => {
+      cy.findByText('producer.ipynb').dblclick();
+    });
+
+    cy.findAllByRole('tab', { name: 'producer.ipynb' }).should('exist');
+
+    cy.closeTab();
+    // dismiss 'save your work' dialog
+    cy.findByRole('button', { name: /discard/i }).click();
+  });
+
+  it('should open notebook from node right-click menu', () => {
+    // Open a pipeline in root directory
+    cy.openFile('helloworld.pipeline');
+
+    // Open notebook node with right-click menu
+    cy.get('#jp-main-dock-panel').within(() => {
+      cy.findByText('helloworld.ipynb').rightclick();
+      cy.findByRole('menuitem', { name: /open file/i }).click();
+    });
+
+    cy.findAllByRole('tab', { name: 'helloworld.ipynb' }).should('exist');
+
+    cy.closeTab();
+    // dismiss 'save your work' dialog
+    cy.findByRole('button', { name: /discard/i }).click();
+
+    // Open a pipeline in a subfolder
+    cy.bootstrapFile('pipelines/producer.ipynb');
+    cy.openDirectory('pipelines');
+    cy.writeFile('build/cypress-tests/pipelines/complex.pipeline', '');
+    cy.openFile('complex.pipeline');
+    cy.get('.common-canvas-drop-div');
+    cy.wait(300);
+    cy.addFileToPipeline('producer.ipynb');
+
+    // Open notebook node with right-click menu
+    cy.get('#jp-main-dock-panel').within(() => {
+      cy.findByText('producer.ipynb').rightclick();
+      cy.findByRole('menuitem', { name: /open file/i }).click();
+    });
+
+    cy.findAllByRole('tab', { name: 'producer.ipynb' }).should('exist');
+    cy.closeTab();
+    // dismiss 'save your work' dialog
+    cy.findByRole('button', { name: /discard/i }).click();
   });
 
   it('should save runtime configuration', () => {

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -259,15 +259,16 @@ describe('Pipeline Editor tests', () => {
     cy.openFile('helloworld.pipeline');
 
     // Open notebook node with double-click
-    cy.get('#jp-main-dock-panel').within(() => {
+    cy.get('.common-canvas-drop-div').within(() => {
       cy.findByText('helloworld.ipynb').dblclick();
     });
 
     cy.findAllByRole('tab', { name: 'helloworld.ipynb' }).should('exist');
 
-    cy.closeTab();
-    // dismiss 'save your work' dialog
+    // close tabs
+    cy.closeTab(-1); // notebook tab
     cy.findByRole('button', { name: /discard/i }).click();
+    cy.closeTab(-1); // pipeline tab
 
     // Open a pipeline in a subfolder
     cy.bootstrapFile('pipelines/producer.ipynb');
@@ -277,6 +278,7 @@ describe('Pipeline Editor tests', () => {
     cy.get('.common-canvas-drop-div');
     cy.wait(300);
     cy.addFileToPipeline('producer.ipynb');
+    cy.wait(300);
 
     // Open notebook node with double-click
     cy.get('#jp-main-dock-panel').within(() => {
@@ -284,10 +286,6 @@ describe('Pipeline Editor tests', () => {
     });
 
     cy.findAllByRole('tab', { name: 'producer.ipynb' }).should('exist');
-
-    cy.closeTab();
-    // dismiss 'save your work' dialog
-    cy.findByRole('button', { name: /discard/i }).click();
   });
 
   it('should open notebook from node right-click menu', () => {
@@ -302,9 +300,10 @@ describe('Pipeline Editor tests', () => {
 
     cy.findAllByRole('tab', { name: 'helloworld.ipynb' }).should('exist');
 
-    cy.closeTab();
-    // dismiss 'save your work' dialog
+    // close tabs
+    cy.closeTab(-1); // notebook tab
     cy.findByRole('button', { name: /discard/i }).click();
+    cy.closeTab(-1); // pipeline tab
 
     // Open a pipeline in a subfolder
     cy.bootstrapFile('pipelines/producer.ipynb');
@@ -322,7 +321,7 @@ describe('Pipeline Editor tests', () => {
     });
 
     cy.findAllByRole('tab', { name: 'producer.ipynb' }).should('exist');
-    cy.closeTab();
+    cy.closeTab(-1);
     // dismiss 'save your work' dialog
     cy.findByRole('button', { name: /discard/i }).click();
   });

--- a/tests/support/commands.ts
+++ b/tests/support/commands.ts
@@ -158,3 +158,9 @@ Cypress.Commands.add('expandPaletteCategory', ({ type } = {}): void => {
       break;
   }
 });
+
+Cypress.Commands.add('closeTab', (index: number): void => {
+  cy.get('.lm-TabBar-tabCloseIcon:visible')
+    .eq(index)
+    .click();
+});

--- a/tests/support/index.d.ts
+++ b/tests/support/index.d.ts
@@ -32,5 +32,6 @@ declare namespace Cypress {
     expandPaletteCategory(options?: {
       type?: 'kfp' | 'airflow' | 'generic';
     }): Chainable<void>;
+    closeTab(index: number): Chainable<void>;
   }
 }


### PR DESCRIPTION
Fixes #1931 - Right-click node -> Open File command now works for pipelines in subdirectories

### What changes were proposed in this pull request?
Update relative node path used in `openFile` command

### How was this pull request tested?
Integration tests added for the scenarios:
- open file from node right-click menu (pipeline in root dir & in a subdirectory)
- open file on double-clicking the node (pipeline in a subdirectory)
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
