### PR TITLE
Reverse how description and type information appear in node properties

### DIFF
--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -342,14 +342,13 @@ class ComponentParser(LoggingConfigurable):  # ABC
         except Exception:
             raise ValueError(f'Unsupported registry type {component_entry.type}.')
 
-    def _get_description_with_type_hint(self, type: str, description: Optional[str]) -> str:
+    def _format_description(self, description: str, type: str) -> str:
         """
         Adds type information parsed from component specification to parameter description.
         """
         if description:
             return f"{description} (type: {type})"
-        else:
-            return f"(type: {type})"
+        return f"(type: {type})"
 
     def determine_type_information(self, parsed_type: str) -> Tuple[str, str, Any]:
         """

--- a/elyra/pipeline/component_parser_airflow.py
+++ b/elyra/pipeline/component_parser_airflow.py
@@ -148,7 +148,7 @@ class AirflowComponentParser(ComponentParser):
                 description = match.group(1).strip().replace("\"", "'")
 
             # Amend description to include type information
-            description = self._get_description_with_type_hint(type, description)
+            description = self._format_description(description=description, type=type)
 
             type, control_id, default_value = self.determine_type_information(type)
 

--- a/elyra/pipeline/component_parser_airflow.py
+++ b/elyra/pipeline/component_parser_airflow.py
@@ -142,13 +142,13 @@ class AirflowComponentParser(ComponentParser):
 
             # Search for :param [param] in class doctring to get description
             description = ""
-            param_regex = re.compile(f":param {arg}:" + r"([\s\S]*?(?=:type|:param))")
+            param_regex = re.compile(f":param {arg}:" + r"([\s\S]*?(?=:type|:param|\"\"\"|'''|\.\.))")
             match = param_regex.search(class_content)
             if match:
                 description = match.group(1).strip().replace("\"", "'")
 
             # Amend description to include type information
-            description = self._get_description_with_type_hint(description, type)
+            description = self._get_description_with_type_hint(type, description)
 
             type, control_id, default_value = self.determine_type_information(type)
 

--- a/elyra/pipeline/component_parser_kfp.py
+++ b/elyra/pipeline/component_parser_kfp.py
@@ -72,7 +72,7 @@ class KfpComponentParser(ComponentParser):
             type = param.get('type', 'string')
 
             # Set description and include parsed type information
-            description = self._get_description_with_type_hint(type, param.get('description'))
+            description = self._format_description(description=param.get('description', ''), type=type)
 
             # Change type to reflect the type of input (inputValue vs inputPath)
             type = self._get_adjusted_parameter_fields(component_body=component_yaml,

--- a/elyra/pipeline/component_parser_kfp.py
+++ b/elyra/pipeline/component_parser_kfp.py
@@ -72,7 +72,7 @@ class KfpComponentParser(ComponentParser):
             type = param.get('type', 'string')
 
             # Set description and include parsed type information
-            description = self._get_description_with_type_hint(param.get('description'), type)
+            description = self._get_description_with_type_hint(type, param.get('description'))
 
             # Change type to reflect the type of input (inputValue vs inputPath)
             type = self._get_adjusted_parameter_fields(component_body=component_yaml,

--- a/elyra/pipeline/tests/resources/components/airflow_test_operator.py
+++ b/elyra/pipeline/tests/resources/components/airflow_test_operator.py
@@ -49,6 +49,7 @@ class TestOperator(BaseOperator):
     :type test_unusual_type_list: a list of strings
     :param test_unusual_type_string: The test command description
     :type test_unusual_type_string: a string
+    :param test_unusual_type_notgiven: The test command description
     """
 
     @apply_defaults
@@ -67,6 +68,7 @@ class TestOperator(BaseOperator):
                  test_unusual_type_dict=None,
                  test_unusual_type_list=None,
                  test_unusual_type_string="",
+                 test_unusual_type_notgiven="",
                  *args, **kwargs):
 
         super().__init__(*args, **kwargs)

--- a/elyra/pipeline/tests/resources/components/kfp_test_operator.yaml
+++ b/elyra/pipeline/tests/resources/components/kfp_test_operator.yaml
@@ -18,6 +18,7 @@ inputs:
 - {name: test_unusual_type_list, description: 'The test command description', type: An array}
 - {name: test_unusual_type_string, description: 'The test command description', type: A string}
 - {name: test_unusual_type_file, description: 'The test command description', type: Notebook}
+- {name: test_unusual_type_notgiven, description: 'The test command description'}
 outputs:
 - {name: Filtered text}
 implementation:

--- a/elyra/pipeline/tests/test_component_parser_airflow.py
+++ b/elyra/pipeline/tests/test_component_parser_airflow.py
@@ -75,17 +75,29 @@ def test_parse_airflow_component_file():
     assert properties_json['current_parameters']['elyra_test_dict_default'] == ''  # {}
     assert properties_json['current_parameters']['elyra_test_list_default'] == ''  # []
 
+    # Ensure that type information is inferred correctly
     unusual_dict_property = next(prop for prop in properties_json['uihints']['parameter_info']
                                  if prop.get('parameter_ref') == 'elyra_test_unusual_type_dict')
     assert unusual_dict_property['data']['format'] == "dictionary"
 
-    unusual_array_property = next(prop for prop in properties_json['uihints']['parameter_info']
-                                  if prop.get('parameter_ref') == 'elyra_test_unusual_type_list')
-    assert unusual_array_property['data']['format'] == "list"
+    unusual_list_property = next(prop for prop in properties_json['uihints']['parameter_info']
+                                 if prop.get('parameter_ref') == 'elyra_test_unusual_type_list')
+    assert unusual_list_property['data']['format'] == "list"
 
     unusual_string_property = next(prop for prop in properties_json['uihints']['parameter_info']
                                    if prop.get('parameter_ref') == 'elyra_test_unusual_type_string')
     assert unusual_string_property['data']['format'] == "string"
+
+    no_type_property = next(prop for prop in properties_json['uihints']['parameter_info']
+                            if prop.get('parameter_ref') == 'elyra_test_unusual_type_notgiven')
+    assert no_type_property['data']['format'] == "string"
+
+    # Ensure descriptions are rendered properly with type hint in parentheses
+    assert unusual_dict_property['description']['default'] == "The test command description "\
+                                                              "(type: a dictionary of arrays)"
+    assert unusual_list_property['description']['default'] == "The test command description (type: a list of strings)"
+    assert unusual_string_property['description']['default'] == "The test command description (type: a string)"
+    assert no_type_property['description']['default'] == "The test command description (type: string)"
 
 
 def test_parse_airflow_component_url():

--- a/elyra/pipeline/tests/test_component_parser_kfp.py
+++ b/elyra/pipeline/tests/test_component_parser_kfp.py
@@ -89,6 +89,7 @@ def test_parse_kfp_component_file():
                                      if prop.get('parameter_ref') == 'elyra_test_required_property_default')
     assert default_required_property['data']['required'] is True
 
+    # Ensure that type information is inferred correctly
     unusual_dict_property = next(prop for prop in properties_json['uihints']['parameter_info']
                                  if prop.get('parameter_ref') == 'elyra_test_unusual_type_dict')
     assert unusual_dict_property['data']['format'] == "dictionary"
@@ -104,6 +105,18 @@ def test_parse_kfp_component_file():
     file_property = next(prop for prop in properties_json['uihints']['parameter_info']
                          if prop.get('parameter_ref') == 'elyra_test_unusual_type_file')
     assert file_property['data']['format'] == "file"
+
+    no_type_property = next(prop for prop in properties_json['uihints']['parameter_info']
+                            if prop.get('parameter_ref') == 'elyra_test_unusual_type_notgiven')
+    assert no_type_property['data']['format'] == "string"
+
+    # Ensure descriptions are rendered properly with type hint in parentheses
+    assert unusual_dict_property['description']['default'] == "The test command description "\
+                                                              "(type: Dictionary of arrays)"
+    assert unusual_list_property['description']['default'] == "The test command description (type: An array)"
+    assert unusual_string_property['description']['default'] == "The test command description (type: A string)"
+    assert file_property['description']['default'] == "The test command description (type: Notebook)"
+    assert no_type_property['description']['default'] == "The test command description (type: string)"
 
 
 def test_parse_kfp_component_url():


### PR DESCRIPTION
Fixes the issue seen in the below screenshot where component description and type are in the opposite position as expected.

![127157010-3ebc0b75-75d9-4122-8184-dfb9b8c11326](https://user-images.githubusercontent.com/31816267/127195426-8a7ffc61-1061-4c7e-be90-934d6f1a6352.png)


### What changes were proposed in this pull request?
Creates a description of the format `[parsed description] (type: [parsed type])`, as shown in below screenshot. 

<img width="452" alt="Screen Shot 2021-07-27 at 11 53 23 AM" src="https://user-images.githubusercontent.com/31816267/127195660-7bd283a0-bc7d-4223-97bc-3d8078a01424.png">

Also adds a clause to the description parsing regex for Airflow that accounts for the case where a parameter is given a description (`:param [param_name]: ...`) but not a type (`:type [param_name]: ...`) in the operator class docstring.
### How was this pull request tested?
Tests are added that check that the descriptions and types given in the component specification appear as expected.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
