### PR TITLE
Fix css for resources fields to show all fields on same line

### DIFF
--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -199,14 +199,14 @@ span.bx--list-box__label {
   display: none;
 }
 
-.properties-control-panel[data-id='properties-resources']
+.properties-control-panel[data-id='properties-elyra_resources']
   .properties-custom-ctrl {
   position: absolute;
   bottom: 18px;
   padding-right: 14px;
 }
 
-.properties-control-panel[data-id='properties-resources']
+.properties-control-panel[data-id='properties-elyra_resources']
   .properties-control-description {
   padding-bottom: 35px;
 }
@@ -697,11 +697,11 @@ input.elyra-Dialog-checkbox.jp-mod-styled {
   background: var(--jp-border-color1);
 }
 
-.properties-control-panel[data-id='properties-resources'] {
+.properties-control-panel[data-id='properties-elyra_resources'] {
   display: flex;
 }
 
-.properties-control-panel[data-id='properties-resources']
+.properties-control-panel[data-id='properties-elyra_resources']
   .properties-ctrl-wrapper {
   width: 33%;
 }


### PR DESCRIPTION
The `data-id` of the resource fields in the properties editor changed, so the css that put all of them on the same line stopped working. This adjusts the css to use the correct data id. 
![image](https://user-images.githubusercontent.com/6673460/126677980-0308a956-057d-4aa9-b868-73682fb21d9c.png)


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
