### PR TITLE
Expose pipeline description to runtime environments

### DIFF
--- a/elyra/pipeline/parser.py
+++ b/elyra/pipeline/parser.py
@@ -51,11 +51,14 @@ class PipelineParser(LoggingConfigurable):
 
         source = PipelineParser._get_app_data_field(primary_pipeline, 'source')
 
+        description = PipelineParser._get_app_data_field(primary_pipeline, 'properties', {}).get('description')
+
         pipeline_object = Pipeline(id=primary_pipeline_id,
                                    name=PipelineParser._get_app_data_field(primary_pipeline, 'name', 'untitled'),
                                    runtime=runtime,
                                    runtime_config=runtime_config,
-                                   source=source)
+                                   source=source,
+                                   description=description)
         self._nodes_to_operations(pipeline_definitions, pipeline_object, primary_pipeline['nodes'])
         return pipeline_object
 

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -377,7 +377,7 @@ class Pipeline(object):
         return self._operations
 
     @property
-    def description(self) -> str:
+    def description(self) -> Optional[str]:
         """
         Pipeline description
         """

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -312,7 +312,13 @@ class Pipeline(object):
     Represents a single pipeline constructed in the pipeline editor
     """
 
-    def __init__(self, id: str, name: str, runtime: str, runtime_config: str, source: Optional[str] = None):
+    def __init__(self,
+                 id: str,
+                 name: str,
+                 runtime: str,
+                 runtime_config: str,
+                 source: Optional[str] = None,
+                 description: Optional[str] = None):
         """
         :param id: Generated UUID, 128 bit number used as a unique identifier
                    e.g. 123e4567-e89b-12d3-a456-426614174000
@@ -322,6 +328,7 @@ class Pipeline(object):
                         e.g. kfp OR airflow
         :param runtime_config: Runtime configuration that should be used to submit the pipeline to execution
         :param source: The pipeline source, e.g. a pipeline file or a notebook.
+        :description: Pipeline description
         """
 
         if not name:
@@ -333,6 +340,7 @@ class Pipeline(object):
 
         self._id = id
         self._name = name
+        self._description = description
         self._source = source
         self._runtime = runtime
         self._runtime_config = runtime_config
@@ -368,11 +376,19 @@ class Pipeline(object):
     def operations(self) -> Dict[str, Operation]:
         return self._operations
 
+    @property
+    def description(self) -> str:
+        """
+        Pipeline description
+        """
+        return self._description
+
     def __eq__(self, other: 'Pipeline') -> bool:
         if isinstance(self, other.__class__):
             return self.id == other.id and \
                 self.name == other.name and \
                 self.source == other.source and \
+                self.description == other.description and \
                 self.runtime == other.runtime and \
                 self.runtime_config == other.runtime_config and \
                 self.operations == other.operations

--- a/elyra/pipeline/processor_airflow.py
+++ b/elyra/pipeline/processor_airflow.py
@@ -321,7 +321,9 @@ class AirflowPipelineProcessor(RuntimePipelineProcessor):
             user_namespace = runtime_configuration.metadata.get('user_namespace') or 'default'
             cos_secret = runtime_configuration.metadata.get('cos_secret')
 
-            description = f"Created with Elyra {__version__} pipeline editor using `{pipeline.source}`."
+            pipeline_description = pipeline.description
+            if pipeline_description is None:
+                pipeline_description = f"Created with Elyra {__version__} pipeline editor using `{pipeline.source}`."
 
             python_output = template.render(operations_list=target_ops,
                                             pipeline_name=pipeline_name,
@@ -330,7 +332,7 @@ class AirflowPipelineProcessor(RuntimePipelineProcessor):
                                             kube_config_path=None,
                                             is_paused_upon_creation='False',
                                             in_cluster='True',
-                                            pipeline_description=description)
+                                            pipeline_description=pipeline_description)
 
             # Write to python file and fix formatting
             with open(pipeline_export_path, "w") as fh:

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -209,10 +209,10 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
             # Upload the compiled pipeline, create an experiment and run
 
             try:
-                if pipeline.description is not None:
-                    description = pipeline.description
-                else:
-                    description = f"Created with Elyra {__version__} pipeline editor using `{pipeline.source}`."
+                pipeline_description = pipeline.description
+                if pipeline_description is None:
+                    pipeline_description = f"Created with Elyra {__version__} pipeline editor "\
+                                           f"using `{pipeline.source}`."
                 t0 = time.time()
 
                 if pipeline_id is None:
@@ -221,7 +221,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                     kfp_pipeline = \
                         client.upload_pipeline(pipeline_path,
                                                pipeline_name,
-                                               description)
+                                               pipeline_description)
                     pipeline_id = kfp_pipeline.id
                     version_id = None
                 else:

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -209,7 +209,10 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
             # Upload the compiled pipeline, create an experiment and run
 
             try:
-                description = f"Created with Elyra {__version__} pipeline editor using '{pipeline.source}'."
+                if pipeline.description is not None:
+                    description = pipeline.description
+                else:
+                    description = f"Created with Elyra {__version__} pipeline editor using `{pipeline.source}`."
                 t0 = time.time()
 
                 if pipeline_id is None:
@@ -273,6 +276,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
         t0_all = time.time()
         timestamp = datetime.now().strftime("%m%d%H%M%S")
         pipeline_name = pipeline.name
+        pipeline_description = pipeline.description
         pipeline_version_name = f'{pipeline_name}-{timestamp}'
         # work around https://github.com/kubeflow/pipelines/issues/5172
         experiment_name = pipeline_name.lower()
@@ -337,7 +341,8 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                                                  cos_directory=cos_directory,
                                                  export=True)
 
-            description = f'Created with Elyra {__version__} pipeline editor using {pipeline.source}.'
+            if pipeline_description is None:
+                pipeline_description = f"Created with Elyra {__version__} pipeline editor using `{pipeline.source}`."
 
             if self.log.isEnabledFor(logging.DEBUG):
                 self.log.debug(f"Exporting pipeline {pipeline_name} with components: \n")
@@ -361,7 +366,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                                             cos_secret=cos_secret,
                                             namespace=namespace,
                                             api_endpoint=api_endpoint,
-                                            pipeline_description=description,
+                                            pipeline_description=pipeline_description,
                                             writable_container_dir=self.WCD,
                                             kf_secured=kf_secured)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

Expose user-provided pipeline description in the runtime environments if one was provided, otherwise the current behavior is retained and a generic text displayed:  

![image](https://user-images.githubusercontent.com/13068832/131527134-eb074b58-4415-4a82-bb20-9a23e4da5ba7.png)

Example with user-provided description in KFP:

![image](https://user-images.githubusercontent.com/13068832/131526557-8fd89068-4629-4dfb-8481-23dc06e02707.png)

Example with user-provided description in AA:

![image](https://user-images.githubusercontent.com/13068832/131526864-3f97580a-67ea-4574-9754-2d56f5353bb2.png)



### What changes were proposed in this pull request?

This is a follow-up to https://github.com/elyra-ai/elyra/pull/1708, which introduced VPE support for a pipeline description property:
 - extend pipeline parser to recognize a user-provided description
 - extend pipeline class by adding a description property (populated by the parser)
 - pass-through user-provided pipeline description to runtime environments (kfp/aa) instead of static string
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
