### PR TITLE
Make Pipeline CLI preprocessing parameters optional

### DIFF
--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -85,7 +85,9 @@ def _validate_pipeline_file_extension(pipeline_file: str):
         raise click.ClickException('Pipeline file should be a [.pipeline] file.\n')
 
 
-def _preprocess_pipeline(pipeline_path: str, runtime: str, runtime_config: str) -> dict:
+def _preprocess_pipeline(pipeline_path: str,
+                         runtime: Optional[str] = None,
+                         runtime_config: Optional[str] = None) -> dict:
     pipeline_path = os.path.expanduser(pipeline_path)
     pipeline_abs_path = os.path.join(os.getcwd(), pipeline_path)
     pipeline_dir = os.path.dirname(pipeline_abs_path)
@@ -136,7 +138,7 @@ def _preprocess_pipeline(pipeline_path: str, runtime: str, runtime_config: str) 
         raise click.ClickException(f"Error pre-processing pipeline: \n {e}")
 
     if not _validate_pipeline_runtime(primary_pipeline, runtime):
-        runtime_description = primary_pipeline['app_data']['ui_data']['runtime']['display_name']
+        runtime_description = primary_pipeline['app_data']['properties']['runtime']
         runtime_config_display_name = _get_runtime_display_name(runtime_config)
         raise click.ClickException(
             f"This pipeline requires an instance of {runtime_description} runtime configuration.\n"
@@ -144,9 +146,12 @@ def _preprocess_pipeline(pipeline_path: str, runtime: str, runtime_config: str) 
 
     # update pipeline transient fields
     primary_pipeline["app_data"]["name"] = pipeline_name
-    primary_pipeline["app_data"]["runtime"] = runtime
-    primary_pipeline["app_data"]["runtime-config"] = runtime_config
     primary_pipeline["app_data"]["source"] = os.path.basename(pipeline_abs_path)
+    # Only update the following if values were provided (and runtime is valid)
+    if runtime:
+        primary_pipeline["app_data"]["runtime"] = runtime
+    if runtime_config:
+        primary_pipeline["app_data"]["runtime-config"] = runtime_config
 
     return pipeline_definition
 


### PR DESCRIPTION
There were a couple of items fixed with this pull request, one of which is in preparation for work being done in #1995.

1. The traceback produced in #2037 when the given runtime doesn't correspond to the pipeline's runtime (if non-generic) is no longer produced and an appropriate message is displayed.
2. The pipeline pre-processor validation input parameters, `runtime` and `runtime_config`, have been made optional and the pipeline is no longer altered with their values - since this changes the results of the upcoming `describe` command (as `['app_data']['runtime'] could be displayed as the runtime configuration/schema) and is unnecessary for the `run` command.

Here's the updated output when submission to Airflow is attempted with a KFP-based pipeline.
```
────────────────────────────────────────────────────────────────
 Elyra Pipeline Submission
────────────────────────────────────────────────────────────────

Error: This pipeline requires an instance of Kubeflow Pipelines runtime configuration.
The specified configuration 'af_teacloth1' is for Apache Airflow runtime.
```
### How was this pull request tested?
This was only tested manually.  The unit tests are currently targeting command-line options and don't involve pipeline format structures or methods like `_preprocess_pipeline()` at this time.

Resolves #2037
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
