### PR TITLE
Account for component specifications with no component parameters

### DIFF
--- a/elyra/pipeline/component_parser_kfp.py
+++ b/elyra/pipeline/component_parser_kfp.py
@@ -61,7 +61,8 @@ class KfpComponentParser(ComponentParser):
         # properties.extend(self.get_runtime_specific_properties())
 
         # Then loop through and create custom properties
-        for param in component_yaml.get('inputs'):
+        input_params = component_yaml.get('inputs', [])
+        for param in input_params:
             # KFP components default to being required unless otherwise stated.
             # Reference: https://www.kubeflow.org/docs/components/pipelines/reference/component-spec/#interface
             required = True

--- a/elyra/pipeline/tests/resources/components/airflow_test_operator_no_inputs.py
+++ b/elyra/pipeline/tests/resources/components/airflow_test_operator_no_inputs.py
@@ -1,0 +1,29 @@
+#
+# Copyright 2018-2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class TestOperatorNoInputs(BaseOperator):
+    r"""
+    Execute a test script.
+    """
+
+    @apply_defaults
+    def __init__(self,
+                 *args, **kwargs):
+
+        super().__init__(*args, **kwargs)

--- a/elyra/pipeline/tests/resources/components/kfp_test_operator_no_inputs.yaml
+++ b/elyra/pipeline/tests/resources/components/kfp_test_operator_no_inputs.yaml
@@ -1,0 +1,16 @@
+name: Test Operator No Inputs
+description: no input one output
+
+outputs:
+- {name: Output 1, type: String, description: 'Output 1 data'}
+
+implementation:
+  container:
+    image: alpine
+    command: [
+        python3,
+        # Path of the program inside the container
+        /pipelines/component/src/0_1.py,
+        --output1-path,
+        { outputPath: Output 1 },
+    ]

--- a/elyra/pipeline/tests/test_component_parser_airflow.py
+++ b/elyra/pipeline/tests/test_component_parser_airflow.py
@@ -124,6 +124,33 @@ def test_parse_airflow_component_url():
     assert properties_json['current_parameters']['elyra_output_encoding'] == 'utf-8'
 
 
+def test_parse_airflow_component_file_no_inputs():
+    entry = {
+        'id': 'test-operator_TestOperatorNoInputs',
+        'type': FilesystemComponentReader.type,
+        'location': _get_resource_path('airflow_test_operator_no_inputs.py'),
+        'catalog_entry_id': '',
+        'category_id': 'kfp'
+    }
+    component_entry = SimpleNamespace(**entry)
+
+    parser = AirflowComponentParser()
+    component = parser.parse(component_entry)[0]
+    properties_json = ComponentRegistry.to_canvas_properties(component)
+
+    # Properties JSON should only include the two parameters common to every
+    # component:'label' and 'component_source'
+    num_common_params = 2
+    assert len(properties_json['current_parameters'].keys()) == num_common_params
+    assert len(properties_json['parameters']) == num_common_params
+    assert len(properties_json['uihints']['parameter_info']) == num_common_params
+    assert len(properties_json['uihints']['group_info'][0]['group_info']) == num_common_params
+
+    # Ensure that template still renders the two common parameters correctly
+    assert properties_json['current_parameters']['label'] == ""
+    assert properties_json['current_parameters']['component_source'] == component_entry.location
+
+
 async def test_parse_components_invalid_location():
     # Ensure a component with an invalid location is not returned
     component_registry_location = os.path.join(os.path.dirname(__file__),

--- a/elyra/pipeline/tests/test_component_parser_kfp.py
+++ b/elyra/pipeline/tests/test_component_parser_kfp.py
@@ -142,6 +142,33 @@ def test_parse_kfp_component_url():
     assert properties_json['current_parameters']['elyra_input_data'] == ''
 
 
+def test_parse_kfp_component_file_no_inputs():
+    entry = {
+        'id': 'test-no-inputs',
+        'type': FilesystemComponentReader.type,
+        'location': _get_resource_path('kfp_test_operator_no_inputs.yaml'),
+        'catalog_entry_id': '',
+        'category_id': 'kfp'
+    }
+    component_entry = SimpleNamespace(**entry)
+
+    parser = KfpComponentParser()
+    component = parser.parse(component_entry)[0]
+    properties_json = ComponentRegistry.to_canvas_properties(component)
+
+    # Properties JSON should only include the two parameters common to every
+    # component:'label' and 'component_source'
+    num_common_params = 2
+    assert len(properties_json['current_parameters'].keys()) == num_common_params
+    assert len(properties_json['parameters']) == num_common_params
+    assert len(properties_json['uihints']['parameter_info']) == num_common_params
+    assert len(properties_json['uihints']['group_info'][0]['group_info']) == num_common_params
+
+    # Ensure that template still renders the two common parameters correctly
+    assert properties_json['current_parameters']['label'] == ""
+    assert properties_json['current_parameters']['component_source'] == component_entry.location
+
+
 async def test_parse_components_invalid_location():
     # Ensure a component with an invalid location is not returned
     component_registry_location = os.path.join(os.path.dirname(__file__),

--- a/elyra/templates/components/canvas_properties_template.jinja2
+++ b/elyra/templates/components/canvas_properties_template.jinja2
@@ -1,7 +1,7 @@
 {
     "current_parameters": {
       "label": "",
-      "component_source": "{{ component.source }}",
+      "component_source": "{{ component.source }}"{% if component.properties|length > 0 %},{% endif %}
 {% for property in component.properties %}
     {% if property.type|lower == "bool" or property.type|lower == "boolean" %}
       "elyra_{{ property.ref }}": {{ property.value|lower }}
@@ -21,7 +21,7 @@
       },
       {
         "id": "component_source"
-      },
+      }{% if component.properties|length > 0 %},{% endif %}
 {% for property in component.properties %}
       {
         "id": "elyra_{{ property.ref }}"
@@ -58,7 +58,7 @@
             "placement": "on_panel"
           },
           "data": {}
-        },
+        }{% if component.properties|length > 0 %},{% endif %}
 {% for property in component.properties %}
         {
           "parameter_ref": "elyra_{{ property.ref }}",
@@ -106,7 +106,7 @@
               "id": "component_source",
               "type": "controls",
               "parameter_refs": ["component_source"]
-            },
+            }{% if component.properties|length > 0 %},{% endif %}
 {% for property in component.properties %}
             {
               "id": "elyra_{{ property.ref }}",


### PR DESCRIPTION
Fixes #2049 

### What changes were proposed in this pull request?
In `KfpComponentParser`, `_parse_properties()` is changed to account for the case where no inputs are found in the KFP specification. A variable `input_params` is initialized as an empty list `[]` if the 'inputs' key does not exist in the component YAML.

The properties jinja template also has to be modified to only include a comma in the properties JSON if the list of component parameters is not empty. Otherwise, JSON serialization will fail.

### How was this pull request tested?

A test was added to cover the case of no input parameters for both KFP and Airflow. For Airflow, this just corresponds to an operator `init` function that does not include any arguments (besides `self`, `*args`, and `**kwargs`). For each, a test resource had to be added to cover this scenario. If this is too heavy-duty, I can look into alternatives that call `parse_properties()` and `to_canvas_properties()` directly.

To test manually, add the following component to the `kfp_component_catalog.json`, run `make install-server`, and restart JL. 
```json=
"no-input-example": {
    "location": {
      "url": "https://raw.githubusercontent.com/ptitzler/kfp-component-tests/main/component_definitions/requirement-examples/kfp-components/0-n/0_1_component.yaml"
    },
    "category": "kfp"
 }
```
This should be the result on the UI:

<img width="990" alt="Screen Shot 2021-08-17 at 3 04 50 PM" src="https://user-images.githubusercontent.com/31816267/129792971-22d303b9-12e1-4e67-95d7-bc6ffeb32e70.png">


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
