### PR TITLE
Update pipeline cli to tolerate empty pipelines

### DIFF
--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -50,7 +50,7 @@ def _get_runtime_type(runtime_config: Optional[str]) -> Optional[str]:
         raise click.ClickException(f'Invalid runtime configuration: {runtime_config}\n {e}')
 
 
-def _get_runtime_display_name(runtime_config: Optional[str]) -> Optional[str]:
+def _get_runtime_display_name_from_config(runtime_config: Optional[str]) -> Optional[str]:
     if not runtime_config:
         return None
 
@@ -61,6 +61,18 @@ def _get_runtime_display_name(runtime_config: Optional[str]) -> Optional[str]:
         return schema['display_name']
     except Exception as e:
         raise click.ClickException(f'Invalid runtime configuration: {runtime_config}\n {e}')
+
+
+def _get_runtime_display_name(schema_name: Optional[str]) -> Optional[str]:
+    if not schema_name:
+        return None
+
+    try:
+        schema_manager = SchemaManager.instance()
+        schema = schema_manager.get_schema('runtimes', schema_name)
+        return schema['display_name']
+    except Exception as e:
+        raise click.ClickException(f'Invalid runtime: {schema_name}\n {e}')
 
 
 def _validate_pipeline_runtime(primary_pipeline: dict, runtime: str) -> bool:
@@ -138,8 +150,8 @@ def _preprocess_pipeline(pipeline_path: str,
         raise click.ClickException(f"Error pre-processing pipeline: \n {e}")
 
     if not _validate_pipeline_runtime(primary_pipeline, runtime):
-        runtime_description = primary_pipeline['app_data']['properties']['runtime']
-        runtime_config_display_name = _get_runtime_display_name(runtime_config)
+        runtime_description = _get_runtime_display_name(primary_pipeline['app_data']['runtime'])
+        runtime_config_display_name = _get_runtime_display_name_from_config(runtime_config)
         raise click.ClickException(
             f"This pipeline requires an instance of {runtime_description} runtime configuration.\n"
             f"The specified configuration '{runtime_config}' is for {runtime_config_display_name} runtime.")

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -137,11 +137,11 @@ def _preprocess_pipeline(pipeline_path: str,
         raise click.ClickException(f"Error pre-processing pipeline: \n {e}")
 
     if not _validate_pipeline_runtime(primary_pipeline, runtime):
-        runtime_description = _get_runtime_display_name(primary_pipeline['app_data']['runtime'])
-        runtime_config_display_name = _get_runtime_display_name(_get_runtime_type(runtime_config))
+        pipeline_runtime_display_name = _get_runtime_display_name(primary_pipeline['app_data']['runtime'])
+        provided_runtime_display_name = _get_runtime_display_name(_get_runtime_type(runtime_config))
         raise click.ClickException(
-            f"This pipeline requires an instance of {runtime_description} runtime configuration.\n"
-            f"The specified configuration '{runtime_config}' is for {runtime_config_display_name} runtime.")
+            f"This pipeline requires an instance of {pipeline_runtime_display_name} runtime configuration.\n"
+            f"The specified configuration '{runtime_config}' is for {provided_runtime_display_name} runtime.")
 
     # update pipeline transient fields
     primary_pipeline["app_data"]["name"] = pipeline_name

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -50,16 +50,16 @@ def _get_runtime_type(runtime_config: Optional[str]) -> Optional[str]:
         raise click.ClickException(f'Invalid runtime configuration: {runtime_config}\n {e}')
 
 
-def _get_runtime_display_name(schema_name: Optional[str]) -> Optional[str]:
-    if not schema_name:
+def _get_runtime_display_name(runtime_config: Optional[str]) -> Optional[str]:
+    if not runtime_config:
         return None
 
     try:
         schema_manager = SchemaManager.instance()
-        schema = schema_manager.get_schema('runtimes', schema_name)
+        schema = schema_manager.get_schema('runtimes', runtime_config)
         return schema['display_name']
     except Exception as e:
-        raise click.ClickException(f'Invalid runtime: {schema_name}\n {e}')
+        raise click.ClickException(f'Invalid runtime configuration: {runtime_config}\n {e}')
 
 
 def _validate_pipeline_runtime(primary_pipeline: dict, runtime: str) -> bool:

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -50,16 +50,16 @@ def _get_runtime_type(runtime_config: Optional[str]) -> Optional[str]:
         raise click.ClickException(f'Invalid runtime configuration: {runtime_config}\n {e}')
 
 
-def _get_runtime_display_name(runtime_config: Optional[str]) -> Optional[str]:
-    if not runtime_config:
+def _get_runtime_display_name(schema_name: Optional[str]) -> Optional[str]:
+    if not schema_name:
         return None
 
     try:
         schema_manager = SchemaManager.instance()
-        schema = schema_manager.get_schema('runtimes', runtime_config)
+        schema = schema_manager.get_schema('runtimes', schema_name)
         return schema['display_name']
     except Exception as e:
-        raise click.ClickException(f'Invalid runtime configuration: {runtime_config}\n {e}')
+        raise click.ClickException(f'Invalid runtime configuration: {schema_name}\n {e}')
 
 
 def _validate_pipeline_runtime(primary_pipeline: dict, runtime: str) -> bool:

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -50,19 +50,6 @@ def _get_runtime_type(runtime_config: Optional[str]) -> Optional[str]:
         raise click.ClickException(f'Invalid runtime configuration: {runtime_config}\n {e}')
 
 
-def _get_runtime_display_name_from_config(runtime_config: Optional[str]) -> Optional[str]:
-    if not runtime_config:
-        return None
-
-    try:
-        schema_manager = SchemaManager.instance()
-        schema_name = _get_runtime_type(runtime_config)
-        schema = schema_manager.get_schema('runtimes', schema_name)
-        return schema['display_name']
-    except Exception as e:
-        raise click.ClickException(f'Invalid runtime configuration: {runtime_config}\n {e}')
-
-
 def _get_runtime_display_name(schema_name: Optional[str]) -> Optional[str]:
     if not schema_name:
         return None
@@ -151,7 +138,7 @@ def _preprocess_pipeline(pipeline_path: str,
 
     if not _validate_pipeline_runtime(primary_pipeline, runtime):
         runtime_description = _get_runtime_display_name(primary_pipeline['app_data']['runtime'])
-        runtime_config_display_name = _get_runtime_display_name_from_config(runtime_config)
+        runtime_config_display_name = _get_runtime_display_name(_get_runtime_type(runtime_config))
         raise click.ClickException(
             f"This pipeline requires an instance of {runtime_description} runtime configuration.\n"
             f"The specified configuration '{runtime_config}' is for {runtime_config_display_name} runtime.")


### PR DESCRIPTION
Command: 

```
$  elyra-pipeline submit airflow-empty.pipeline --runtime-config kubeflow_pipeline_130_cloning
```

Now displays:


```
────────────────────────────────────────────────────────────────
 Elyra Pipeline Submission
────────────────────────────────────────────────────────────────

Error: This pipeline requires an instance of Apache Airflow runtime configuration.
The specified configuration 'kubeflow_pipeline_130_cloning' is for Kubeflow Pipelines runtime.
```

Fixes #2044 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
