### PR TITLE
Update pipeline cli to handle errors without node info

### DIFF
--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -155,14 +155,19 @@ def _preprocess_pipeline(pipeline_path: str,
 
     return pipeline_definition
 
-
 def _print_issues(issues):
     # print validation issues
     for issue in issues:
         if issue.get('severity') == ValidationSeverity.Error:
-            click.echo(
-                f'- (Fatal error on node \'{issue["data"]["nodeName"]}\' property \'{issue["data"]["propertyName"]}\') '
-                f'- {issue["message"]}')
+            if issue.get('data'):
+                node_name = issue["data"].get("nodeName")
+                property_name = issue["data"].get("propertyName")
+                click.echo(
+                    f'- (Fatal error on node \'{node_name}\' property \'{property_name}\') '
+                    f'- {issue["message"]}')
+            else:
+                click.echo(
+                    f'- Fatal error - {issue["message"]}')
         else:
             # TODO check warning nodeNames are empty
             click.echo(

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -155,6 +155,7 @@ def _preprocess_pipeline(pipeline_path: str,
 
     return pipeline_definition
 
+
 def _print_issues(issues):
     # print validation issues
     for issue in issues:


### PR DESCRIPTION
Fixes #2040 

With the fix, described scenario will produce:
```
$ elyra-pipeline submit generic.pipeline --runtime-config kfp-runtime

────────────────────────────────────────────────────────────────
 Elyra Pipeline Submission
────────────────────────────────────────────────────────────────

Pipeline validation FAILED:
- Fatal error - At least one node must exist in the primary pipeline.

Error: Error validating pipeline.
$ 
```
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
