### PR TITLE
Resolve component name error in new function in component registry

### DIFF
--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -166,7 +166,7 @@ class ComponentRegistry(LoggingConfigurable):
             # Process component entries from catalog
             if 'components' in catalog_json.keys():
                 for component_id, component_entry in catalog_json['components'].items():
-                    self.log.debug(f"Component registry: processing component {component_entry.get('name')}")
+                    self.log.debug(f"Component registry: processing component {component_id}")
 
                     component_type = next(iter(component_entry.get('location')))
                     component_location = self._get_relative_location(component_type,

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -225,7 +225,7 @@ class ComponentRegistry(LoggingConfigurable):
 
             component_entry = {
                 "id": queried_component_id,
-                "name": component_entry['name'],
+                "name": component_entry.get("name"),
                 "type": location_type,
                 "location": component_location,
                 "catalog_entry_id": catalog_entry_id,


### PR DESCRIPTION


### What changes were proposed in this pull request?
This is a follow-up to both #1958 and #1948. #1948 introduced a new function that accesses the component catalog `name` key. Since these PRs were merged at the same time, the new function now needs to be updated in accordance with #1958 making `name` and optional property in the catalog.

It also changes the log message given when registering a component to use the `component_id` rather than the name.

### How was this pull request tested?
Tests are passing

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
