### PR TITLE
Make 'name' an optional property when parsing a component registry entry

### DIFF
--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -178,7 +178,7 @@ class ComponentRegistry(LoggingConfigurable):
                     # TODO Add error checking for category here or elsewhere
                     entry = {
                         "id": component_id,
-                        "name": component_entry["name"],
+                        "name": component_entry.get("name"),
                         "type": component_type,
                         "location": component_location,
                         "adjusted_id": None,

--- a/etc/config/components/airflow_component_catalog.json
+++ b/etc/config/components/airflow_component_catalog.json
@@ -8,42 +8,36 @@
   },
   "components": {
     "bash-operator": {
-      "name": "Bash Operator",
       "location": {
         "url": "https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/bash_operator.py"
       },
       "category": "airflow"
     },
     "email-operator": {
-      "name": "Email Operator",
       "location": {
         "url": "https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/email_operator.py"
       },
       "category": "airflow"
     },
     "http-operator": {
-      "name": "HTTP Operator",
       "location": {
         "url": "https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/http_operator.py"
       },
       "category": "airflow"
     },
     "spark-sql-operator": {
-      "name": "Spark Sql Operator",
       "location": {
         "url": "https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/contrib/operators/spark_sql_operator.py"
       },
       "category": "airflow"
     },
     "spark-submit-operator": {
-      "name": "Spark Submit Operator",
       "location": {
         "url": "https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/contrib/operators/spark_submit_operator.py"
       },
       "category": "airflow"
     },
     "slack-operator": {
-      "name": "Slack Operator",
       "location": {
         "filename": "slack_operator.py"
       },

--- a/etc/config/components/kfp_component_catalog.json
+++ b/etc/config/components/kfp_component_catalog.json
@@ -8,21 +8,18 @@
   },
   "components": {
     "run-notebook-using-papermill": {
-      "name": "Run Notebook Using Papermill",
       "location": {
         "filename": "run_notebook_using_papermill/component.yaml"
       },
       "category": "kfp"
     },
     "filter-text": {
-      "name": "Filter text",
       "location": {
         "filename": "filter_text_using_shell_and_grep/component.yaml"
       },
       "category": "kfp"
     },
     "kubeflow-serve-model-using-kfserving": {
-      "name": "Serve Model using KFServing",
       "location": {
         "filename": "kubeflow_serve_model_using_kfserving/component.yaml"
       },


### PR DESCRIPTION
### What changes were proposed in this pull request?
No error is thrown when accessing an entry from the component registry that does not include the `name` key. This allows a component registry entry like the below to be parsed with no difference in functionality.

```
"run-notebook-using-papermill": {
  "location": {
    "filename": "run_notebook_using_papermill/component.yaml"
  },
  "category": "kfp"
}
```

This also removes the `name` key from the KFP and Airflow component catalogs to reduce confusion.

We may want to discuss whether we want to remove `name` and all uses of it in the catalogs and during parsing since we do not currently use this field for anything. The idea behind including the name field sort of rests on the assumption that eventually we may have a GUI where users can add new components to the catalog and provide their own UI-friendly name.

### How was this pull request tested?

- Delete the `name` key/value pair from an entry in either component catalog
- Rebuild and launch JupyterLab
- Drag the changed component onto a pipeline
- No error is thrown

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
