### PR TITLE
Add Describe Command to CLI

### DIFF
--- a/docs/source/user_guide/pipelines.md
+++ b/docs/source/user_guide/pipelines.md
@@ -141,7 +141,14 @@ To run a pipeline from the Visual Pipeline Editor:
 
 **Running a pipeline from the command line interface**
 
-The [`elyra-pipeline` command line interface](https://elyra.readthedocs.io/en/latest/user_guide/command-line-interface.html#working-with-pipelines) provides two pipeline execution commands: `run` and `submit`.
+The [`elyra-pipeline` command line interface](https://elyra.readthedocs.io/en/latest/user_guide/command-line-interface.html#working-with-pipelines)
+provides an informative command: `describe` and two execution commands: `run` and `submit`.
+
+Use the `elyra-pipeline describe` command to display pipeline details such as name, version, etc.
+
+```bash
+$ elyra-pipeline describe elyra-pipelines/a-notebook.pipeline
+```
 
 Use the `elyra-pipeline run` command to run a generic pipeline in your JupyterLab environment:
 
@@ -177,4 +184,3 @@ To export a pipeline from the Visual Pipeline Editor:
    ![Configure pipeline export options](../images/user_guide/pipelines/configure-pipeline-export-options.png)
 
 1. Import the exported pipeline file using the Kubeflow Central Dashboard or add it to the Git repository that Apache Airflow is monitoring.   
- 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -329,9 +329,9 @@ def describe(pipeline_path):
     pipeline_definition = \
         _preprocess_pipeline(pipeline_path, runtime='local', runtime_config='local')
 
-    print_banner(pipeline_definition)
-
     click.echo(pipeline_definition)
+
+    click.echo(type(pipeline_definition))
 
     print_banner("Elyra Pipeline Description Complete")
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -317,7 +317,7 @@ def run(pipeline_path):
               'json_option',
               is_flag=True,
               required=False,
-              help='Returns pipeline file in a machine-readable JSON format')
+              help='Display pipeline summary in JSON format')
 @click.argument('pipeline_path')
 def describe(json_option, pipeline_path):
     """

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -330,9 +330,9 @@ def describe(json_option, pipeline_path):
 
     indent_length = 4
     for current_pipeline in pipeline_definition["pipelines"]:
-        pipeline_keys = ["name", "description", "type", "version", "nodes", "dependencies"]
+        pipeline_keys = ["name", "description", "type", "version", "nodes", "file dependencies"]
 
-        iter_keys = {"dependencies"}
+        iter_keys = {"file_dependencies"}
 
         describe_dict = OrderedDict()
 
@@ -352,23 +352,24 @@ def describe(json_option, pipeline_path):
 
         describe_dict["nodes"] = len(current_pipeline.get("nodes", []))
 
-        describe_dict["dependencies"] = set()
+        describe_dict["file_dependencies"] = set()
         for node in current_pipeline["nodes"]:
             if "dependencies" in node["app_data"]["component_parameters"]:
                 for dependency in node["app_data"]["component_parameters"].get("dependencies", []):
-                    describe_dict["dependencies"].add(f"{dependency}")
+                    describe_dict["file_dependencies"].add(f"{dependency}")
 
         if not json_option:
             for key in pipeline_keys:
+                readable_key = ' '.join(key.title().split('_'))
                 if key in iter_keys:
-                    click.echo(f"{key.title()}:")
+                    click.echo(f"{readable_key}:")
                     if describe_dict.get(key, set()) == set():
                         click.echo(f"{' ' * indent_length}None")
                     else:
                         for item in describe_dict.get(key, ["None"]):
                             click.echo(f"{' ' * indent_length}{item}")
                 else:
-                    click.echo(f"{key.title()}: {describe_dict.get(key, 'None')}")
+                    click.echo(f"{readable_key}: {describe_dict.get(key, 'None')}")
         else:
             for key in iter_keys:
                 describe_dict[key] = list(describe_dict[key])

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -331,43 +331,32 @@ def describe(json_option, pipeline_path):
         _preprocess_pipeline(pipeline_path, runtime='local', runtime_config='local')
 
     if not json_option:
-        click.echo("Name:")
-        for current_pipeline in pipeline_definition["pipelines"]:
-            click.echo("  " + str(current_pipeline["app_data"]["properties"]["name"]))
-
-        click.echo("Version:")
-        for current_pipeline in pipeline_definition["pipelines"]:
-            click.echo("  " + str(current_pipeline["app_data"]["version"]))
-
-        has_description = False
+        indent_length = 2
 
         for current_pipeline in pipeline_definition["pipelines"]:
-            if current_pipeline["app_data"]["properties"]["description"] != "":
-                if not has_description:
-                    click.echo("Description:")
-                    has_description = True
-                click.echo("  " + str(current_pipeline["app_data"]["properties"]["description"]))
+            pipeline_data = current_pipeline["app_data"]
 
-        if not has_description:
-            click.echo("No Description")
+            click.echo("Name: " + str(pipeline_data["properties"]["name"]))
 
-        click.echo("Type:")
-        for current_pipeline in pipeline_definition["pipelines"]:
-            click.echo("  " + str(current_pipeline["app_data"]["properties"]["runtime"]))
+            click.echo("Version: " + str(pipeline_data["version"]))
 
-        has_dependencies = False
+            click.echo("Description: " + str(pipeline_data["properties"]["description"]))
 
-        for current_pipeline in pipeline_definition["pipelines"]:
+            click.echo("Type: " + str(pipeline_data["properties"]["runtime"]))
+
+            has_dependencies = False
+
+            click.echo("Dependencies:")
+
             for node in current_pipeline["nodes"]:
                 if len(node["app_data"]["component_parameters"]["dependencies"]) >= 1:
                     if not has_dependencies:
-                        click.echo("Dependencies:")
                         has_dependencies = True
                     for dependency in node["app_data"]["component_parameters"]["dependencies"]:
-                        click.echo("  " + str(dependency))
+                        click.echo((indent_length * " ") + str(dependency))
 
-        if not has_dependencies:
-            click.echo("No Dependencies")
+            if not has_dependencies:
+                click.echo((indent_length * " ") + "None")
     else:
         click.echo(json.dumps(pipeline_definition, indent=2))
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -332,7 +332,7 @@ def describe(pipeline_path):
     click.echo(type(pipeline_definition))
 
     for key in pipeline_definition:
-        click.echo(pipeline_definition[key])
+        click.echo(f"{key}: " + str(pipeline_definition[key]))
 
     print_banner("Elyra Pipeline Description Complete")
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -317,9 +317,14 @@ def run(pipeline_path):
 @click.argument('pipeline_path')
 def describe(pipeline_path):
     """
-    Display pipeline description in a human readable format
+    Describe a pipeline in a human readable format
     """
+
+    click.echo()
+
     print_banner("Elyra Pipeline Describe")
+
+    _validate_pipeline_file(pipeline_path)
 
 
 pipeline.add_command(submit)

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -324,15 +324,12 @@ def describe(pipeline_path):
 
     print_banner("Elyra Pipeline Describe")
 
-    _validate_pipeline_file(pipeline_path)
+    _validate_pipeline_file_extension(pipeline_path)
 
     pipeline_definition = \
         _preprocess_pipeline(pipeline_path, runtime='local', runtime_config='local')
 
-    for key in {"version", "doc_type"}:
-        click.echo(f"{key}:\n" + str(pipeline_definition[key]))
-
-    click.echo("Dependencies:")
+    click.echo("dependencies:")
     for current_pipeline in pipeline_definition["pipelines"]:
         for node in current_pipeline["nodes"]:
             for dependency in node["app_data"]["dependencies"]:

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -326,6 +326,11 @@ def describe(pipeline_path):
 
     _validate_pipeline_file(pipeline_path)
 
+    pipeline_definition = \
+        _preprocess_pipeline(pipeline_path, runtime='local', runtime_config='local')
+
+    print_banner(pipeline_definition)
+
     print_banner("Elyra Pipeline Description Complete")
 
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -344,8 +344,9 @@ def describe(json_option, pipeline_path):
 
         properties = pipeline_data.get("properties", dict())
 
-        # If the name is actually "None", it will seem as if there is no name
-        # The same can be said for all fields
+        # If the name is actually the same as the blank_field, it will seem as if there is no name
+        # The same can be said for all single fields
+        # The same issue happens with iterable fields and the blank_list
         describe_dict["name"] = properties.get("name")
 
         describe_dict["description"] = properties.get("description")

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -329,7 +329,7 @@ def describe(json_option, pipeline_path):
     _validate_pipeline_file_extension(pipeline_path)
 
     pipeline_definition = \
-        _preprocess_pipeline(pipeline_path, runtime='local', runtime_config='local')
+        _preprocess_pipeline(pipeline_path, runtime="None", runtime_config="None")
 
     indent_length = 4
     for current_pipeline in pipeline_definition["pipelines"]:

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -329,23 +329,34 @@ def describe(pipeline_path):
     pipeline_definition = \
         _preprocess_pipeline(pipeline_path, runtime='local', runtime_config='local')
 
-    click.echo("version:")
+    click.echo("Version:")
     for current_pipeline in pipeline_definition["pipelines"]:
         click.echo(current_pipeline["app_data"]["version"])
 
-    click.echo("description:")
+    click.echo()
+
+    click.echo("Description:")
     for current_pipeline in pipeline_definition["pipelines"]:
         click.echo(current_pipeline["app_data"]["properties"]["description"])
 
-    click.echo("type:")
+    click.echo()
+
+    click.echo("Type:")
     for current_pipeline in pipeline_definition["pipelines"]:
         click.echo(current_pipeline["app_data"]["properties"]["runtime"])
 
-    click.echo("dependencies:")
+    click.echo()
+
     for current_pipeline in pipeline_definition["pipelines"]:
         for node in current_pipeline["nodes"]:
-            for dependency in node["app_data"]["component_parameters"]["dependencies"]:
-                click.echo(dependency)
+            if len(node["app_data"]["component_parameters"]["dependencies"]) != 0:
+                click.echo("Dependencies:")
+                for dependency in node["app_data"]["component_parameters"]["dependencies"]:
+                    click.echo(dependency)
+            else:
+                pass
+
+    click.echo()
 
     print_banner("Elyra Pipeline Description Complete")
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -332,7 +332,7 @@ def describe(json_option, pipeline_path):
 
     blank_field = "Not Specified"
 
-    blank_list = "None Listed"
+    blank_list = ["None Listed"]
     for current_pipeline in pipeline_definition["pipelines"]:
         pipeline_keys = ["name", "description", "type", "version", "nodes", "file dependencies"]
 
@@ -346,13 +346,13 @@ def describe(json_option, pipeline_path):
 
         # If the name is actually "None", it will seem as if there is no name
         # The same can be said for all fields
-        describe_dict["name"] = properties.get("name", blank_field)
+        describe_dict["name"] = properties.get("name")
 
-        describe_dict["description"] = properties.get("description", blank_field)
+        describe_dict["description"] = properties.get("description")
 
-        describe_dict["type"] = properties.get("runtime", blank_field)
+        describe_dict["type"] = properties.get("runtime")
 
-        describe_dict["version"] = pipeline_data.get("version", blank_field)
+        describe_dict["version"] = pipeline_data.get("version")
 
         describe_dict["nodes"] = len(current_pipeline.get("nodes", []))
 
@@ -370,7 +370,7 @@ def describe(json_option, pipeline_path):
                     if describe_dict.get(key, set()) == set():
                         click.echo(f"{' ' * indent_length}{blank_field}")
                     else:
-                        for item in describe_dict.get(key, [blank_list]):
+                        for item in describe_dict.get(key, blank_list):
                             click.echo(f"{' ' * indent_length}{item}")
                 else:
                     click.echo(f"{readable_key}: {describe_dict.get(key, blank_field)}")

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -328,8 +328,7 @@ def describe(json_option, pipeline_path):
 
     _validate_pipeline_file_extension(pipeline_path)
 
-    pipeline_definition = \
-        _preprocess_pipeline(pipeline_path, runtime="None", runtime_config="None")
+    pipeline_definition = _preprocess_pipeline(pipeline_path)
 
     indent_length = 4
     for current_pipeline in pipeline_definition["pipelines"]:

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -333,10 +333,12 @@ def describe(json_option, pipeline_path):
     blank_field = "Not Specified"
 
     blank_list = ["None Listed"]
-    for current_pipeline in pipeline_definition["pipelines"]:
-        pipeline_keys = ["name", "description", "type", "version", "nodes", "file dependencies"]
 
-        iter_keys = {"file_dependencies"}
+    pipeline_keys = ["name", "description", "type", "version", "nodes", "file_dependencies"]
+
+    iter_keys = {"file_dependencies"}
+
+    for current_pipeline in pipeline_definition.get("pipelines", list()):
 
         describe_dict = OrderedDict()
 
@@ -355,12 +357,13 @@ def describe(json_option, pipeline_path):
 
         describe_dict["version"] = pipeline_data.get("version")
 
-        describe_dict["nodes"] = len(current_pipeline.get("nodes", []))
+        describe_dict["nodes"] = len(current_pipeline.get("nodes", list()))
 
         describe_dict["file_dependencies"] = set()
-        for node in current_pipeline["nodes"]:
-            if "dependencies" in node["app_data"]["component_parameters"]:
-                for dependency in node["app_data"]["component_parameters"].get("dependencies", []):
+        for node in current_pipeline.get("nodes", list()):
+            if "dependencies" in node.get("app_data", dict()).get("component_parameters", list()):
+                for dependency in \
+                        node.get("app_data", dict()).get("component_parameters", dict()).get("dependencies", list()):
                     describe_dict["file_dependencies"].add(f"{dependency}")
 
         if not json_option:

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -337,9 +337,10 @@ def describe(json_option, pipeline_path):
 
             pipeline_values = ["None"] * len(pipeline_keys)
 
-            pipeline_values[pipeline_keys.index("description")] = \
-                pipeline_values[pipeline_keys.index("dependencies")] = \
-                f"\n{' ' * indent_length}None"
+            list_keys = {"description", "dependencies"}
+
+            for key in list_keys:
+                pipeline_values[pipeline_keys.index(key)] = f"\n{' ' * indent_length}None"
 
             properties = current_pipeline["app_data"]["properties"]
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -331,6 +331,8 @@ def describe(pipeline_path):
 
     print_banner(pipeline_definition)
 
+    click.echo(pipeline_definition)
+
     print_banner("Elyra Pipeline Description Complete")
 
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -332,7 +332,7 @@ def describe(pipeline_path):
     click.echo(type(pipeline_definition))
 
     for key in pipeline_definition:
-        click.echo(f"{key}: " + str(pipeline_definition[key]))
+        click.echo(f"{key}({type(pipeline_definition[key])}):\n" + str(pipeline_definition[key]))
 
     print_banner("Elyra Pipeline Description Complete")
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -331,19 +331,27 @@ def describe(pipeline_path):
 
     click.echo("Version:")
     for current_pipeline in pipeline_definition["pipelines"]:
-        click.echo(current_pipeline["app_data"]["version"])
+        click.echo("\t" + str(current_pipeline["app_data"]["version"]))
 
     click.echo()
 
-    click.echo("Description:")
+    has_description = False
+
     for current_pipeline in pipeline_definition["pipelines"]:
-        click.echo(current_pipeline["app_data"]["properties"]["description"])
+        if current_pipeline["app_data"]["properties"]["description"] != "":
+            if not has_description:
+                click.echo("Description:")
+                has_description = True
+            click.echo("\t" + str(current_pipeline["app_data"]["properties"]["description"]))
+
+    if not has_description:
+        click.echo("No Description")
 
     click.echo()
 
     click.echo("Type:")
     for current_pipeline in pipeline_definition["pipelines"]:
-        click.echo(current_pipeline["app_data"]["properties"]["runtime"])
+        click.echo("\t" + str(current_pipeline["app_data"]["properties"]["runtime"]))
 
     click.echo()
 
@@ -356,11 +364,11 @@ def describe(pipeline_path):
                     click.echo("Dependencies:")
                     has_dependencies = True
                 for dependency in node["app_data"]["component_parameters"]["dependencies"]:
-                    click.echo(dependency)
+                    click.echo("\t" + str(dependency))
 
     if not has_dependencies:
         click.echo("No Dependencies")
-        
+
     click.echo()
 
     print_banner("Elyra Pipeline Description Complete")

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -331,6 +331,10 @@ def describe(json_option, pipeline_path):
         _preprocess_pipeline(pipeline_path, runtime='local', runtime_config='local')
 
     if not json_option:
+        click.echo("Name:")
+        for current_pipeline in pipeline_definition["pipelines"]:
+            click.echo("  " + str(current_pipeline["app_data"]["properties"]["name"]))
+
         click.echo("Version:")
         for current_pipeline in pipeline_definition["pipelines"]:
             click.echo("  " + str(current_pipeline["app_data"]["version"]))

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -347,15 +347,20 @@ def describe(pipeline_path):
 
     click.echo()
 
+    has_dependencies = False
+
     for current_pipeline in pipeline_definition["pipelines"]:
         for node in current_pipeline["nodes"]:
-            if len(node["app_data"]["component_parameters"]["dependencies"]) != 0:
-                click.echo("Dependencies:")
+            if len(node["app_data"]["component_parameters"]["dependencies"]) >= 1:
+                if not has_dependencies:
+                    click.echo("Dependencies:")
+                    has_dependencies = True
                 for dependency in node["app_data"]["component_parameters"]["dependencies"]:
                     click.echo(dependency)
-            else:
-                pass
 
+    if not has_dependencies:
+        click.echo("No Dependencies")
+        
     click.echo()
 
     print_banner("Elyra Pipeline Description Complete")

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -325,10 +325,6 @@ def describe(json_option, pipeline_path):
     Describe a pipeline in a human readable format
     """
 
-    click.echo()
-
-    print_banner("Elyra Pipeline Describe")
-
     _validate_pipeline_file_extension(pipeline_path)
 
     pipeline_definition = \
@@ -337,9 +333,7 @@ def describe(json_option, pipeline_path):
     if not json_option:
         click.echo("Version:")
         for current_pipeline in pipeline_definition["pipelines"]:
-            click.echo("\t" + str(current_pipeline["app_data"]["version"]))
-
-        click.echo()
+            click.echo("  " + str(current_pipeline["app_data"]["version"]))
 
         has_description = False
 
@@ -348,18 +342,14 @@ def describe(json_option, pipeline_path):
                 if not has_description:
                     click.echo("Description:")
                     has_description = True
-                click.echo("\t" + str(current_pipeline["app_data"]["properties"]["description"]))
+                click.echo("  " + str(current_pipeline["app_data"]["properties"]["description"]))
 
         if not has_description:
             click.echo("No Description")
 
-        click.echo()
-
         click.echo("Type:")
         for current_pipeline in pipeline_definition["pipelines"]:
-            click.echo("\t" + str(current_pipeline["app_data"]["properties"]["runtime"]))
-
-        click.echo()
+            click.echo("  " + str(current_pipeline["app_data"]["properties"]["runtime"]))
 
         has_dependencies = False
 
@@ -370,16 +360,12 @@ def describe(json_option, pipeline_path):
                         click.echo("Dependencies:")
                         has_dependencies = True
                     for dependency in node["app_data"]["component_parameters"]["dependencies"]:
-                        click.echo("\t" + str(dependency))
+                        click.echo("  " + str(dependency))
 
         if not has_dependencies:
             click.echo("No Dependencies")
     else:
         click.echo(json.dumps(pipeline_definition, indent=2))
-
-    click.echo()
-
-    print_banner("Elyra Pipeline Description Complete")
 
 
 pipeline.add_command(submit)

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -322,7 +322,7 @@ def run(pipeline_path):
 @click.argument('pipeline_path')
 def describe(json_option, pipeline_path):
     """
-    Describe a pipeline in a human readable format
+    Display pipeline description in a human readable format
     """
 
     _validate_pipeline_file_extension(pipeline_path)

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -335,7 +335,7 @@ def describe(json_option, pipeline_path):
     for current_pipeline in pipeline_definition["pipelines"]:
         pipeline_keys = ["name", "description", "type", "version", "nodes", "dependencies"]
 
-        list_keys = {"dependencies"}
+        iter_keys = {"dependencies"}
 
         describe_dict = OrderedDict()
 
@@ -355,22 +355,26 @@ def describe(json_option, pipeline_path):
 
         describe_dict["nodes"] = str(len(current_pipeline.get("nodes", [])))
 
+        describe_dict["dependencies"] = set()
         for node in current_pipeline["nodes"]:
             if "dependencies" in node["app_data"]["component_parameters"]:
                 for dependency in node["app_data"]["component_parameters"].get("dependencies", []):
-                    if describe_dict.get("dependencies") is None:
-                        describe_dict["dependencies"] = []
-                    describe_dict["dependencies"].append(f"{dependency}")
+                    describe_dict["dependencies"].add(f"{dependency}")
+
         if not json_option:
             for key in pipeline_keys:
-                if key in list_keys:
-                    click.echo(f"{key.title()}")
-                    for item in describe_dict.get(key, ["None"]):
-                        click.echo(f"{' ' * indent_length}{item}")
+                if key in iter_keys:
+                    click.echo(f"{key.title()}:")
+                    if describe_dict.get(key, set()) == set():
+                        click.echo(f"{' ' * indent_length}None")
+                    else:
+                        for item in describe_dict.get(key, ["None"]):
+                            click.echo(f"{' ' * indent_length}{item}")
                 else:
                     click.echo(f"{key.title()}: {describe_dict.get(key, 'None')}")
-
         else:
+            for key in iter_keys:
+                describe_dict[key] = list(describe_dict[key])
             click.echo(json.dumps(describe_dict, indent=indent_length))
 
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -379,6 +379,9 @@ def describe(json_option, pipeline_path):
                 else:
                     click.echo(f"{readable_key}: {describe_dict.get(key, blank_field)}")
         else:
+            for key in pipeline_keys:
+                if describe_dict.get(key) is None:
+                    describe_dict.pop(key)
             for key in iter_keys:
                 describe_dict[key] = list(describe_dict[key])
             click.echo(json.dumps(describe_dict, indent=indent_length))

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -345,24 +345,19 @@ def describe(json_option, pipeline_path):
 
         # If the name is actually "None", it will seem as if there is no name
         # The same can be said for all fields
-        if "name" in properties.keys():
-            describe_dict["name"] = str(properties.get("name"))
+        describe_dict["name"] = str(properties.get("name", "None"))
 
-        if "description" in properties.keys():
-            describe_dict["description"] = str(properties.get("description"))
+        describe_dict["description"] = str(properties.get("description", "None"))
 
-        if "runtime" in properties.keys():
-            describe_dict["type"] = str(properties.get("runtime"))
+        describe_dict["type"] = str(properties.get("runtime", "None"))
 
-        if "version" in pipeline_data.keys():
-            describe_dict["version"] = str(pipeline_data.get("version"))
+        describe_dict["version"] = str(pipeline_data.get("version", "None"))
 
-        # Will break if there are no nodes
-        describe_dict["nodes"] = str(len(current_pipeline["nodes"]))
+        describe_dict["nodes"] = str(len(current_pipeline.get("nodes", [])))
 
         for node in current_pipeline["nodes"]:
             if "dependencies" in node["app_data"]["component_parameters"]:
-                for dependency in node["app_data"]["component_parameters"].get("dependencies"):
+                for dependency in node["app_data"]["component_parameters"].get("dependencies", []):
                     if describe_dict.get("dependencies") is None:
                         describe_dict["dependencies"] = []
                     describe_dict["dependencies"].append(f"{dependency}")
@@ -370,16 +365,10 @@ def describe(json_option, pipeline_path):
             for key in pipeline_keys:
                 if key in list_keys:
                     click.echo(f"{key.title()}")
-                    if describe_dict.get(key) is None:
-                        click.echo(f"{' ' * indent_length}None")
-                    else:
-                        for item in describe_dict[key]:
-                            click.echo(f"{' ' * indent_length}{item}")
+                    for item in describe_dict.get(key, ["None"]):
+                        click.echo(f"{' ' * indent_length}{item}")
                 else:
-                    if describe_dict.get(key) is None:
-                        click.echo(f"{key.title()}: None")
-                    else:
-                        click.echo(f"{key.title()}: {describe_dict[key]}")
+                    click.echo(f"{key.title()}: {describe_dict.get(key, 'None')}")
 
         else:
             click.echo(json.dumps(describe_dict, indent=indent_length))

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -379,11 +379,12 @@ def describe(json_option, pipeline_path):
                 else:
                     click.echo(f"{readable_key}: {describe_dict.get(key, blank_field)}")
         else:
-            for key in pipeline_keys:
-                if describe_dict.get(key) is None:
-                    describe_dict.pop(key)
             for key in iter_keys:
                 describe_dict[key] = list(describe_dict[key])
+            for key in pipeline_keys:
+                value = describe_dict.get(key)
+                if value is None or (key in iter_keys and len(value) == 0):
+                    describe_dict.pop(key)
             click.echo(json.dumps(describe_dict, indent=indent_length))
 
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -329,10 +329,22 @@ def describe(pipeline_path):
     pipeline_definition = \
         _preprocess_pipeline(pipeline_path, runtime='local', runtime_config='local')
 
+    click.echo("version:")
+    for current_pipeline in pipeline_definition["pipelines"]:
+        click.echo(current_pipeline["app_data"]["version"])
+
+    click.echo("description:")
+    for current_pipeline in pipeline_definition["pipelines"]:
+        click.echo(current_pipeline["app_data"]["properties"]["description"])
+
+    click.echo("type:")
+    for current_pipeline in pipeline_definition["pipelines"]:
+        click.echo(current_pipeline["app_data"]["properties"]["runtime"])
+
     click.echo("dependencies:")
     for current_pipeline in pipeline_definition["pipelines"]:
         for node in current_pipeline["nodes"]:
-            for dependency in node["app_data"]["dependencies"]:
+            for dependency in node["app_data"]["component_parameters"]["dependencies"]:
                 click.echo(dependency)
 
     print_banner("Elyra Pipeline Description Complete")

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -321,7 +321,7 @@ def run(pipeline_path):
 @click.argument('pipeline_path')
 def describe(json_option, pipeline_path):
     """
-    Display pipeline description in a human readable format
+    Display pipeline summary
     """
 
     _validate_pipeline_file_extension(pipeline_path)

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -338,11 +338,11 @@ def describe(json_option, pipeline_path):
 
             click.echo("Name: " + str(pipeline_data["properties"]["name"]))
 
-            click.echo("Version: " + str(pipeline_data["version"]))
-
             click.echo("Description: " + str(pipeline_data["properties"]["description"]))
 
             click.echo("Type: " + str(pipeline_data["properties"]["runtime"]))
+
+            click.echo("Version: " + str(pipeline_data["version"]))
 
             has_dependencies = False
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -314,8 +314,13 @@ def run(pipeline_path):
 
 
 @click.command()
+@click.option('--json',
+              'json_option',
+              is_flag=True,
+              required=False,
+              help='Returns pipeline file in a machine-readable JSON format')
 @click.argument('pipeline_path')
-def describe(pipeline_path):
+def describe(json_option, pipeline_path):
     """
     Describe a pipeline in a human readable format
     """
@@ -329,45 +334,48 @@ def describe(pipeline_path):
     pipeline_definition = \
         _preprocess_pipeline(pipeline_path, runtime='local', runtime_config='local')
 
-    click.echo("Version:")
-    for current_pipeline in pipeline_definition["pipelines"]:
-        click.echo("\t" + str(current_pipeline["app_data"]["version"]))
+    if not json_option:
+        click.echo("Version:")
+        for current_pipeline in pipeline_definition["pipelines"]:
+            click.echo("\t" + str(current_pipeline["app_data"]["version"]))
 
-    click.echo()
+        click.echo()
 
-    has_description = False
+        has_description = False
 
-    for current_pipeline in pipeline_definition["pipelines"]:
-        if current_pipeline["app_data"]["properties"]["description"] != "":
-            if not has_description:
-                click.echo("Description:")
-                has_description = True
-            click.echo("\t" + str(current_pipeline["app_data"]["properties"]["description"]))
+        for current_pipeline in pipeline_definition["pipelines"]:
+            if current_pipeline["app_data"]["properties"]["description"] != "":
+                if not has_description:
+                    click.echo("Description:")
+                    has_description = True
+                click.echo("\t" + str(current_pipeline["app_data"]["properties"]["description"]))
 
-    if not has_description:
-        click.echo("No Description")
+        if not has_description:
+            click.echo("No Description")
 
-    click.echo()
+        click.echo()
 
-    click.echo("Type:")
-    for current_pipeline in pipeline_definition["pipelines"]:
-        click.echo("\t" + str(current_pipeline["app_data"]["properties"]["runtime"]))
+        click.echo("Type:")
+        for current_pipeline in pipeline_definition["pipelines"]:
+            click.echo("\t" + str(current_pipeline["app_data"]["properties"]["runtime"]))
 
-    click.echo()
+        click.echo()
 
-    has_dependencies = False
+        has_dependencies = False
 
-    for current_pipeline in pipeline_definition["pipelines"]:
-        for node in current_pipeline["nodes"]:
-            if len(node["app_data"]["component_parameters"]["dependencies"]) >= 1:
-                if not has_dependencies:
-                    click.echo("Dependencies:")
-                    has_dependencies = True
-                for dependency in node["app_data"]["component_parameters"]["dependencies"]:
-                    click.echo("\t" + str(dependency))
+        for current_pipeline in pipeline_definition["pipelines"]:
+            for node in current_pipeline["nodes"]:
+                if len(node["app_data"]["component_parameters"]["dependencies"]) >= 1:
+                    if not has_dependencies:
+                        click.echo("Dependencies:")
+                        has_dependencies = True
+                    for dependency in node["app_data"]["component_parameters"]["dependencies"]:
+                        click.echo("\t" + str(dependency))
 
-    if not has_dependencies:
-        click.echo("No Dependencies")
+        if not has_dependencies:
+            click.echo("No Dependencies")
+    else:
+        click.echo(json.dumps(pipeline_definition, indent=2))
 
     click.echo()
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -319,7 +319,7 @@ def describe(pipeline_path):
     """
     Display pipeline description in a human readable format
     """
-    print_banner("Elyra Pipeline Local Run")
+    print_banner("Elyra Pipeline Describe")
 
 
 pipeline.add_command(submit)

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -313,5 +313,15 @@ def run(pipeline_path):
     print_banner("Elyra Pipeline Local Run Complete")
 
 
+@click.command()
+@click.argument('pipeline_path')
+def describe(pipeline_path):
+    """
+    Display pipeline description in a human readable format
+    """
+    print_banner("Elyra Pipeline Local Run")
+
+
 pipeline.add_command(submit)
 pipeline.add_command(run)
+pipeline.add_command(describe)

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -329,10 +329,14 @@ def describe(pipeline_path):
     pipeline_definition = \
         _preprocess_pipeline(pipeline_path, runtime='local', runtime_config='local')
 
-    click.echo(type(pipeline_definition))
+    for key in {"version", "doc_type"}:
+        click.echo(f"{key}:\n" + str(pipeline_definition[key]))
 
-    for key in pipeline_definition:
-        click.echo(f"{key}({type(pipeline_definition[key])}):\n" + str(pipeline_definition[key]))
+    click.echo("Dependencies:")
+    for current_pipeline in pipeline_definition["pipelines"]:
+        for node in current_pipeline["nodes"]:
+            for dependency in node["app_data"]["dependencies"]:
+                click.echo(dependency)
 
     print_banner("Elyra Pipeline Description Complete")
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -336,21 +336,21 @@ def describe(json_option, pipeline_path):
 
         describe_dict = OrderedDict()
 
-        properties = current_pipeline["app_data"]["properties"]
+        pipeline_data = current_pipeline.get("app_data", dict())
 
-        pipeline_data = current_pipeline["app_data"]
+        properties = pipeline_data.get("properties", dict())
 
         # If the name is actually "None", it will seem as if there is no name
         # The same can be said for all fields
-        describe_dict["name"] = str(properties.get("name", "None"))
+        describe_dict["name"] = properties.get("name", "None")
 
-        describe_dict["description"] = str(properties.get("description", "None"))
+        describe_dict["description"] = properties.get("description", "None")
 
-        describe_dict["type"] = str(properties.get("runtime", "None"))
+        describe_dict["type"] = properties.get("runtime", "None")
 
-        describe_dict["version"] = str(pipeline_data.get("version", "None"))
+        describe_dict["version"] = pipeline_data.get("version", "None")
 
-        describe_dict["nodes"] = str(len(current_pipeline.get("nodes", [])))
+        describe_dict["nodes"] = len(current_pipeline.get("nodes", []))
 
         describe_dict["dependencies"] = set()
         for node in current_pipeline["nodes"]:

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -329,6 +329,10 @@ def describe(json_option, pipeline_path):
     pipeline_definition = _preprocess_pipeline(pipeline_path)
 
     indent_length = 4
+
+    blank_field = "Not Specified"
+
+    blank_list = "None Listed"
     for current_pipeline in pipeline_definition["pipelines"]:
         pipeline_keys = ["name", "description", "type", "version", "nodes", "file dependencies"]
 
@@ -342,13 +346,13 @@ def describe(json_option, pipeline_path):
 
         # If the name is actually "None", it will seem as if there is no name
         # The same can be said for all fields
-        describe_dict["name"] = properties.get("name", "None")
+        describe_dict["name"] = properties.get("name", blank_field)
 
-        describe_dict["description"] = properties.get("description", "None")
+        describe_dict["description"] = properties.get("description", blank_field)
 
-        describe_dict["type"] = properties.get("runtime", "None")
+        describe_dict["type"] = properties.get("runtime", blank_field)
 
-        describe_dict["version"] = pipeline_data.get("version", "None")
+        describe_dict["version"] = pipeline_data.get("version", blank_field)
 
         describe_dict["nodes"] = len(current_pipeline.get("nodes", []))
 
@@ -364,12 +368,12 @@ def describe(json_option, pipeline_path):
                 if key in iter_keys:
                     click.echo(f"{readable_key}:")
                     if describe_dict.get(key, set()) == set():
-                        click.echo(f"{' ' * indent_length}None")
+                        click.echo(f"{' ' * indent_length}{blank_field}")
                     else:
-                        for item in describe_dict.get(key, ["None"]):
+                        for item in describe_dict.get(key, [blank_list]):
                             click.echo(f"{' ' * indent_length}{item}")
                 else:
-                    click.echo(f"{readable_key}: {describe_dict.get(key, 'None')}")
+                    click.echo(f"{readable_key}: {describe_dict.get(key, blank_field)}")
         else:
             for key in iter_keys:
                 describe_dict[key] = list(describe_dict[key])

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -73,13 +73,11 @@ def _validate_pipeline_runtime(primary_pipeline: dict, runtime: str) -> bool:
     Generic pipelines do not have a persisted runtime type, and can be run on any runtime
     Runtime specific pipeline have a runtime type, and con only be run on matching runtime
     """
-    is_valid = False
-    pipeline_runtime = primary_pipeline["app_data"].get("runtime")
-    if not pipeline_runtime:
-        is_valid = True
-    else:
-        if runtime and pipeline_runtime == runtime:
-            is_valid = True
+    is_valid = True
+    if runtime:  # Only perform validation if a target runtime has been specified
+        pipeline_runtime = primary_pipeline["app_data"].get("runtime")
+        if pipeline_runtime and pipeline_runtime != runtime:
+            is_valid = False
 
     return is_valid
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -333,11 +333,13 @@ def describe(json_option, pipeline_path):
     if not json_option:
         indent_length = 4
         for current_pipeline in pipeline_definition["pipelines"]:
-            pipeline_keys = ["name", "description", "type", "version", "dependencies"]
+            pipeline_keys = ["name", "description", "type", "version", "nodes", "dependencies"]
 
             pipeline_values = ["None"] * len(pipeline_keys)
 
-            pipeline_values[1] = pipeline_values[4] = f"\n{' ' * indent_length}None"
+            pipeline_values[pipeline_keys.index("description")] = \
+                pipeline_values[pipeline_keys.index("dependencies")] = \
+                f"\n{' ' * indent_length}None"
 
             properties = current_pipeline["app_data"]["properties"]
 
@@ -358,6 +360,8 @@ def describe(json_option, pipeline_path):
                 pipeline_values[pipeline_keys.index("version")] = str(pipeline_data.get("version"))
 
             # Will break if there are no nodes
+            pipeline_values[pipeline_keys.index("nodes")] = str(len(current_pipeline["nodes"]))
+
             for node in current_pipeline["nodes"]:
                 if "dependencies" in node["app_data"]["component_parameters"]:
                     for dependency in node["app_data"]["component_parameters"].get("dependencies"):

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -326,6 +326,8 @@ def describe(pipeline_path):
 
     _validate_pipeline_file(pipeline_path)
 
+    print_banner("Elyra Pipeline Description Complete")
+
 
 pipeline.add_command(submit)
 pipeline.add_command(run)

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -372,7 +372,7 @@ def describe(json_option, pipeline_path):
                 if key in iter_keys:
                     click.echo(f"{readable_key}:")
                     if describe_dict.get(key, set()) == set():
-                        click.echo(f"{' ' * indent_length}{blank_field}")
+                        click.echo(f"{' ' * indent_length}{blank_list[0]}")
                     else:
                         for item in describe_dict.get(key, blank_list):
                             click.echo(f"{' ' * indent_length}{item}")

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -329,9 +329,10 @@ def describe(pipeline_path):
     pipeline_definition = \
         _preprocess_pipeline(pipeline_path, runtime='local', runtime_config='local')
 
-    click.echo(pipeline_definition)
-
     click.echo(type(pipeline_definition))
+
+    for key in pipeline_definition:
+        click.echo(pipeline_definition[key])
 
     print_banner("Elyra Pipeline Description Complete")
 

--- a/elyra/cli/tests/test_pipeline_app.py
+++ b/elyra/cli/tests/test_pipeline_app.py
@@ -21,7 +21,7 @@ from click.testing import CliRunner
 import elyra.cli.pipeline_app as pipeline_app
 from elyra.cli.pipeline_app import pipeline
 
-SUB_COMMANDS = ['run', 'submit']
+SUB_COMMANDS = ['run', 'submit', 'describe']
 
 PIPELINE_SOURCE_WITH_ZERO_LENGTH_PIPELINES_FIELD = \
     '{"doc_type":"pipeline","version":"3.0","id":"0","primary_pipeline":"1","pipelines":[],"schemas":[]}'

--- a/elyra/cli/tests/test_pipeline_app.py
+++ b/elyra/cli/tests/test_pipeline_app.py
@@ -42,7 +42,7 @@ def test_no_opts():
     result = runner.invoke(pipeline)
     assert 'run       Run a pipeline in your local environment' in result.output
     assert 'submit    Submit a pipeline to be executed on the server' in result.output
-    assert 'describe  Display pipeline description in a human readable format' in result.output
+    assert 'describe  Display pipeline summary' in result.output
     assert result.exit_code == 0
 
 

--- a/elyra/cli/tests/test_pipeline_app.py
+++ b/elyra/cli/tests/test_pipeline_app.py
@@ -40,9 +40,9 @@ def mock_get_runtime_type(runtime_config: str) -> str:
 def test_no_opts():
     runner = CliRunner()
     result = runner.invoke(pipeline)
-    assert 'run     Run a pipeline in your local environment' in result.output
-    assert 'submit  Submit a pipeline to be executed on the server' in result.output
-    assert 'describe    Display pipeline description in a human readable format' in result.output
+    assert 'run       Run a pipeline in your local environment' in result.output
+    assert 'submit    Submit a pipeline to be executed on the server' in result.output
+    assert 'describe  Display pipeline description in a human readable format' in result.output
     assert result.exit_code == 0
 
 

--- a/elyra/cli/tests/test_pipeline_app.py
+++ b/elyra/cli/tests/test_pipeline_app.py
@@ -42,6 +42,7 @@ def test_no_opts():
     result = runner.invoke(pipeline)
     assert 'run     Run a pipeline in your local environment' in result.output
     assert 'submit  Submit a pipeline to be executed on the server' in result.output
+    assert 'describe    Display pipeline description in a human readable format' in result.output
     assert result.exit_code == 0
 
 

--- a/elyra/cli/tests/test_pipeline_app.py
+++ b/elyra/cli/tests/test_pipeline_app.py
@@ -82,6 +82,15 @@ def test_submit_with_invalid_pipeline(monkeypatch):
     assert result.exit_code != 0
 
 
+def test_describe_with_invalid_pipeline():
+    runner = CliRunner()
+
+    result = runner.invoke(pipeline, ['describe', 'foo.pipeline'])
+    assert "Pipeline file not found:" in result.output
+    assert "foo.pipeline" in result.output
+    assert result.exit_code != 0
+
+
 def test_run_with_unsupported_file_type():
     runner = CliRunner()
     with runner.isolated_filesystem():
@@ -103,6 +112,17 @@ def test_submit_with_unsupported_file_type(monkeypatch):
 
         result = runner.invoke(pipeline, ['submit', 'foo.ipynb',
                                           '--runtime-config', 'foo'])
+        assert "Pipeline file should be a [.pipeline] file" in result.output
+        assert result.exit_code != 0
+
+
+def test_describe_with_unsupported_file_type():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('foo.ipynb', 'w') as f:
+            f.write('{ "nbformat": 4, "cells": [] }')
+
+        result = runner.invoke(pipeline, ['describe', 'foo.ipynb'])
         assert "Pipeline file should be a [.pipeline] file" in result.output
         assert result.exit_code != 0
 
@@ -134,6 +154,18 @@ def test_submit_with_no_pipelines_field(monkeypatch):
         assert result.exit_code != 0
 
 
+def test_describe_with_no_pipelines_field():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('foo.pipeline', 'w') as pipeline_file:
+            pipeline_file.write(PIPELINE_SOURCE_WITHOUT_PIPELINES_FIELD)
+            pipeline_file_path = os.path.join(os.getcwd(), pipeline_file.name)
+
+        result = runner.invoke(pipeline, ['describe', pipeline_file_path])
+        assert "Pipeline is missing 'pipelines' field." in result.output
+        assert result.exit_code != 0
+
+
 def test_run_with_zero_length_pipelines_field():
     runner = CliRunner()
     with runner.isolated_filesystem():
@@ -157,6 +189,18 @@ def test_submit_with_zero_length_pipelines_field(monkeypatch):
 
         result = runner.invoke(pipeline, ['submit', pipeline_file_path,
                                           '--runtime-config', 'foo'])
+        assert "Pipeline has zero length 'pipelines' field." in result.output
+        assert result.exit_code != 0
+
+
+def test_describe_with_zero_length_pipelines_field():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('foo.pipeline', 'w') as pipeline_file:
+            pipeline_file.write(PIPELINE_SOURCE_WITH_ZERO_LENGTH_PIPELINES_FIELD)
+            pipeline_file_path = os.path.join(os.getcwd(), pipeline_file.name)
+
+        result = runner.invoke(pipeline, ['describe', pipeline_file_path])
         assert "Pipeline has zero length 'pipelines' field." in result.output
         assert result.exit_code != 0
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description is updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->
These changes close #1831, adding a `describe` command to the CLI.
```
$ elyra-pipeline describe <path_to_pipeline>
```
Our expected output if [this file](https://github.com/elyra-ai/examples/blob/master/pipelines/run-generic-pipelines-on-kubeflow-pipelines/hello-generic-world.pipeline) was placed in the path:
```
Name: hello-generic-world
Description: A generic pipeline tutorial
Type: Generic
Version: 4
Nodes: 4
File Dependencies: 
    None Listed
```
Any missing and/or empty fields will be listed as "None".
The command has the optional flag `--json`.
```
$ elyra-pipeline describe --json <path_to_pipeline>
```
This will return the same information in JSON format. Any fields that are missing/empty will also be undefined in the output.
This is the `--json` output for the same pipeline file:
```
{
    "name": "hello-generic-world",
    "description": "A generic pipeline tutorial",
    "type": "Generic",
    "version": 4,
    "nodes": 4
}
```

### How was this pull request tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
I've added a few tests based on the tests that were already in the `test_pipeline_app` file for the 'run' command.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
