### PR TITLE
Fix error case where error handler throws error

### DIFF
--- a/elyra/kfp/tests/test_bootstrapper.py
+++ b/elyra/kfp/tests/test_bootstrapper.py
@@ -54,7 +54,11 @@ def start_minio():
             check=True)
         time.sleep(3)
     except subprocess.CalledProcessError as ex:
-        raise RuntimeError(f'Error executing process: {ex.stderr.decode("unicode_escape")}') from ex
+        if ex.stderr:
+            error = ex.stderr.decode("unicode_escape")
+        else:
+            error = ''
+        raise RuntimeError(f'Error executing process: {error}') from ex
 
 
 @pytest.fixture(scope='function')

--- a/elyra/kfp/tests/test_bootstrapper.py
+++ b/elyra/kfp/tests/test_bootstrapper.py
@@ -54,11 +54,7 @@ def start_minio():
             check=True)
         time.sleep(3)
     except subprocess.CalledProcessError as ex:
-        if ex.stderr:
-            error = ex.stderr.decode("unicode_escape")
-        else:
-            error = ''
-        raise RuntimeError(f'Error executing process: {error}') from ex
+        raise RuntimeError(f"Error executing process: {ex.stderr or ''}") from ex
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
Currently when this error handling is called the following error is sometimes thrown:

```
ERROR elyra/kfp/tests/test_bootstrapper.py::test_main_method - AttributeError: 'NoneType' object has no attribute 'decode'
```

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
