### PR TITLE
Fix instances of previous attribute names in processors to their current names

### DIFF
--- a/elyra/pipeline/processor_airflow.py
+++ b/elyra/pipeline/processor_airflow.py
@@ -253,15 +253,15 @@ class AirflowPipelineProcessor(RuntimePipelineProcessor):
                     property_value = operation.component_params.get(component_property.ref)
 
                     self.log.debug(f"Processing component parameter '{component_property.name}' "
-                                   f"of type '{component_property.type}'")
-                    if component_property.type == "string":
+                                   f"of type '{component_property.data_type}'")
+                    if component_property.data_type == "string":
                         # Add surrounding quotation marks to string value for correct rendering
                         # in jinja DAG template
                         operation.component_params[component_property.ref] = json.dumps(property_value)
-                    elif component_property.type == 'dictionary':
+                    elif component_property.data_type == 'dictionary':
                         processed_value = self._process_dictionary_value(property_value)
                         operation.component_params[component_property.ref] = processed_value
-                    elif component_property.type == 'list':
+                    elif component_property.data_type == 'list':
                         processed_value = self._process_list_value(property_value)
                         operation.component_params[component_property.ref] = processed_value
 
@@ -273,7 +273,7 @@ class AirflowPipelineProcessor(RuntimePipelineProcessor):
 
                 target_op = {'notebook': unique_operation_name,
                              'id': operation.id,
-                             'module_name': component.source.rsplit('/', 1)[-1].split('.')[0],
+                             'module_name': component.location.rsplit('/', 1)[-1].split('.')[0],
                              'class_name': component_class,
                              'parent_operation_ids': operation.parent_operation_ids,
                              'component_params': operation.component_params_as_dict,

--- a/elyra/pipeline/processor_kfp.py
+++ b/elyra/pipeline/processor_kfp.py
@@ -532,7 +532,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                     property_value = operation.component_params.get(component_property.ref)
 
                     self.log.debug(f"Processing component parameter '{component_property.name}' "
-                                   f"of type '{component_property.type}'")
+                                   f"of type '{component_property.data_type}'")
                     if component_property.data_type == "file":
                         filename = get_absolute_path(get_expanded_path(self.root_dir), property_value)
                         try:


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fixes a few missed instances of changing `ComponentParameter` attribute `type` to `data_type` and changes what was previously the `Component` `source` attribute to `location`.

### How was this pull request tested?
Tested manually by successfully running example pipelines.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
