### PR TITLE
Improve validation output in elyra-pipeline CLI

### DIFF
--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -164,13 +164,17 @@ def _print_issues(issues):
     # print validation issues
 
     for issue in sorted(issues, key=itemgetter('severity')):
-        output = f" [{SEVERITY[issue.get('severity')]}]"
+        severity = f" [{SEVERITY[issue.get('severity')]}]"
+        prefix = ''
+        postfix = ''
         if issue.get('data'):
             if issue['data'].get('nodeName'):
-                output = f"{output}[{issue['data'].get('nodeName')}]"
+                prefix = f"[{issue['data'].get('nodeName')}]"
             if issue['data'].get('propertyName'):
-                output = f"{output}[{issue['data'].get('propertyName')}]"
-        output = f"{output} - {issue['message']}"
+                prefix = f"{prefix}[{issue['data'].get('propertyName')}]"
+            if issue['data'].get('value'):
+                postfix = f"The current property value is '{issue['data'].get('value')}'."
+        output = f"{severity}{prefix} - {issue['message']} {postfix}"
         click.echo(output)
 
     click.echo("")

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -17,6 +17,7 @@
 import asyncio
 from collections import OrderedDict
 import json
+from operator import itemgetter
 import os
 from typing import Optional
 import warnings
@@ -161,42 +162,36 @@ def _preprocess_pipeline(pipeline_path: str,
 
 def _print_issues(issues):
     # print validation issues
-    for issue in issues:
-        if issue.get('severity') == ValidationSeverity.Error:
-            if issue.get('data'):
-                node_name = issue["data"].get("nodeName")
-                property_name = issue["data"].get("propertyName")
-                click.echo(
-                    f'- (Fatal error on node \'{node_name}\' property \'{property_name}\') '
-                    f'- {issue["message"]}')
-            else:
-                click.echo(
-                    f'- Fatal error - {issue["message"]}')
-        else:
-            # TODO check warning nodeNames are empty
-            severity = SEVERITY[issue.get('severity')]
-            click.echo(f'- ({severity}) - {issue["message"]}')
+
+    for issue in sorted(issues, key=itemgetter('severity')):
+        output = f" [{SEVERITY[issue.get('severity')]}]"
+        if issue.get('data'):
+            if issue['data'].get('nodeName'):
+                output = f"{output}[{issue['data'].get('nodeName')}]"
+            if issue['data'].get('propertyName'):
+                output = f"{output}[{issue['data'].get('propertyName')}]"
+        output = f"{output} - {issue['message']}"
+        click.echo(output)
 
     click.echo("")
 
 
 def _validate_pipeline_definition(pipeline_definition):
+
+    click.echo("Validating pipeline...")
     # validate pipeline
     validation_response = asyncio.get_event_loop().run_until_complete(
         PipelineValidationManager.instance().validate(pipeline=pipeline_definition))
 
+    # TODO: ptitzler remove
+    print(validation_response.to_json())
+
+    # print validation issues
+    issues = validation_response.to_json().get('issues')
+    _print_issues(issues)
+
     if validation_response.has_fatal:
-        click.echo('Pipeline validation FAILED:')
-
-        # print validation issues
-        issues = validation_response.to_json().get('issues')
-        _print_issues(issues)
-
-        raise click.ClickException("Error validating pipeline.")
-    else:
-        # print validation issues
-        issues = validation_response.to_json().get('issues')
-        _print_issues(issues)
+        raise click.ClickException("Pipeline validation FAILED. The pipeline was not submitted for execution.")
 
 
 def _execute_pipeline(pipeline_definition):

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -197,9 +197,6 @@ def _validate_pipeline_definition(pipeline_definition):
     validation_response = asyncio.get_event_loop().run_until_complete(
         PipelineValidationManager.instance().validate(pipeline=pipeline_definition))
 
-    # TODO: ptitzler remove
-    print(validation_response.to_json())
-
     # print validation issues
     issues = validation_response.to_json().get('issues')
     _print_issues(issues)

--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -169,11 +169,21 @@ def _print_issues(issues):
         postfix = ''
         if issue.get('data'):
             if issue['data'].get('nodeName'):
+                # issue is associated with a single node; display it
                 prefix = f"[{issue['data'].get('nodeName')}]"
             if issue['data'].get('propertyName'):
+                # issue is associated with a node property; display it
                 prefix = f"{prefix}[{issue['data'].get('propertyName')}]"
             if issue['data'].get('value'):
+                # issue is caused by the value of a node property; display it
                 postfix = f"The current property value is '{issue['data'].get('value')}'."
+            elif issue['data'].get('nodeNames') and isinstance(issue['data']['nodeNames'], list):
+                # issue is associated with multiple nodes
+                postfix = 'Nodes: '
+                separator = ''
+                for nn in issue['data']['nodeNames']:
+                    postfix = f"{postfix}{separator}'{nn}'"
+                    separator = ', '
         output = f"{severity}{prefix} - {issue['message']} {postfix}"
         click.echo(output)
 

--- a/elyra/pipeline/validate.py
+++ b/elyra/pipeline/validate.py
@@ -161,23 +161,23 @@ class PipelineValidationManager(SingletonConfigurable):
                                  message="At least one node must exist in the primary pipeline.")
         if 'app_data' not in primary_pipeline:
             response.add_message(severity=ValidationSeverity.Error, message_type="invalidPipeline",
-                                 message="Pipeline 'app_data' is missing from primary pipeline")
+                                 message="Pipeline 'app_data' is missing from primary pipeline.")
         elif 'version' not in primary_pipeline['app_data']:
             response.add_message(severity=ValidationSeverity.Error, message_type="invalidPipeline",
-                                 message="Pipeline app_data 'version' is missing from primary pipeline")
+                                 message="Pipeline app_data 'version' is missing from primary pipeline.")
         elif not int(primary_pipeline['app_data']['version']) > 0:
             response.add_message(severity=ValidationSeverity.Error, message_type="invalidPipeline",
-                                 message="Primary pipeline version field has an invalid value")
+                                 message="Primary pipeline version field has an invalid value.")
 
         if 'version' not in pipeline_json:
             response.add_message(severity=ValidationSeverity.Error, message_type="invalidPipeline",
-                                 message="Primary pipeline version field is missing")
+                                 message="Primary pipeline version field is missing.")
         if not isinstance(pipeline_json['version'], str):
             response.add_message(severity=ValidationSeverity.Error, message_type="invalidPipeline",
                                  message="Primary pipeline version field should be a string.")
         if float(pipeline_json['version']) < current_pipeline_schema_version:
             response.add_message(severity=ValidationSeverity.Error, message_type="invalidPipeline",
-                                 message="Incompatible pipeline schema version detected")
+                                 message="Incompatible pipeline schema version detected.")
 
     async def _validate_compatibility(self, pipeline: dict, pipeline_runtime: str,
                                       pipeline_execution: str, response: ValidationResponse) -> None:
@@ -197,7 +197,8 @@ class PipelineValidationManager(SingletonConfigurable):
             if pipeline_execution != pipeline_runtime and pipeline_runtime != 'generic':
                 response.add_message(severity=ValidationSeverity.Error,
                                      message_type="invalidRuntime",
-                                     message="Unable to run selected pipeline on selected runtime",
+                                     message="Pipeline runtime platform is not compatible "
+                                             "with selected runtime configuration.",
                                      data={"pipelineRuntime": pipeline_runtime,
                                            "pipelineID": pipeline_id})
             elif pipeline_runtime == 'generic':
@@ -217,7 +218,7 @@ class PipelineValidationManager(SingletonConfigurable):
                         node_label = node['app_data']['ui_data'].get('label', node['app_data']['label'])
                         response.add_message(severity=ValidationSeverity.Error,
                                              message_type="invalidNodeType",
-                                             message="Unsupported node type found in this pipeline",
+                                             message="Unsupported node type found in this pipeline.",
                                              data={"nodeID": node['id'],
                                                    "nodeOpName": node['op'],
                                                    "nodeName": node_label,
@@ -307,7 +308,7 @@ class PipelineValidationManager(SingletonConfigurable):
                                 if self._is_required_property(property_dict, f"elyra_{node_property}"):
                                     response.add_message(severity=ValidationSeverity.Error,
                                                          message_type="invalidNodeProperty",
-                                                         message="Node is missing required property",
+                                                         message="Node is missing required property.",
                                                          data={"nodeID": node['id'],
                                                                "nodeName": node_label,
                                                                "propertyName": node_property})
@@ -315,7 +316,7 @@ class PipelineValidationManager(SingletonConfigurable):
                                                 type(property_dict['current_parameters']['elyra_' + node_property])):
                                 response.add_message(severity=ValidationSeverity.Error,
                                                      message_type="invalidNodeProperty",
-                                                     message="Node property is incorrect type",
+                                                     message="Node property is incorrect type.",
                                                      data={"nodeID": node['id'],
                                                            "nodeName": node_label,
                                                            "propertyName": node_property})
@@ -350,17 +351,19 @@ class PipelineValidationManager(SingletonConfigurable):
             if int(resource_value) <= 0:
                 response.add_message(severity=ValidationSeverity.Error,
                                      message_type="invalidNodeProperty",
-                                     message="Property must be greater than zero",
+                                     message="Property must be greater than zero.",
                                      data={"nodeID": node_id,
                                            "nodeName": node_label,
-                                           "propertyName": resource_name})
+                                           "propertyName": resource_name,
+                                           "value": resource_value})
         except (ValueError, TypeError):
             response.add_message(severity=ValidationSeverity.Error,
                                  message_type="invalidNodeProperty",
-                                 message="Property has a non-parsable value",
+                                 message="Property has a non-numeric value.",
                                  data={"nodeID": node_id,
                                        "nodeName": node_label,
-                                       "propertyName": resource_name})
+                                       "propertyName": resource_name,
+                                       "value": resource_value})
 
     def _validate_filepath(self, node_id: str, node_label: str, property_name: str,
                            filename: str, response: ValidationResponse, file_dir: Optional[str] = "") -> None:
@@ -386,7 +389,7 @@ class PipelineValidationManager(SingletonConfigurable):
         if not os.path.commonpath([normalized_path, self.root_dir]) == self.root_dir:
             response.add_message(severity=ValidationSeverity.Error,
                                  message_type="invalidFilePath",
-                                 message="Property has an invalid reference to a file/dir outside the root workspace",
+                                 message="Property has an invalid reference to a file/dir outside the root workspace.",
                                  data={"nodeID": node_id,
                                        "nodeName": node_label,
                                        "propertyName": property_name,
@@ -396,7 +399,7 @@ class PipelineValidationManager(SingletonConfigurable):
                 response.add_message(severity=ValidationSeverity.Error,
                                      message_type="invalidFilePath",
                                      message="Property(wildcard) has an invalid path to a file/dir"
-                                             " or the file/dir does not exist",
+                                             " or the file/dir does not exist.",
                                      data={"nodeID": node_id,
                                            "nodeName": node_label,
                                            "propertyName": property_name,
@@ -404,7 +407,7 @@ class PipelineValidationManager(SingletonConfigurable):
         elif not os.path.exists(normalized_path):
             response.add_message(severity=ValidationSeverity.Error,
                                  message_type="invalidFilePath",
-                                 message="Property has an invalid path to a file/dir or the file/dir does not exist",
+                                 message="Property has an invalid path to a file/dir or the file/dir does not exist.",
                                  data={"nodeID": node_id,
                                        "nodeName": node_label,
                                        "propertyName": property_name,
@@ -424,7 +427,7 @@ class PipelineValidationManager(SingletonConfigurable):
         if len(result) != 2:
             response.add_message(severity=ValidationSeverity.Error,
                                  message_type="invalidEnvPair",
-                                 message="Property has an improperly formatted env variable key value pair",
+                                 message="Property has an improperly formatted env variable key value pair.",
                                  data={"nodeID": node_id,
                                        "nodeName": node_label,
                                        "propertyName": 'env_vars',
@@ -445,9 +448,9 @@ class PipelineValidationManager(SingletonConfigurable):
         if len(node_label) > label_name_max_length:
             response.add_message(severity=ValidationSeverity.Warning,
                                  message_type="invalidNodeLabel",
-                                 message="Property value has exceeded the max length allowed "
+                                 message="Property value exceeds the max length allowed "
                                          "({label_name_max_length}). This value may be truncated "
-                                         "by the runtime service",
+                                         "by the runtime service.",
                                  data={"nodeID": node_id,
                                        "nodeName": node_label,
                                        "propertyName": 'label',
@@ -505,21 +508,11 @@ class PipelineValidationManager(SingletonConfigurable):
                             for link in node['inputs'][0]['links']:
                                 graph.add_edge(link['node_id_ref'], node['id'])
 
-        # TODO ptitzler remove
-        # for isolate in nx.isolates(graph):
-        #    if graph.number_of_nodes() > 1:
-        #        response.add_message(severity=ValidationSeverity.Warning,
-        #                             message_type="singletonReference",
-        #                             message="This node is not connected to any part of the pipeline",
-        #                             data={"nodeID": isolate,
-        #                                  "nodeNames": self._get_node_names(pipeline=pipeline, node_id_list=[isolate]),
-        #                                   "pipelineID": self._get_pipeline_id(pipeline, node_id=isolate)})
-
         for isolate in nx.isolates(graph):
             if graph.number_of_nodes() > 1:
                 response.add_message(severity=ValidationSeverity.Warning,
                                      message_type="singletonReference",
-                                     message="This node is not connected to any other node.",
+                                     message="Node is not connected to any other node.",
                                      data={"nodeID": isolate,
                                            "nodeName":
                                            self._get_node_names(pipeline=pipeline, node_id_list=[isolate])[0],
@@ -543,10 +536,10 @@ class PipelineValidationManager(SingletonConfigurable):
         for cycle_number, cycle_link_list in link_dict_table.items():
             response.add_message(severity=ValidationSeverity.Error,
                                  message_type="circularReference",
-                                 message="A cycle was found within this pipeline.",
+                                 message="The pipeline contains a circular dependency between nodes.",
                                  data={"cycleNumber": cycle_number,
-                                       "nodeNames": self._get_node_names(pipeline=pipeline,
-                                                                         node_id_list=cycle_link_list),
+                                       "nodeNames": self._get_node_labels(pipeline,
+                                                                          cycle_link_list),
                                        "linkIDList": cycle_link_list})
 
     def _get_link_id(self, pipeline: dict, u_edge: str, v_edge: str) -> str:
@@ -623,7 +616,7 @@ class PipelineValidationManager(SingletonConfigurable):
         else:
             response.add_message(severity=ValidationSeverity.Error,
                                  message_type="invalidRuntime",
-                                 message="Unsupported pipeline runtime selected in this pipeline",
+                                 message="Unsupported pipeline runtime selected in this pipeline.",
                                  data={"pipelineRuntime": runtime})
 
     def _get_node_names(self, pipeline: dict, node_id_list: list) -> List:
@@ -636,13 +629,59 @@ class PipelineValidationManager(SingletonConfigurable):
         node_name_list = []
         pipeline_json = json.loads(json.dumps(pipeline))
         for node_id in node_id_list:
+            found = False
             for single_pipeline in pipeline_json['pipelines']:
-                nodes = single_pipeline['nodes']
-                for node in nodes:
+                for node in single_pipeline['nodes']:
                     if node['id'] == node_id:
-                        node_name_list.append(node['app_data'].get('label'))
+                        node_name_list.append(self._get_node_label(node))
+                        found = True
+                        break
+                if found:
+                    break
 
         return node_name_list
+
+    def _get_node_labels(self, pipeline: dict, link_ids: List[str]) -> List[str]:
+        """
+        Returns the names (labels) of the nodes that are connected by
+        the specified link_ids.
+
+        :param pipeline: the pipeline dict
+        :param link_id: link id
+        :return a tuple containing two node labels that are connected
+        """
+        if link_ids is None:
+            return None
+
+        pipeline_json = json.loads(json.dumps(pipeline))
+        node_labels = []
+        for link_id in link_ids:
+            for single_pipeline in pipeline_json['pipelines']:
+                for node in single_pipeline['nodes']:
+                    if node['type'] == "execution_node":
+                        for input in node.get('inputs', []):
+                            for link in input.get('links', []):
+                                if link['id'] == link_id:
+                                    node_labels.append(self._get_node_label(node))
+        return node_labels
+
+    def _get_node_label(self, node: dict) -> str:
+        """
+        Returns the label for the provided node or None if the information
+        cannot be derived from the inpuit dictionary.
+
+        :param node_dict: a dict representing a pipeline node
+        :return: node label
+        :rtype: str
+        """
+
+        if node is None or node.get('app_data') is None:
+            return None
+
+        node_label = node['app_data'].get('label')
+        if node['type'] == 'execution_node' and node['app_data'].get('ui_data'):
+            node_label = node['app_data']['ui_data'].get('label')
+        return node_label
 
     def _is_legacy_pipeline(self, pipeline: dict) -> bool:
         """

--- a/elyra/pipeline/validate.py
+++ b/elyra/pipeline/validate.py
@@ -331,7 +331,7 @@ class PipelineValidationManager(SingletonConfigurable):
         if not image_name:
             response.add_message(severity=ValidationSeverity.Error,
                                  message_type="invalidNodeProperty",
-                                 message="Node is missing image name",
+                                 message="Required property value is missing.",
                                  data={"nodeID": node_id,
                                        "nodeName": node_label,
                                        "propertyName": 'runtime_image'})
@@ -455,10 +455,10 @@ class PipelineValidationManager(SingletonConfigurable):
         if not matched or matched.group(0) != node_label:
             response.add_message(severity=ValidationSeverity.Warning,
                                  message_type="invalidNodeLabel",
-                                 message="Property value contains invalid characters. Invalid characters "
-                                         "may be replaced by the runtime service. Node labels must "
+                                 message="The node label contains characters that may be replaced "
+                                         "by the runtime service. Node labels should "
                                          "start with lower case alphanumeric and contain "
-                                         "only lower case alphanumeric, underscores, dots and dashes",
+                                         "only lower case alphanumeric, underscores, dots, and dashes.",
                                  data={"nodeID": node_id,
                                        "nodeName": node_label,
                                        "propertyName": 'label',
@@ -505,13 +505,23 @@ class PipelineValidationManager(SingletonConfigurable):
                             for link in node['inputs'][0]['links']:
                                 graph.add_edge(link['node_id_ref'], node['id'])
 
+        # for isolate in nx.isolates(graph):
+        #    if graph.number_of_nodes() > 1:
+        #        response.add_message(severity=ValidationSeverity.Warning,
+        #                             message_type="singletonReference",
+        #                             message="This node is not connected to any part of the pipeline",
+        #                             data={"nodeID": isolate,
+        #                                  "nodeNames": self._get_node_names(pipeline=pipeline, node_id_list=[isolate]),
+        #                                   "pipelineID": self._get_pipeline_id(pipeline, node_id=isolate)})
+
         for isolate in nx.isolates(graph):
             if graph.number_of_nodes() > 1:
                 response.add_message(severity=ValidationSeverity.Warning,
                                      message_type="singletonReference",
-                                     message="This node is not connected to any part of the pipeline",
+                                     message="This node is not connected to any other node.",
                                      data={"nodeID": isolate,
-                                           "nodeNames": self._get_node_names(pipeline=pipeline, node_id_list=[isolate]),
+                                           "nodeName":
+                                           self._get_node_names(pipeline=pipeline, node_id_list=[isolate])[0],
                                            "pipelineID": self._get_pipeline_id(pipeline, node_id=isolate)})
 
         cycles_detected = nx.simple_cycles(graph)
@@ -532,7 +542,7 @@ class PipelineValidationManager(SingletonConfigurable):
         for cycle_number, cycle_link_list in link_dict_table.items():
             response.add_message(severity=ValidationSeverity.Error,
                                  message_type="circularReference",
-                                 message="A cycle was found within this pipeline",
+                                 message="A cycle was found within this pipeline.",
                                  data={"cycleNumber": cycle_number,
                                        "nodeNames": self._get_node_names(pipeline=pipeline,
                                                                          node_id_list=cycle_link_list),

--- a/elyra/pipeline/validate.py
+++ b/elyra/pipeline/validate.py
@@ -505,6 +505,7 @@ class PipelineValidationManager(SingletonConfigurable):
                             for link in node['inputs'][0]['links']:
                                 graph.add_edge(link['node_id_ref'], node['id'])
 
+        # TODO ptitzler remove
         # for isolate in nx.isolates(graph):
         #    if graph.number_of_nodes() > 1:
         #        response.add_message(severity=ValidationSeverity.Warning,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
This PR:
 - improves visualization of pipeline validation results
 - simplifies existing code to reduce maintenance efforts
 - updates pipeline validation messages for clarity (wording, punctuation, etc)
 - adds incorrect property value to validation issue payload to aid with troubleshooting
 - fixes validation bugs

The proposed output introduces a new generic message display "pattern", comprising
- `[validation-issue-severity]` - always displayed
- `[node-label]` - displayed if applicable and available
- `[property-name]` - displayed if applicable and available
- ` - <validation-message-text>` - always displayed

Messages are sorted by severity (error > warning > ...), enabling the user to quickly locate issues that cause the operation to be aborted.

For clarity each component _could_ be prefixed, but that would result in a lot more "static" output.

Example output without prefixes:

```
$ elyra-pipeline submit a-circle.pipeline --runtime-config my_airflow_test_instance

────────────────────────────────────────────────────────────────
 Elyra Pipeline Submission
────────────────────────────────────────────────────────────────

Validating pipeline...

[Error][i depend on you][runtime_image] - Required property value is missing. 
[Error][you depend on me][env_vars] - Property has an improperly formatted env variable key value pair. The current property value is 'what up'.
[Error][hello.ipynb][runtime_image] - Required property value is missing. 
[Error][labeled-notebook-nod][env_vars] - Property has an improperly formatted env variable key value pair. The current property value is 'humpty goes dumpty'.
[Error] - The pipeline contains a circular dependency between nodes. Nodes: 'you depend on me', 'i depend on you'
[Warning][i depend on you][label] - The node label contains characters that may be replaced by the runtime service. Node labels should start with lower case alphanumeric and contain only lower case alphanumeric, underscores, dots, and dashes. The current property value is 'i depend on you'.
[Warning][you depend on me][label] - The node label contains characters that may be replaced by the runtime service. Node labels should start with lower case alphanumeric and contain only lower case alphanumeric, underscores, dots, and dashes. The current property value is 'you depend on me'.
[Warning][hello.ipynb] - Node is not connected to any other node. 
[Warning][labeled-notebook-nod] - Node is not connected to any other node. 
```

Example output with prefixes:

```
$ elyra-pipeline submit a-circle.pipeline --runtime-config my_airflow_test_instance
────────────────────────────────────────────────────────────────
 Elyra Pipeline Submission
────────────────────────────────────────────────────────────────
Validating pipeline...

[Error][node: i depend on you][property:runtime_image] - Required property value is missing. 
[Error][node: you depend on me][property: env_vars] - Property has an improperly formatted env variable key value pair. The current property value is 'what up'.

```

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Reviewed output for the following scenarios
- [ ] validation output (no errors or warnings) `run command`
- [ ] validation output (errors but no warnings) `run command`
- [ ] validation output (warnings only) `run command`
- [ ] validation output (no errors or warnings) `submit command`
- [ ] validation output (errors but no warnings) `submit command`
- [ ] validation output (warnings only) `submit command`

- [ ] verify that validation changes don't break VPE output
 
Fixes #1999

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
