### PR TITLE
Set KFP component display name to the provided label name

### DIFF
--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -531,9 +531,15 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
 
                 # Add factory function, which returns a ContainerOp task instance, to pipeline operation dict
                 try:
+                    # Remove inputs and outputs from params dict until support for data exchange is provided
                     operation.component_params_as_dict.pop("inputs")
                     operation.component_params_as_dict.pop("outputs")
-                    target_ops[operation.id] = factory_function(**operation.component_params_as_dict)
+
+                    # Create ContainerOp instance and assign appropriate user-provided name
+                    container_op = factory_function(**operation.component_params_as_dict)
+                    container_op.set_display_name(operation.name)
+
+                    target_ops[operation.id] = container_op
                 except Exception as e:
                     # TODO Fix error messaging and break exceptions down into categories
                     self.log.error(f"Error constructing component {operation.name}: {str(e)}")


### PR DESCRIPTION
Fixes #1963.

### What changes were proposed in this pull request?
In pipeline pre-processing, the operation name is now set as the display name of a KFP runtime-specific component. For some context, the operation name is the value of the `label` field sent in the pipeline JSON, which is the user-entered label if one is provided. Otherwise, the label is set to the component name for runtime-specific components.

In this example, a `Run notebook using papermill` component was given the label `mylabel`:

<img width="671" alt="Screen Shot 2021-07-27 at 10 54 30 AM" src="https://user-images.githubusercontent.com/31816267/127186516-d08a0c8d-9d48-42d3-ac6d-6fe608fce56a.png">


And now shows up in the KFP experiment with this new label:
<img width="197" alt="Screen Shot 2021-07-27 at 10 21 02 AM" src="https://user-images.githubusercontent.com/31816267/127181072-c2c0c79e-ec1f-442d-b525-749d15e15e85.png">


### How was this pull request tested?
Tests are passing. If desired, a test could be added on top of the new tests in #1957 that checks if the display name is set properly. 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
