### PR TITLE
Enable release of individual Elyra runtime extensions

### DIFF
--- a/create-release.py
+++ b/create-release.py
@@ -36,7 +36,7 @@ config: SimpleNamespace
 VERSION_REG_EX = r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<pre_release>[a-z]+)(?P<build>\d+))?"
 
 DEFAULT_GIT_URL = 'git@github.com:elyra-ai/elyra.git'
-DEFAULT_EXTENSION_PACKAGE_GIT_URL = 'git@github.com:lresende/elyra-package-template.git'
+DEFAULT_EXTENSION_PACKAGE_GIT_URL = 'git@github.com:elyra-ai/elyra-package-template.git'
 DEFAULT_BUILD_DIR = 'build/release'
 
 
@@ -473,7 +473,7 @@ def prepare_runtime_extensions_package_release() -> None:
         # copy source files
         source_dir = os.path.join(config.source_dir, 'elyra', packages_source[package])
         dest_dir = os.path.join(package_source_dir, 'elyra', packages_source[package])
-        print(f'Copying package cousrce from {source_dir} to {dest_dir}')
+        print(f'Copying package source from {source_dir} to {dest_dir}')
         Path(os.path.join(package_source_dir, 'elyra')).mkdir(parents=True, exist_ok=True)
         shutil.copytree(source_dir, dest_dir)
 
@@ -509,7 +509,7 @@ def prepare_release() -> None:
     # clone repository
     checkout_code()
     # generate changelog with new release list of commits
-    # prepare_changelog()
+    prepare_changelog()
     # Update to new release version
     update_version_to_release()
     # commit and tag

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup_args = dict(
         'kfp-tekton==0.8.1',
         # Airflow runtime dependencies
         'pygithub',
-        'black'
+        'black',
     ],
     extras_require={
         'test': ['pytest', 'pytest-tornasync'],


### PR DESCRIPTION
After small updates to the template package project, update the release script to publish the embedded `kfp-notebook` and `airflow-notebook` into PyPi. 


Fixes #1941 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
