### PR TITLE
Schema Filters

### DIFF
--- a/elyra/metadata/schema.py
+++ b/elyra/metadata/schema.py
@@ -17,15 +17,40 @@ import copy
 import io
 import json
 import os
+from typing import Dict
 from typing import Optional
 import warnings
 
+from ipython_genutils.importstring import import_item
 from traitlets.config import SingletonConfigurable
 
 from elyra.metadata.error import SchemaNotFoundError
 
+default_schema_filter_class_name = 'elyra.metadata.schema.SchemaFilter'
 
 METADATA_TEST_NAMESPACE = "metadata-tests"  # exposed via METADATA_TESTING env
+
+
+class SchemaFilter(object):
+    """
+    This class is used by the SchemaManager to process schema instances if the
+    schema references a `schema_filter_class_name` meta-property.  It is meant to be
+    subclassed since instances of this class are associated with a specific schema
+    and have knowledge about how to filter instances of "their" schema.
+
+    Instances of SchemaFilter are meant to be short-lived and stateless, essentially
+    performing an operation on the schema and returning its filtered result.
+    """
+
+    def post_load(self, name: str, schema_json: Dict) -> Dict:
+        """Called by SchemaManager after fetching the schema instance, this method
+        filters the schema based on current runtime situations.
+
+        :param name: The name of the schema
+        :param schema_json: The schema itself
+        :return: The filtered schema
+        """
+        return schema_json
 
 
 class SchemaManager(SingletonConfigurable):
@@ -118,6 +143,11 @@ class SchemaManager(SingletonConfigurable):
             if name is None:
                 # If schema is missing a name attribute, use file's basename.
                 name = os.path.splitext(os.path.basename(schema_file))[0]
-            namespace_schemas[namespace][name] = schema_json
+
+            # apply post-load filter
+            schema_filter_class_name = schema_json.get('schema_filter_class_name', default_schema_filter_class_name)
+            schema_filter_class = import_item(schema_filter_class_name)
+            filtered_schema = schema_filter_class().post_load(name, schema_json)
+            namespace_schemas[namespace][name] = filtered_schema
 
         return copy.deepcopy(namespace_schemas)

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -4,6 +4,7 @@
   "name": "kfp",
   "display_name": "Kubeflow Pipelines",
   "namespace": "runtimes",
+  "schema_filter_class_name": "elyra.pipeline.processor_kfp.KfpSchemaFilter",
   "uihints": {
     "title": "Kubeflow Pipelines runtimes",
     "icon": "elyra:runtimes",
@@ -71,7 +72,7 @@
         },
         "engine": {
           "title": "Kubeflow Pipelines engine",
-          "description": "The Kubeflow Pipelines engine in use ('Argo' or 'Tekton')",
+          "description": "The Kubeflow Pipelines engine in use",
           "type": "string",
           "enum": ["Argo", "Tekton"],
           "default": "Argo",

--- a/elyra/metadata/schemas/metadata-test.json
+++ b/elyra/metadata/schemas/metadata-test.json
@@ -5,6 +5,7 @@
   "display_name": "Metadata Test",
   "namespace": "metadata-tests",
   "metadata_class_name": "elyra.metadata.tests.test_utils.MockMetadataTest",
+  "schema_filter_class_name": "elyra.metadata.tests.test_utils.TestSchemaFilter",
   "properties": {
     "schema_name": {
       "title": "Schema Name",

--- a/elyra/metadata/tests/test_metadata.py
+++ b/elyra/metadata/tests/test_metadata.py
@@ -38,10 +38,11 @@ from elyra.metadata.storage import MetadataStore
 from elyra.metadata.tests.test_utils import byo_metadata_json
 from elyra.metadata.tests.test_utils import create_instance
 from elyra.metadata.tests.test_utils import create_json_file
-from elyra.metadata.tests.test_utils import get_schema
+from elyra.metadata.tests.test_utils import get_unfiltered_schema
 from elyra.metadata.tests.test_utils import invalid_metadata_json
 from elyra.metadata.tests.test_utils import invalid_no_display_name_json
 from elyra.metadata.tests.test_utils import MockMetadataStore
+from elyra.metadata.tests.test_utils import TestSchemaFilter
 from elyra.metadata.tests.test_utils import valid_display_name_json
 from elyra.metadata.tests.test_utils import valid_metadata_json
 
@@ -703,7 +704,7 @@ def test_store_delete_instance(store_manager, namespace_location):
 def test_schema_manager_all(schema_manager):
     schema_manager.clear_all()
 
-    test_schema_json = get_schema('metadata-test')
+    test_schema_json = get_unfiltered_schema('metadata-test')
 
     with pytest.raises(ValueError):
         schema_manager.add_schema("foo", "metadata-test", test_schema_json)
@@ -734,7 +735,8 @@ def test_schema_manager_all(schema_manager):
     schema_manager.clear_all()  # Ensure test schema has been restored
     test_schema = schema_manager.get_schema(METADATA_TEST_NAMESPACE, "metadata-test")
     assert test_schema is not None
-    assert test_schema == test_schema_json
+    # Since test_schema is filtered and test_schema_json is unfiltered, apply filtering for comparison
+    assert test_schema == TestSchemaFilter().post_load("metadata-test", test_schema_json)
 
 
 # ########################## Error Tests ###########################

--- a/elyra/metadata/tests/test_metadata_app.py
+++ b/elyra/metadata/tests/test_metadata_app.py
@@ -52,7 +52,7 @@ def mock_data_dir():
 def test_no_opts(script_runner):
     ret = script_runner.run('elyra-metadata')
     assert ret.success is False
-    assert ret.stdout.startswith("No subcommand specified. Must specify one of: ['list', 'install', 'remove']")
+    assert "No subcommand specified. Must specify one of: ['list', 'install', 'remove']" in ret.stdout
     assert ret.stderr == ''
 
 
@@ -516,8 +516,8 @@ def test_integer_multiple(script_runner, mock_data_dir):
     prop_test.negative_value = 32
     prop_test.negative_stdout = "Property used to test integers with multipleOf restrictions"
     #  this can be joined with previous if adding meta-properties
-    #  "; title: Integer Multiple Test, multipleOf: 7"
-    prop_test.negative_stderr = "32 is not a multiple of 7"
+    #  "; title: Integer Multiple Test, multipleOf: 6"
+    prop_test.negative_stderr = "32 is not a multiple of 6"
     prop_test.positive_value = 42
     prop_test.run(script_runner, mock_data_dir)
 
@@ -571,9 +571,9 @@ def test_enum(script_runner, mock_data_dir):
     prop_test.negative_value = "jupyter"
     prop_test.negative_stdout = "Property used to test properties with enums"
     #  this can be joined with previous if adding meta-properties
-    #  "; title: Enum Test, enum: ['elyra', 'rocks']"
-    prop_test.negative_stderr = "'jupyter' is not one of ['elyra', 'rocks']"
-    prop_test.positive_value = "rocks"
+    #  "; title: Enum Test, enum: ['elyra', 'rocks', 'added']"
+    prop_test.negative_stderr = "'jupyter' is not one of ['elyra', 'rocks', 'added']"
+    prop_test.positive_value = "added"
     prop_test.run(script_runner, mock_data_dir)
 
 

--- a/elyra/metadata/tests/test_metadata_app.py
+++ b/elyra/metadata/tests/test_metadata_app.py
@@ -53,7 +53,6 @@ def test_no_opts(script_runner):
     ret = script_runner.run('elyra-metadata')
     assert ret.success is False
     assert "No subcommand specified. Must specify one of: ['list', 'install', 'remove']" in ret.stdout
-    assert ret.stderr == ''
 
 
 def test_bad_subcommand(script_runner):
@@ -61,7 +60,6 @@ def test_bad_subcommand(script_runner):
     assert ret.success is False
     assert ret.stdout.startswith("Subcommand 'bogus-subcommand' is invalid.")
     assert "No subcommand specified. Must specify one of: ['list', 'install', 'remove']" in ret.stdout
-    assert ret.stderr == ''
 
 
 def test_install_bad_argument(script_runner):
@@ -77,14 +75,12 @@ def test_install_bad_namespace(script_runner):
     assert ret.stdout.startswith("Subcommand 'bogus-namespace' is invalid.")
     assert "Install a metadata instance into a given namespace." in ret.stdout
     assert "Install a metadata instance into namespace \'{}\'.".format(METADATA_TEST_NAMESPACE) in ret.stdout
-    assert ret.stderr == ''
 
 
 def test_install_help(script_runner):
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_NAMESPACE, '--help')
     assert ret.success is False
     assert ret.stdout.startswith("\nInstall a metadata instance into namespace '{}'.".format(METADATA_TEST_NAMESPACE))
-    assert ret.stderr == ''
 
 
 def test_install_no_schema_single(script_runner, mock_data_dir):
@@ -93,7 +89,6 @@ def test_install_no_schema_single(script_runner, mock_data_dir):
     ret = script_runner.run('elyra-metadata', 'install', "runtime-images")
     assert ret.success is False
     assert ret.stdout.startswith("'--display_name' is a required parameter.")
-    assert ret.stderr == ''
 
 
 def test_install_no_schema_multiple(script_runner, mock_data_dir):
@@ -103,21 +98,18 @@ def test_install_no_schema_multiple(script_runner, mock_data_dir):
     # first known difference in the schema names.
     assert ret.stdout.startswith("'--schema_name' is a required parameter and must be one of the "
                                  "following values: ['metadata-test")
-    assert ret.stderr == ''
 
 
 def test_install_bad_schema_multiple(script_runner, mock_data_dir):
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_NAMESPACE, '--schema_name=metadata-foo')
     assert ret.success is False
     assert ret.stdout.startswith("Parameter '--schema_name' requires one of the following values: ['metadata-test")
-    assert ret.stderr == ''
 
 
 def test_install_no_name(script_runner, mock_data_dir):
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_NAMESPACE, '--schema_name=metadata-test')
     assert ret.success is False
     assert ret.stdout.startswith("'--display_name' is a required parameter.")
-    assert ret.stderr == ''
 
 
 def test_install_only_display_name(script_runner, mock_data_dir):
@@ -218,14 +210,12 @@ def test_list_help(script_runner):
     ret = script_runner.run('elyra-metadata', 'list', METADATA_TEST_NAMESPACE, '--help')
     assert ret.success is False
     assert ret.stdout.startswith("\nList installed metadata for {}.".format(METADATA_TEST_NAMESPACE))
-    assert ret.stderr == ''
 
 
 def test_list_bad_argument(script_runner):
     ret = script_runner.run('elyra-metadata', 'list', METADATA_TEST_NAMESPACE, '--bogus-argument')
     assert ret.success is False
     assert ret.stdout.startswith("The following arguments were unexpected: ['--bogus-argument']")
-    assert ret.stderr == ''
 
 
 def test_list_instances(script_runner, mock_data_dir):
@@ -262,7 +252,6 @@ def test_list_instances(script_runner, mock_data_dir):
     assert line_elements[2][1] == "valid"
     assert line_elements[3][0] == "metadata-test"
     assert line_elements[3][1] == "valid2"
-    assert ret.stderr == ''
 
     # Remove the '2' runtimes and reconfirm smaller set
     metadata_manager.remove('valid2')
@@ -321,7 +310,6 @@ def test_list_json_instances(script_runner, mock_data_dir):
 
     ret = script_runner.run('elyra-metadata', 'list', METADATA_TEST_NAMESPACE, '--json')
     assert ret.success
-    assert ret.stderr == ''
     # Consume results
     results = json.loads(ret.stdout)
     assert len(results) == 4
@@ -350,14 +338,12 @@ def test_remove_help(script_runner):
     ret = script_runner.run('elyra-metadata', 'remove', METADATA_TEST_NAMESPACE, '--help')
     assert ret.success is False
     assert ret.stdout.startswith("\nRemove a metadata instance from namespace '{}'.".format(METADATA_TEST_NAMESPACE))
-    assert ret.stderr == ''
 
 
 def test_remove_no_name(script_runner):
     ret = script_runner.run('elyra-metadata', 'remove', METADATA_TEST_NAMESPACE)
     assert ret.success is False
     assert ret.stdout.startswith("'--name' is a required parameter.")
-    assert ret.stderr == ''
 
 
 def test_remove_malformed_name(script_runner):
@@ -365,7 +351,6 @@ def test_remove_malformed_name(script_runner):
 
     ret = script_runner.run('elyra-metadata', 'remove', METADATA_TEST_NAMESPACE, '--name', 'valid')
     assert ret.success is False
-    assert ret.stderr == ''
     assert "Parameter '--name' requires a value." in ret.stdout
 
 
@@ -377,7 +362,6 @@ def test_remove_missing(script_runner):
 
     ret = script_runner.run('elyra-metadata', 'remove', METADATA_TEST_NAMESPACE, '--name=missing')
     assert ret.success is False
-    assert ret.stderr == ''
     assert "No such instance named 'missing' was found in the metadata-tests namespace." in ret.stdout
 
     # Now cleanup original instance.

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -34,15 +34,21 @@ from kfp import compiler as kfp_argo_compiler
 from kfp import components as components
 from kfp.aws import use_aws_secret  # noqa H306
 from kfp_server_api.exceptions import ApiException
-from kfp_tekton import compiler as kfp_tekton_compiler
-from kfp_tekton import TektonClient
 import requests
 from urllib3.exceptions import LocationValueError
 from urllib3.exceptions import MaxRetryError
+try:
+    from kfp_tekton import compiler as kfp_tekton_compiler
+    from kfp_tekton import TektonClient
+except ImportError:
+    # We may not have kfp-tekton available and that's okay!
+    kfp_tekton_compiler = None
+    TektonClient = None
 
 from elyra._version import __version__
 from elyra.kfp.operator import ExecuteFileOp
 from elyra.metadata.manager import MetadataManager
+from elyra.metadata.schema import SchemaFilter
 from elyra.pipeline.component_parser_kfp import KfpComponentParser
 from elyra.pipeline.pipeline import GenericOperation
 from elyra.pipeline.pipeline import Operation
@@ -635,3 +641,24 @@ class KfpPipelineProcessorResponse(PipelineProcessorResponse):
     @property
     def type(self):
         return self._type
+
+
+class KfpSchemaFilter(SchemaFilter):
+    """
+    This class exists to ensure that the KFP schema's engine metadata
+    appropriately reflects what is installed on the system.
+    """
+
+    def post_load(self, name: str, schema_json: Dict) -> Dict:
+        """Ensure tekton packages are present and remove engine from schema if not."""
+
+        filtered_schema = super().post_load(name, schema_json)
+
+        # If TektonClient package is missing, navigate to the engine property
+        # and remove 'tekton' entry if present and return updated result.
+        if not TektonClient:
+            engine_enum: list = filtered_schema['properties']['metadata']['properties']['engine']['enum']
+            if 'Tekton' in engine_enum:
+                engine_enum.remove('Tekton')
+                filtered_schema['properties']['metadata']['properties']['engine']['enum'] = engine_enum
+        return filtered_schema


### PR DESCRIPTION
This pull request adds support for _Schema Filters_.  Schema FIlters allow for dynamic schema rendering so that schema meta information can properly reflect an installation.  This will seldom be used but could be more helpful when _bring-your-own-schema_ capabilities are introduced.

Support for this functionality was necessitated by #2043 where the installation of the `Tekton` engine was made optional.  However, since `Tekton` is one of the enumerated values in the [`kfp` schema](https://github.com/elyra-ai/elyra/blob/35d3a46962f0821360dd9458cdf0028aeacebbd6/elyra/metadata/schemas/kfp.json#L76), installations in which the `kfp-tekton` package is not installed would erroneously display `Tekton` as an engine option when configuring a `kfp` runtime instance in the UI.

With _schema filtering_, a `KfpSchemaFilter` now exists which filters the `kfp` JSON schema such that `Tekton` only appears in the engine property's enumeration if the `kfp-tekton` package is installed.

Schema filters are _registered_ by setting the `schema_filter_class_name` property in the corresponding schema file - and model the behavior of the [`metadata_class_name` property](https://github.com/elyra-ai/elyra/pull/725).  When schemas consisting of a registered schema filter are loaded, the schema filter class is instantiated and passed the schema file to its `post_load()` method.  This method is then responsible for altering the schema such that the returned value is what is used by the hosting application.  

### How was this pull request tested?
The test metadata was extended to include a `"schema_filter_class_name": "elyra.metadata.tests.test_utils.TestSchemaFilter",` entry where `TestSchemaFilter` alters two meta-properties - an `enum` in property `enum_test` and the `multipleOf` meta-property in the `integer_multiple_test` property.  Existing tests were updated accordingly such that the results of the updated schema are reflected.

Also tested the `kfp-tekton` case to demonstrate the resulting UI...

On installations in which `kfp-tekton` is installed, users will see this drop-down:
![image](https://user-images.githubusercontent.com/22599560/129954476-c359cd87-ca8e-48b9-b9e4-e9cb6f01e0dc.png)

While users in installations that do not have `kfp-tekton` installed will see this drop-down:
![Screen Shot 2021-08-18 at 11 43 46 AM](https://user-images.githubusercontent.com/22599560/129954650-5bba68e4-42b5-49a8-bce7-a8e4b6e86921.png)


Unrelated change:
A recent version of `black` is producing output in `stderr`.  This causes a test side-effect to occur in which `stderr` is asserted to be empty (`''`).  This pull request removes these assertions.

 
Resolves: #2046 
Related: #2043

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
