### PR TITLE
Fix failing server tests

### DIFF
--- a/elyra/pipeline/tests/test_processor_kfp.py
+++ b/elyra/pipeline/tests/test_processor_kfp.py
@@ -203,7 +203,8 @@ def test_processing_url_runtime_specific_component(monkeypatch, processor, sampl
                           op="filter-text",
                           source_type="url",
                           source=url,
-                          properties=[])
+                          properties=[],
+                          catalog_entry_id="")
 
     # Replace cached component registry with single url-based component for testing
     processor._component_registry._cached_components = [component]
@@ -249,7 +250,8 @@ def test_processing_filename_runtime_specific_component(monkeypatch, processor, 
                           op="filter-text",
                           source_type="filename",
                           source="kfp/filter_text_using_shell_and_grep/component.yaml",
-                          properties=[])
+                          properties=[],
+                          catalog_entry_id="")
 
     # Replace cached component registry with single filename-based component for testing
     processor._component_registry._cached_components = [component]


### PR DESCRIPTION

### What changes were proposed in this pull request?
Due to 2 PRs merged at the same time, 2 tests in `test_processor_kfp.py` are failing citing a missing attribute `catalog_entry_id`. This PR will fix the test failures.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
