### PR TITLE
Fix mismatched runtime handling for run command

### DIFF
--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -160,8 +160,6 @@ def _preprocess_pipeline(pipeline_path: str,
         primary_pipeline["app_data"]["runtime"] = runtime
     if runtime_config:
         primary_pipeline["app_data"]["runtime-config"] = runtime_config
-    else:
-        primary_pipeline["app_data"]["runtime-config"] = 'local'
 
     return pipeline_definition
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -142,10 +142,11 @@ def _preprocess_pipeline(pipeline_path: str,
 
     if not _validate_pipeline_runtime(primary_pipeline, runtime):
         pipeline_runtime_display_name = _get_runtime_display_name(primary_pipeline['app_data']['runtime'])
-        provided_runtime_display_name = _get_runtime_display_name(_get_runtime_type(runtime_config))
-        raise click.ClickException(
-            f"This pipeline requires an instance of {pipeline_runtime_display_name} runtime configuration.\n"
-            f"The specified configuration '{runtime_config}' is for {provided_runtime_display_name} runtime.")
+        msg = f"This pipeline requires an instance of {pipeline_runtime_display_name} runtime configuration.\n"
+        if runtime_config:
+            provided_runtime_display_name = _get_runtime_display_name(_get_runtime_type(runtime_config))
+            msg = f"{msg}The specified configuration '{runtime_config}' is for {provided_runtime_display_name} runtime."
+        raise click.ClickException(msg)
 
     # update pipeline transient fields
     primary_pipeline["app_data"]["name"] = pipeline_name
@@ -155,6 +156,8 @@ def _preprocess_pipeline(pipeline_path: str,
         primary_pipeline["app_data"]["runtime"] = runtime
     if runtime_config:
         primary_pipeline["app_data"]["runtime-config"] = runtime_config
+    else:
+        primary_pipeline["app_data"]["runtime-config"] = 'local'
 
     return pipeline_definition
 
@@ -301,7 +304,7 @@ def run(pipeline_path):
     _validate_pipeline_file_extension(pipeline_path)
 
     pipeline_definition = \
-        _preprocess_pipeline(pipeline_path, runtime='local', runtime_config='local')
+        _preprocess_pipeline(pipeline_path, runtime='local')
 
     _validate_pipeline_definition(pipeline_definition)
 

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -45,8 +45,10 @@ SEVERITY = {ValidationSeverity.Error: 'Error',
 
 
 def _get_runtime_type(runtime_config: Optional[str]) -> Optional[str]:
-    if not runtime_config:
-        return None
+    if not runtime_config or runtime_config == 'local':
+        # No runtime configuration was  specified or it is local.
+        # Cannot use metadata manager to determine the runtime type.
+        return runtime_config
 
     try:
         metadata_manager = MetadataManager(namespace='runtimes')
@@ -57,8 +59,10 @@ def _get_runtime_type(runtime_config: Optional[str]) -> Optional[str]:
 
 
 def _get_runtime_display_name(schema_name: Optional[str]) -> Optional[str]:
-    if not schema_name:
-        return None
+    if not schema_name or schema_name == 'local':
+        # No schame name was  specified or it is local.
+        # Cannot use metadata manager to determine the display name.
+        return schema_name
 
     try:
         schema_manager = SchemaManager.instance()
@@ -142,10 +146,10 @@ def _preprocess_pipeline(pipeline_path: str,
 
     if not _validate_pipeline_runtime(primary_pipeline, runtime):
         pipeline_runtime_display_name = _get_runtime_display_name(primary_pipeline['app_data']['runtime'])
-        msg = f"This pipeline requires an instance of {pipeline_runtime_display_name} runtime configuration.\n"
+        msg = f"This pipeline requires an instance of {pipeline_runtime_display_name} runtime configuration."
         if runtime_config:
             provided_runtime_display_name = _get_runtime_display_name(_get_runtime_type(runtime_config))
-            msg = f"{msg}The specified configuration '{runtime_config}' is for {provided_runtime_display_name} runtime."
+            msg = f"{msg} The provided configuration '{runtime_config}' is for {provided_runtime_display_name} runtime."
         raise click.ClickException(msg)
 
     # update pipeline transient fields
@@ -304,7 +308,7 @@ def run(pipeline_path):
     _validate_pipeline_file_extension(pipeline_path)
 
     pipeline_definition = \
-        _preprocess_pipeline(pipeline_path, runtime='local')
+        _preprocess_pipeline(pipeline_path, runtime='local', runtime_config='local')
 
     _validate_pipeline_definition(pipeline_definition)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?

Fixes #2054

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?

Verified that the `elyra-pipeline run` command returns the expected results:

```
$ elyra-pipeline run generic.pipeline  # correct
   ...
   Elyra Pipeline Local Run Complete

$ elyra-pipeline run kfp.pipeline  # incorrect invocation
   ...
   Error: This pipeline requires an instance of Kubeflow Pipelines runtime configuration. The provided configuration 'local' is for local runtime.

$ elyra-pipeline run airflow.pipeline # incorrect invocation
   ...
   Error: This pipeline requires an instance of Apache Airflow runtime configuration. The provided configuration 'local' is for local runtime.
```

Confirmed that `describe` and `submit` commands still behave as expected.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
