### PR TITLE
Add DAG repo to airflow submission response messages

### DIFF
--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -32,6 +32,7 @@ from elyra.metadata.manager import MetadataManager
 from elyra.metadata.schema import SchemaManager
 from elyra.pipeline.parser import PipelineParser
 from elyra.pipeline.processor import PipelineProcessorManager
+from elyra.pipeline.processor import PipelineProcessorResponse
 from elyra.pipeline.validation import PipelineValidationManager
 from elyra.pipeline.validation import ValidationSeverity
 
@@ -192,7 +193,7 @@ def _validate_pipeline_definition(pipeline_definition):
         raise click.ClickException("Pipeline validation FAILED. The pipeline was not submitted for execution.")
 
 
-def _execute_pipeline(pipeline_definition):
+def _execute_pipeline(pipeline_definition) -> PipelineProcessorResponse:
     try:
         # parse pipeline
         pipeline_object = PipelineParser().parse(pipeline_definition)
@@ -265,15 +266,22 @@ def submit(pipeline_path, runtime_config):
     _validate_pipeline_definition(pipeline_definition)
 
     with yaspin(text="Submitting pipeline..."):
-        response = _execute_pipeline(pipeline_definition)
+        response: PipelineProcessorResponse = _execute_pipeline(pipeline_definition)
 
     if response:
-        print_info("Job submission succeeded",
-                   [
-                       f"Check the status of your job at: {response._run_url}",
-                       f"The results and outputs are in the {response._object_storage_path} ",
-                       f"working directory in {response._object_storage_url}"
-                   ])
+        msg = []
+        # If there's a git_url attr, assume Apache Airflow DAG repo.
+        # TODO: this will need to be revisited once front-end is decoupled from runtime platforms.
+        if hasattr(response, 'git_url'):
+            msg.append(f"Apache Airflow DAG has been pushed to: {response.git_url}")
+        msg.extend(
+            [
+                f"Check the status of your job at: {response.run_url}",
+                f"The results and outputs are in the {response.object_storage_path} ",
+                f"working directory in {response.object_storage_url}"
+            ]
+        )
+        print_info("Job submission succeeded", msg)
 
     click.echo()
 


### PR DESCRIPTION
This pull request updates the submission response message to include the GitHub URL that contains the uploaded Airflow DAG.  This addition only occurs if the response object contains a `git_url` attribute.

Note: this logic will need to be revisited once we decouple the platform runtimes from the front-end (as part of https://github.com/elyra-ai/elyra/issues/2100), at which time I suspect the response object will also include the message text appropriate to the platform runtime.

### How was this pull request tested?
The current automation tests don't cover submission, so this was manually verified using an appropriate pipeline and produced this output:
```
 $ elyra-pipeline submit --runtime-config af_teacloth1 my_pipeline/kb1_nb_only.pipeline 

────────────────────────────────────────────────────────────────
 Elyra Pipeline Submission
────────────────────────────────────────────────────────────────

Validating pipeline...
 [Warning][Prepare for the apocalypse now!][label] - The node label contains characters that may be replaced by the runtime service. Node labels should start with lower case alphanumeric and contain only lower case alphanumeric, underscores, dots, and dashes. The current property value is 'Prepare for the apocalypse now!'.
 [Warning][Finalize][label] - The node label contains characters that may be replaced by the runtime service. Node labels should start with lower case alphanumeric and contain only lower case alphanumeric, underscores, dots, and dashes. The current property value is 'Finalize'.
 [Warning][Process][label] - The node label contains characters that may be replaced by the runtime service. Node labels should start with lower case alphanumeric and contain only lower case alphanumeric, underscores, dots, and dashes. The current property value is 'Process'.

❯ Job submission succeeded
  Apache Airflow DAG has been pushed to: https://github.com/akchinstc/test-repo/tree/test
  Check the status of your job at: http://teacloth1.fyre.ibm.com:31187
  The results and outputs are in the /kbates/kb1_nb_only-0902134652 
  working directory in http://cloning1.fyre.ibm.com:31467


────────────────────────────────────────────────────────────────
 Elyra Pipeline Submission Complete
────────────────────────────────────────────────────────────────
```

Resolves #2101
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
