### PR TITLE
Convert exception to string for error handling

### DIFF
--- a/elyra/util/http.py
+++ b/elyra/util/http.py
@@ -61,7 +61,7 @@ class HttpErrorMixin(object):
                 reply['message'] = exception.log_message or message
             else:
                 if isinstance(exception, Exception) and exception.args:
-                    reply['message'] = exception.args[0]
+                    reply['message'] = str(exception.args[0])
                 else:
                     reply['message'] = "{}: {}".format(exception.__class__.__name__, str(exception))
                 reply['traceback'] = ''.join(traceback.format_exception(*exc_info))

--- a/elyra/util/http.py
+++ b/elyra/util/http.py
@@ -61,7 +61,14 @@ class HttpErrorMixin(object):
                 reply['message'] = exception.log_message or message
             else:
                 if isinstance(exception, Exception) and exception.args:
-                    reply['message'] = str(exception.args[0])
+                    if isinstance(exception.args[0], Exception):
+                        reply['message'] = \
+                            "Error. The server sent an invalid response.\
+                            \nPlease open an issue and provide this error message,\
+                            any error details, and any related JupyterLab log messages.\
+                            \n\nError found:\n{}".format(str(exception.args[0]))
+                    else:
+                        reply['message'] = str(exception.args[0])
                 else:
                     reply['message'] = "{}: {}".format(exception.__class__.__name__, str(exception))
                 reply['traceback'] = ''.join(traceback.format_exception(*exc_info))

--- a/packages/ui-components/style/index.css
+++ b/packages/ui-components/style/index.css
@@ -106,6 +106,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  white-space: pre-line;
 }
 
 .elyra-errorDialog-messageDisplay > div:nth-child(2) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The server wasn't sending the correct error information because of an encoding error happening in the error mixin. This converts the object causing issues to a string to fix the encoding error. 

Before changes:
![image](https://user-images.githubusercontent.com/6673460/127553336-10d7bc57-142b-4b36-b43c-b0fd5111b50b.png)

After changes:
![image](https://user-images.githubusercontent.com/6673460/127593307-412a1955-b7a9-4f77-9fe3-ae5357ef8cb5.png)

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
