### PR TITLE
Re-enable tests for constructing KFP pipeline with custom components

### DIFF
--- a/elyra/pipeline/tests/resources/components/filter_text.yaml
+++ b/elyra/pipeline/tests/resources/components/filter_text.yaml
@@ -1,0 +1,41 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Component source location: https://raw.githubusercontent.com/kubeflow/pipelines/master/components/sample/Shell_script/component.yaml
+# Component details: Takes a text file and a regex pattern filter to produce a filtered text file
+name: Filter text
+inputs:
+- {name: Text, optional: false, description: 'Path to file to be filtered'}
+- {name: Pattern, optional: true, default: '.*', description: 'Regex pattern'}
+outputs:
+- {name: Filtered text}
+metadata:
+  annotations:
+    author: Alexey Volkov <alexey.volkov@ark-kun.com>
+implementation:
+  container:
+    image: alpine
+    command:
+    - sh
+    - -ec
+    - |
+      text_path=$0
+      pattern=$1
+      filtered_text_path=$2
+      mkdir -p "$(dirname "$filtered_text_path")"
+      
+      grep "$pattern" < "$text_path" > "$filtered_text_path"
+    - {inputPath: Text}
+    - {inputValue: Pattern}
+    - {outputPath: Filtered text}

--- a/elyra/pipeline/tests/test_processor_kfp.py
+++ b/elyra/pipeline/tests/test_processor_kfp.py
@@ -13,13 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import ast
 import os
 import tarfile
 from unittest import mock
 
 from kfp import compiler as kfp_argo_compiler
-from kfp.components.structures import TaskSpec
 import pytest
+import yaml
 
 from elyra.metadata.metadata import Metadata
 from elyra.pipeline.component import Component
@@ -192,11 +193,10 @@ def test_collect_envs(processor):
     assert 'USER_NO_VALUE' not in envs
 
 
-@pytest.mark.skip(reason="failing - need to evaluate function at kfp compiler level")
-def test_processing_url_runtime_specific_component(monkeypatch, processor, sample_metadata):
+def test_processing_url_runtime_specific_component(monkeypatch, processor, sample_metadata, tmpdir):
     # Assign test resource location
-    url = 'https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/' \
-          'pipeline/resources/kfp/filter_text_using_shell_and_grep/component.yaml'
+    url = 'https://raw.githubusercontent.com/elyra-ai/elyra/master/' \
+          'etc/config/components/kfp/filter_text_using_shell_and_grep.yaml'
 
     # Instantiate a url-based component
     component = Component(id="filter-text",
@@ -212,12 +212,17 @@ def test_processing_url_runtime_specific_component(monkeypatch, processor, sampl
     processor._component_registry._cached_components = [component]
 
     # Construct hypothetical operation for component
+    operation_name = "Filter text test"
+    operation_params = {
+        "text": "path/to/text.txt",
+        "pattern": "hello"
+    }
     operation = Operation(id='filter-text-id',
                           type='execution_node',
                           classifier='filter-text',
-                          name='Filter text',
+                          name=operation_name,
                           parent_operation_ids=[],
-                          component_params={"text": "resources/components/filter.txt", "pattern": "hello"})
+                          component_params=operation_params)
 
     # Build a mock runtime config for use in _cc_pipeline
     mocked_runtime = Metadata(name="test-metadata",
@@ -230,29 +235,45 @@ def test_processing_url_runtime_specific_component(monkeypatch, processor, sampl
 
     # Construct single-operation pipeline
     pipeline = Pipeline(id='pipeline-id',
-                        name='untitled',
+                        name='kfp_test',
                         runtime='kfp',
                         runtime_config='test',
                         source='filter_text.pipeline')
     pipeline.operations[operation.id] = operation
 
-    # Process pipeline with a scaled-down version of the processor cc_pipeline function
-    constructed_pipeline = processor._cc_pipeline(pipeline=pipeline, pipeline_name='test_pipeline')
+    # Establish path and function to construct pipeline
+    pipeline_path = os.path.join(tmpdir, 'kfp_test.yaml')
+    constructed_pipeline_function = lambda: processor._cc_pipeline(pipeline=pipeline, pipeline_name='test_pipeline')
 
-    # Ensure the pipeline operation was properly processed for execution, creating a KFP TaskSpec object
-    assert isinstance(constructed_pipeline[operation.id], TaskSpec)
-    assert constructed_pipeline[operation.id].component_ref.url == url
+    # TODO Check against both argo and tekton compilations
+    # Compile pipeline and save into pipeline_path
+    kfp_argo_compiler.Compiler().compile(constructed_pipeline_function, pipeline_path)
+
+    # Read contents of pipeline YAML
+    with open(pipeline_path) as f:
+        pipeline_yaml = yaml.safe_load(f.read())
+
+    # Check the pipeline file contents for correctness
+    pipeline_template = pipeline_yaml['spec']['templates'][0]
+    assert pipeline_template['metadata']['annotations']['pipelines.kubeflow.org/task_display_name'] == operation_name
+    assert pipeline_template['inputs']['artifacts'][0]['raw']['data'] == operation_params['text']
+
+    component_ref = pipeline_template['metadata']['annotations']['pipelines.kubeflow.org/component_ref']
+    component_ref = ast.literal_eval(component_ref)
+    assert component_ref['url'] == url
 
 
-@pytest.mark.skip(reason="failing - need to evaluate function at kfp compiler level")
 def test_processing_filename_runtime_specific_component(monkeypatch, processor, sample_metadata, tmpdir):
+    # Assign test resource location
+    relative_path = "kfp/filter_text_using_shell_and_grep.yaml"
+
     # Instantiate a file-based component
     component = Component(id="filter-text",
                           name="Filter text",
                           description="",
                           op="filter-text",
                           source_type="filename",
-                          source="kfp/filter_text_using_shell_and_grep/component.yaml",
+                          source=relative_path,
                           properties=[],
                           catalog_entry_id="")
 
@@ -260,12 +281,17 @@ def test_processing_filename_runtime_specific_component(monkeypatch, processor, 
     processor._component_registry._cached_components = [component]
 
     # Construct hypothetical operation for component
+    operation_name = "Filter text test"
+    operation_params = {
+        "text": "path/to/text.txt",
+        "pattern": "hello"
+    }
     operation = Operation(id='filter-text-id',
                           type='execution_node',
                           classifier='filter-text',
-                          name='Filter text',
+                          name=operation_name,
                           parent_operation_ids=[],
-                          component_params={"text": "resources/components/filter.txt", "pattern": "hello"})
+                          component_params=operation_params)
 
     # Build a mock runtime config for use in _cc_pipeline
     mocked_runtime = Metadata(name="test-metadata",
@@ -278,28 +304,29 @@ def test_processing_filename_runtime_specific_component(monkeypatch, processor, 
 
     # Construct single-operation pipeline
     pipeline = Pipeline(id='pipeline-id',
-                        name='untitled',
+                        name='kfp_test',
                         runtime='kfp',
-                        runtime_config='test-metadata',
+                        runtime_config='test',
                         source='filter_text.pipeline')
     pipeline.operations[operation.id] = operation
 
-    # Process pipeline with a scaled-down version of the processor cc_pipeline function
-    pipeline_path = os.path.join(tmpdir, "test_pipeline.yaml")
-
-    # We arent able to access the container op level here since the runtime component is a taskspec
+    # Establish path and function to construct pipeline
+    pipeline_path = os.path.join(tmpdir, 'kfp_test.yaml')
     constructed_pipeline_function = lambda: processor._cc_pipeline(pipeline=pipeline, pipeline_name='test_pipeline')
 
-    # We can check again both argo and tekton compilations
-    compiled_pipeline = kfp_argo_compiler.Compiler().compile(constructed_pipeline_function, pipeline_path)
+    # TODO Check against both argo and tekton compilations
+    # Compile pipeline and save into pipeline_path
+    kfp_argo_compiler.Compiler().compile(constructed_pipeline_function, pipeline_path)
 
-    # we can check the pipeline file for `correctness`
-    print(compiled_pipeline)
+    # Read contents of pipeline YAML
+    with open(pipeline_path) as f:
+        pipeline_yaml = yaml.safe_load(f.read())
 
-    # constructed_pipeline = processor._cc_pipeline(pipeline=pipeline, pipeline_name='test_pipeline')
+    # Check the pipeline file contents for correctness
+    pipeline_template = pipeline_yaml['spec']['templates'][0]
+    assert pipeline_template['metadata']['annotations']['pipelines.kubeflow.org/task_display_name'] == operation_name
+    assert pipeline_template['inputs']['artifacts'][0]['raw']['data'] == operation_params['text']
 
-    # Ensure the pipeline operation was properly processed for execution, creating a KFP TaskSpec object
-    # assert isinstance(constructed_pipeline[operation.id], TaskSpec)
-
-    # filename = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "resources", component.source))
-    # assert constructed_pipeline[operation.id].component_ref.url == filename
+    component_ref = pipeline_template['metadata']['annotations']['pipelines.kubeflow.org/component_ref']
+    component_ref = ast.literal_eval(component_ref)
+    assert relative_path in component_ref['url']

--- a/elyra/pipeline/tests/test_processor_kfp.py
+++ b/elyra/pipeline/tests/test_processor_kfp.py
@@ -196,7 +196,7 @@ def test_collect_envs(processor):
 def test_processing_url_runtime_specific_component(monkeypatch, processor, sample_metadata, tmpdir):
     # Assign test resource location
     url = 'https://raw.githubusercontent.com/elyra-ai/elyra/master/' \
-          'etc/config/components/kfp/filter_text_using_shell_and_grep.yaml'
+          'elyra/pipeline/tests/resources/components/filter_text.yaml'
 
     # Instantiate a url-based component
     component = Component(id="filter-text",


### PR DESCRIPTION
Fixes #1981 as a follow up to #1982. 

### What changes were proposed in this pull request?
Instead of calling `_cc_pipeline()` directly, the pipeline YAML is compiled and saved to `tmpdir` for the comparison of expected vs. actual results.

~~Also changes the url for the tested component to reflect the relocation of component specs in #1974.~~

After discussion, a new test resource was added for the `Filter text` component specification. This way, the url-based component test will now be based on this static version of the component, and any changes made to the component spec stored in `etc/config/components` will not affect this particular test.

### How was this pull request tested?
The test `test_processor_kfp.py::test_processing_url_runtime_specific_component` will fail until this is merged, as it requires the component spec to be present in the pipeline test resources folder on master.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
