### PR TITLE
Properly evaluate parameters of type "list" when processing KFP RTS components

### DIFF
--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -511,7 +511,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                             # If file can't be found locally, assume a remote file location was entered.
                             # This may cause the pipeline run to fail; the user must debug in this case.
                             pass
-                    elif component_property.type in ['dict', 'dictionary']:
+                    elif component_property.type in ['dictionary', 'list']:
                         # Get corresponding property value from parsed pipeline and convert
                         op_property = operation.component_params.get(component_property.ref)
                         operation.component_params[component_property.ref] = ast.literal_eval(op_property)


### PR DESCRIPTION
Fixes #1977; fixes #1967

### What changes were proposed in this pull request?
This PR adds parameters of type `list` to the if/else statement that performs a `literal_eval` on parameter values sent in the pipeline JSON. 

The before and after scenario is shown below for the `Run notebook using papermill` component, which has a property that requires the user enter a list of packages to install. The value entered into that field was `['numpy', 'matplotlib']` for both examples.

Before:
<img width="1076" alt="Screen Shot 2021-07-28 at 3 58 37 PM" src="https://user-images.githubusercontent.com/31816267/127395056-b72a79a4-c916-461a-8030-5afc105975aa.png">


After:
<img width="1064" alt="Screen Shot 2021-07-28 at 3 50 48 PM" src="https://user-images.githubusercontent.com/31816267/127395063-fe9f243e-5294-42d3-814a-48fcb3c3adbf.png">


Additionally, this removes the check for `dict` in the same if/else statement. After the merge of #1936, the types assigned to `ComponentParameter` objects are standardized to be one of `string`, `number`, `boolean`, `dictionary`, `list`, or `file` (KFP-only)

### How was this pull request tested?
Will require merge to get tests passing due to unrelated CI and server test issues. Manual testing done to cover this issue.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
