### PR TITLE
Defer import of black to postpone logging noise

### DIFF
--- a/elyra/pipeline/processor_airflow.py
+++ b/elyra/pipeline/processor_airflow.py
@@ -25,8 +25,6 @@ from typing import List
 from typing import Union
 
 import autopep8
-from black import FileMode
-from black import format_str
 from jinja2 import Environment
 from jinja2 import PackageLoader
 
@@ -334,8 +332,10 @@ class AirflowPipelineProcessor(RuntimePipelineProcessor):
 
             # Write to python file and fix formatting
             with open(pipeline_export_path, "w") as fh:
+                # Defer the import to postpone logger messages: https://github.com/psf/black/issues/2058
+                import black
                 autopep_output = autopep8.fix_code(python_output)
-                output_to_file = format_str(autopep_output, mode=FileMode())
+                output_to_file = black.format_str(autopep_output, mode=black.FileMode())
                 fh.write(output_to_file)
 
         return pipeline_export_path

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -23,8 +23,6 @@ import time
 from typing import Dict
 
 import autopep8
-from black import FileMode
-from black import format_str
 from jinja2 import Environment
 from jinja2 import PackageLoader
 from jupyter_core.paths import ENV_JUPYTER_PATH
@@ -367,8 +365,10 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
 
             # Write to Python file and fix formatting
             with open(absolute_pipeline_export_path, "w") as fh:
+                # Defer the import to postpone logger messages: https://github.com/psf/black/issues/2058
+                import black
                 autopep_output = autopep8.fix_code(python_output)
-                output_to_file = format_str(autopep_output, mode=FileMode())
+                output_to_file = black.format_str(autopep_output, mode=black.FileMode())
                 fh.write(output_to_file)
 
             self.log_pipeline_info(pipeline_name, "pipeline rendered", duration=(time.time() - t0_all))


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pull request defers the load of the `black` package to the point that is needed - which is during KFP and Airflow export functionality.  As a result, the logging messages that are referenced in #2084 nolonger appear when `jupyter lab` starts or the `elyra-metadata` CLI is invoked.  That said, the logging messages _do_ appear, but only during export functionality, only for type `py` export formats, and only once per server instance.

### How was this pull request tested?
Since the current tests don't exercise the necessary logic and Elyra currently doesn't expose the Python exports for KFP, one must use the VPE to create an Airflow pipeline, which is then exported.

The tail-end of the output produced during that call includes the logging statements:
```
[I 2021-08-31 17:10:53.269 ElyraApp] airflow 'untitled7-0831171052' - pipeline dependencies processed (0.672 secs)
[D 2021-08-31 17:10:53.270 ServerApp] Namespace 'runtimes' is using metadata directory: /Users/kbates/Library/Jupyter/metadata/runtimes from list: ['/Users/kbates/Library/Jupyter/metadata/runtimes', '/usr/local/share/jupyter/metadata/runtimes', '/usr/share/jupyter/metadata/runtimes', '/opt/anaconda3/envs/elyra-dev/share/jupyter/metadata/runtimes']
[D 2021-08-31 17:10:53.270 ServerApp] Loading metadata instance from cache: 'af_teacloth1'
Generating grammar tables from /opt/anaconda3/envs/elyra-dev/lib/python3.8/site-packages/blib2to3/Grammar.txt
Writing grammar tables to /Users/kbates/Library/Caches/black/21.7b0/Grammar3.8.5.final.0.pickle
Writing failed: [Errno 2] No such file or directory: '/Users/kbates/Library/Caches/black/21.7b0/tmp5io44kks'
Generating grammar tables from /opt/anaconda3/envs/elyra-dev/lib/python3.8/site-packages/blib2to3/PatternGrammar.txt
Writing grammar tables to /Users/kbates/Library/Caches/black/21.7b0/PatternGrammar3.8.5.final.0.pickle
Writing failed: [Errno 2] No such file or directory: '/Users/kbates/Library/Caches/black/21.7b0/tmp2m8w80xq'
[D 2021-08-31 17:10:53.532 ServerApp] 201 POST /elyra/pipeline/export?1630455051430 (::1) 2096.81ms
```
Note that these log statements still only occur once per server instance (not on each export).

Here are the pipeline and exported python files (with `.txt` suffices):
[untitled7.pipeline.txt](https://github.com/elyra-ai/elyra/files/7087409/untitled7.pipeline.txt)
[untitled7.py.txt](https://github.com/elyra-ai/elyra/files/7087411/untitled7.py.txt)

Resolves #2084
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
