### PR TITLE
Use enter key to save and submit metadata editor form

### DIFF
--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -47,7 +47,6 @@ import * as React from 'react';
 import { MetadataEditorTags } from './MetadataEditorTags';
 
 const ELYRA_METADATA_EDITOR_CLASS = 'elyra-metadataEditor';
-const ELYRA_CODEDEITOR_WRAPPER_CLASS = 'elyra-codeEditorWrapper';
 const DIRTY_CLASS = 'jp-mod-dirty';
 
 interface IMetadataEditorProps {
@@ -135,7 +134,7 @@ const CodeBlock: React.FC<ICodeBlockProps> = ({
   }, [language]);
 
   return (
-    <div className={ELYRA_CODEDEITOR_WRAPPER_CLASS}>
+    <div>
       <InputLabel error={error} required={required}>
         {label}
       </InputLabel>

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -47,6 +47,7 @@ import * as React from 'react';
 import { MetadataEditorTags } from './MetadataEditorTags';
 
 const ELYRA_METADATA_EDITOR_CLASS = 'elyra-metadataEditor';
+const ELYRA_CODEDEITOR_WRAPPER_CLASS = 'elyra-codeEditorWrapper';
 const DIRTY_CLASS = 'jp-mod-dirty';
 
 interface IMetadataEditorProps {
@@ -134,7 +135,7 @@ const CodeBlock: React.FC<ICodeBlockProps> = ({
   }, [language]);
 
   return (
-    <div>
+    <div className={ELYRA_CODEDEITOR_WRAPPER_CLASS}>
       <InputLabel error={error} required={required}>
         {label}
       </InputLabel>
@@ -585,9 +586,17 @@ export class MetadataEditor extends ReactWidget {
       headerText = `Add new ${this.schemaDisplayName}`;
     }
     const error = this.displayName === '' && this.invalidForm;
+    const onKeyPress: React.KeyboardEventHandler = (
+      event: React.KeyboardEvent
+    ) => {
+      const targetElement = event.nativeEvent.target as HTMLElement;
+      if (event.key === 'Enter' && targetElement?.tagName !== 'TEXTAREA') {
+        this.saveMetadata();
+      }
+    };
     return (
       <ThemeProvider themeManager={this.themeManager}>
-        <div className={ELYRA_METADATA_EDITOR_CLASS}>
+        <div onKeyPress={onKeyPress} className={ELYRA_METADATA_EDITOR_CLASS}>
           <h3> {headerText} </h3>
           <p style={{ width: '100%', marginBottom: '10px' }}>
             All fields marked with an asterisk are required.&nbsp;

--- a/tests/integration/codesnippet.ts
+++ b/tests/integration/codesnippet.ts
@@ -79,6 +79,20 @@ describe('Code Snippet tests', () => {
     cy.get('button.jp-mod-accept').click();
   });
 
+  it('should trigger save / submit on pressing enter', () => {
+    populateCodeSnippetFields(snippetName);
+
+    cy.get('.elyra-metadataEditor-form-display_name').type('{enter}');
+
+    // Metadata editor tab should not be visible
+    cy.get(
+      'li.lm-TabBar-tab[data-id="elyra-metadata-editor:code-snippets:code-snippet:new"]'
+    ).should('not.exist');
+
+    // Check new code snippet is displayed
+    getSnippetByName(snippetName);
+  });
+
   // Delete snippet
   it('should delete existing Code Snippet', () => {
     createValidCodeSnippet(snippetName);
@@ -305,7 +319,7 @@ const createInvalidCodeSnippet = (snippetName: string): any => {
   saveAndCloseMetadataEditor();
 };
 
-const createValidCodeSnippet = (snippetName: string): any => {
+const populateCodeSnippetFields = (snippetName: string): any => {
   clickCreateNewSnippetButton();
 
   // Name code snippet
@@ -318,6 +332,10 @@ const createValidCodeSnippet = (snippetName: string): any => {
   cy.get('.CodeMirror .CodeMirror-scroll:visible').type(
     'print("Code Snippet Test")'
   );
+};
+
+const createValidCodeSnippet = (snippetName: string): any => {
+  populateCodeSnippetFields(snippetName);
 
   saveAndCloseMetadataEditor();
 


### PR DESCRIPTION
Fixes #1955. Adds a keypress handler to catch if the enter key is pressed and if so, save and submit the metadata editor form. **Note**: This also adds logic to prevent triggering save and submit when enter is pressed within the code editor (otherwise this would break the code editor). This also doesn't trigger save / submit when enter is pressed while the dropdown is open for things like code snippet language.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
