### PR TITLE
Add additional safeguards around list and dictionary types during processing

### DIFF
--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -410,22 +410,24 @@ class RuntimePipelineProcessor(PipelineProcessor):
         envs['ELYRA_ENABLE_PIPELINE_INFO'] = str(self.enable_pipeline_info)
         return envs
 
-    def _process_dictionary_value(self, value: str) -> Union[Dict, str]:
+    def _process_dictionary_value(self, value: str) -> Optional[Union[Dict, str]]:
         """
         For component parameters of type dictionary, the user-entered string value given in the pipeline
         JSON should be converted to the appropriate Dict format, if possible. If a Dict cannot be formed,
         log and return stripped string value.
         """
-        converted_dict = None
         value = value.strip()
+        if not value:
+            return {}
+        if value == "None":
+            return None
+
+        converted_dict = None
         if value.startswith('{') and value.endswith('}'):
             try:
                 converted_dict = ast.literal_eval(value)
             except Exception:
                 pass
-
-        if not value or value == "None":
-            return {}
 
         # Value could not be successfully converted to dictionary
         if not isinstance(converted_dict, dict):
@@ -434,22 +436,24 @@ class RuntimePipelineProcessor(PipelineProcessor):
 
         return converted_dict
 
-    def _process_list_value(self, value: str) -> Union[List, str]:
+    def _process_list_value(self, value: str) -> Optional[Union[List, str]]:
         """
         For component parameters of type list, the user-entered string value given in the pipeline JSON
         should be converted to the appropriate List format, if possible. If a List cannot be formed,
         log and return stripped string value.
         """
         value = value.strip()
+        if not value:
+            return []
+        if value == "None":
+            return None
+
         converted_list = None
         if value.startswith('[') and value.endswith(']'):
             try:
                 converted_list = ast.literal_eval(value)
             except Exception:
                 pass
-
-        if not value or value == "None":
-            return []
 
         # Value could not be successfully converted to list
         if not isinstance(converted_list, list):

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -416,8 +416,11 @@ class RuntimePipelineProcessor(PipelineProcessor):
         JSON should be converted to the appropriate Dict format, if possible. If a Dict cannot be formed,
         log and return stripped string value.
         """
+        if not value:
+            return {}
+
         value = value.strip()
-        if not value or value == "None":
+        if value == "None":
             return {}
 
         converted_dict = None
@@ -440,8 +443,11 @@ class RuntimePipelineProcessor(PipelineProcessor):
         should be converted to the appropriate List format, if possible. If a List cannot be formed,
         log and return stripped string value.
         """
+        if not value:
+            return []
+
         value = value.strip()
-        if not value or value == "None":
+        if value == "None":
             return []
 
         converted_list = None

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -410,17 +410,15 @@ class RuntimePipelineProcessor(PipelineProcessor):
         envs['ELYRA_ENABLE_PIPELINE_INFO'] = str(self.enable_pipeline_info)
         return envs
 
-    def _process_dictionary_value(self, value: str) -> Optional[Union[Dict, str]]:
+    def _process_dictionary_value(self, value: str) -> Union[Dict, str]:
         """
         For component parameters of type dictionary, the user-entered string value given in the pipeline
         JSON should be converted to the appropriate Dict format, if possible. If a Dict cannot be formed,
         log and return stripped string value.
         """
         value = value.strip()
-        if not value:
+        if not value or value == "None":
             return {}
-        if value == "None":
-            return None
 
         converted_dict = None
         if value.startswith('{') and value.endswith('}'):
@@ -436,17 +434,15 @@ class RuntimePipelineProcessor(PipelineProcessor):
 
         return converted_dict
 
-    def _process_list_value(self, value: str) -> Optional[Union[List, str]]:
+    def _process_list_value(self, value: str) -> Union[List, str]:
         """
         For component parameters of type list, the user-entered string value given in the pipeline JSON
         should be converted to the appropriate List format, if possible. If a List cannot be formed,
         log and return stripped string value.
         """
         value = value.strip()
-        if not value:
+        if not value or value == "None":
             return []
-        if value == "None":
-            return None
 
         converted_list = None
         if value.startswith('[') and value.endswith(']'):

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -424,6 +424,9 @@ class RuntimePipelineProcessor(PipelineProcessor):
             except Exception:
                 pass
 
+        if not value or value == "None":
+            return {}
+
         # Value could not be successfully converted to dictionary
         if not isinstance(converted_dict, dict):
             self.log.debug(f"Could not convert entered parameter value `{value}` to dictionary")
@@ -444,6 +447,9 @@ class RuntimePipelineProcessor(PipelineProcessor):
                 converted_list = ast.literal_eval(value)
             except Exception:
                 pass
+
+        if not value or value == "None":
+            return []
 
         # Value could not be successfully converted to list
         if not isinstance(converted_list, list):

--- a/elyra/pipeline/processor_airflow.py
+++ b/elyra/pipeline/processor_airflow.py
@@ -22,6 +22,7 @@ import tempfile
 import time
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Union
 
 import autopep8
@@ -359,7 +360,7 @@ class AirflowPipelineProcessor(RuntimePipelineProcessor):
 
         return unique_operation_name
 
-    def _process_dictionary_value(self, value: str) -> Union[Dict, str]:
+    def _process_dictionary_value(self, value: str) -> Optional[Union[Dict, str]]:
         """
         For component parameters of type dictionary, if a string value is returned from the superclass
         method, it must be converted to include surrounding quotation marks for correct rendering
@@ -370,7 +371,7 @@ class AirflowPipelineProcessor(RuntimePipelineProcessor):
             converted_value = json.dumps(converted_value)
         return converted_value
 
-    def _process_list_value(self, value: str) -> Union[List, str]:
+    def _process_list_value(self, value: str) -> Optional[Union[List, str]]:
         """
         For component parameters of type list, if a string value is returned from the superclass
         method, it must be converted to include surrounding quotation marks for correct rendering

--- a/elyra/pipeline/processor_airflow.py
+++ b/elyra/pipeline/processor_airflow.py
@@ -22,7 +22,6 @@ import tempfile
 import time
 from typing import Dict
 from typing import List
-from typing import Optional
 from typing import Union
 
 import autopep8
@@ -360,7 +359,7 @@ class AirflowPipelineProcessor(RuntimePipelineProcessor):
 
         return unique_operation_name
 
-    def _process_dictionary_value(self, value: str) -> Optional[Union[Dict, str]]:
+    def _process_dictionary_value(self, value: str) -> Union[Dict, str]:
         """
         For component parameters of type dictionary, if a string value is returned from the superclass
         method, it must be converted to include surrounding quotation marks for correct rendering
@@ -371,7 +370,7 @@ class AirflowPipelineProcessor(RuntimePipelineProcessor):
             converted_value = json.dumps(converted_value)
         return converted_value
 
-    def _process_list_value(self, value: str) -> Optional[Union[List, str]]:
+    def _process_list_value(self, value: str) -> Union[List, str]:
         """
         For component parameters of type list, if a string value is returned from the superclass
         method, it must be converted to include surrounding quotation marks for correct rendering

--- a/elyra/pipeline/tests/test_processor_airflow.py
+++ b/elyra/pipeline/tests/test_processor_airflow.py
@@ -377,6 +377,7 @@ def test_unique_operation_name_non_existent(processor):
 
 def test_process_list_value_function(processor):
     # Test values that will be successfully converted to list
+    assert processor._process_list_value("") == []
     assert processor._process_list_value("[]") == []
     assert processor._process_list_value("['elem1']") == ["elem1"]
     assert processor._process_list_value("['elem1', 'elem2', 'elem3']") == ["elem1", "elem2", "elem3"]
@@ -387,7 +388,6 @@ def test_process_list_value_function(processor):
 
     # Test values that will not be successfully converted to list
     # Surrounding quotes are added to string values for correct DAG render
-    assert processor._process_list_value("") == "\"\""
     assert processor._process_list_value("[[]") == "\"[[]\""
     assert processor._process_list_value("[elem1, elem2]") == "\"[elem1, elem2]\""
     assert processor._process_list_value("elem1, elem2") == "\"elem1, elem2\""
@@ -397,6 +397,7 @@ def test_process_list_value_function(processor):
 
 def test_process_dictionary_value_function(processor):
     # Test values that will be successfully converted to dictionary
+    assert processor._process_dictionary_value("") == {}
     assert processor._process_dictionary_value("{}") == {}
     assert processor._process_dictionary_value("{'key': 'value'}") == {"key": "value"}
 
@@ -432,7 +433,6 @@ def test_process_dictionary_value_function(processor):
 
     # Test values that will not be successfully converted to dictionary
     # Surrounding quotes are added to string values for correct DAG render
-    assert processor._process_dictionary_value("") == "\"\""
     assert processor._process_dictionary_value("{{}") == "\"{{}\""
     assert processor._process_dictionary_value("{key1: value, key2: value}") == "\"{key1: value, key2: value}\""
     assert processor._process_dictionary_value("  { key1: value, key2: value }  ") == "\"{ key1: value, key2: value }\""

--- a/elyra/pipeline/tests/test_processor_airflow.py
+++ b/elyra/pipeline/tests/test_processor_airflow.py
@@ -378,6 +378,7 @@ def test_unique_operation_name_non_existent(processor):
 def test_process_list_value_function(processor):
     # Test values that will be successfully converted to list
     assert processor._process_list_value("") == []
+    assert processor._process_list_value(None) == []
     assert processor._process_list_value("[]") == []
     assert processor._process_list_value("None") == []
     assert processor._process_list_value("['elem1']") == ["elem1"]
@@ -399,6 +400,7 @@ def test_process_list_value_function(processor):
 def test_process_dictionary_value_function(processor):
     # Test values that will be successfully converted to dictionary
     assert processor._process_dictionary_value("") == {}
+    assert processor._process_dictionary_value(None) == {}
     assert processor._process_dictionary_value("{}") == {}
     assert processor._process_dictionary_value("None") == {}
     assert processor._process_dictionary_value("{'key': 'value'}") == {"key": "value"}

--- a/elyra/pipeline/tests/test_processor_airflow.py
+++ b/elyra/pipeline/tests/test_processor_airflow.py
@@ -379,7 +379,7 @@ def test_process_list_value_function(processor):
     # Test values that will be successfully converted to list
     assert processor._process_list_value("") == []
     assert processor._process_list_value("[]") == []
-    assert processor._process_list_value("None") is None
+    assert processor._process_list_value("None") == []
     assert processor._process_list_value("['elem1']") == ["elem1"]
     assert processor._process_list_value("['elem1', 'elem2', 'elem3']") == ["elem1", "elem2", "elem3"]
     assert processor._process_list_value("  ['elem1',   'elem2' , 'elem3']  ") == ["elem1", "elem2", "elem3"]
@@ -400,7 +400,7 @@ def test_process_dictionary_value_function(processor):
     # Test values that will be successfully converted to dictionary
     assert processor._process_dictionary_value("") == {}
     assert processor._process_dictionary_value("{}") == {}
-    assert processor._process_dictionary_value("None") is None
+    assert processor._process_dictionary_value("None") == {}
     assert processor._process_dictionary_value("{'key': 'value'}") == {"key": "value"}
 
     dict_as_str = "{'key1': 'value', 'key2': 'value'}"

--- a/elyra/pipeline/tests/test_processor_airflow.py
+++ b/elyra/pipeline/tests/test_processor_airflow.py
@@ -379,6 +379,7 @@ def test_process_list_value_function(processor):
     # Test values that will be successfully converted to list
     assert processor._process_list_value("") == []
     assert processor._process_list_value("[]") == []
+    assert processor._process_list_value("None") is None
     assert processor._process_list_value("['elem1']") == ["elem1"]
     assert processor._process_list_value("['elem1', 'elem2', 'elem3']") == ["elem1", "elem2", "elem3"]
     assert processor._process_list_value("  ['elem1',   'elem2' , 'elem3']  ") == ["elem1", "elem2", "elem3"]
@@ -399,6 +400,7 @@ def test_process_dictionary_value_function(processor):
     # Test values that will be successfully converted to dictionary
     assert processor._process_dictionary_value("") == {}
     assert processor._process_dictionary_value("{}") == {}
+    assert processor._process_dictionary_value("None") is None
     assert processor._process_dictionary_value("{'key': 'value'}") == {"key": "value"}
 
     dict_as_str = "{'key1': 'value', 'key2': 'value'}"

--- a/elyra/pipeline/tests/test_processor_kfp.py
+++ b/elyra/pipeline/tests/test_processor_kfp.py
@@ -197,6 +197,7 @@ def test_process_list_value_function(processor):
     # Test values that will be successfully converted to list
     assert processor._process_list_value("") == []
     assert processor._process_list_value("[]") == []
+    assert processor._process_list_value("None") is None
     assert processor._process_list_value("['elem1']") == ["elem1"]
     assert processor._process_list_value("['elem1', 'elem2', 'elem3']") == ["elem1", "elem2", "elem3"]
     assert processor._process_list_value("  ['elem1',   'elem2' , 'elem3']  ") == ["elem1", "elem2", "elem3"]
@@ -216,6 +217,7 @@ def test_process_dictionary_value_function(processor):
     # Test values that will be successfully converted to dictionary
     assert processor._process_dictionary_value("") == {}
     assert processor._process_dictionary_value("{}") == {}
+    assert processor._process_dictionary_value("None") is None
     assert processor._process_dictionary_value("{'key': 'value'}") == {"key": "value"}
 
     dict_as_str = "{'key1': 'value', 'key2': 'value'}"

--- a/elyra/pipeline/tests/test_processor_kfp.py
+++ b/elyra/pipeline/tests/test_processor_kfp.py
@@ -196,6 +196,7 @@ def test_collect_envs(processor):
 def test_process_list_value_function(processor):
     # Test values that will be successfully converted to list
     assert processor._process_list_value("") == []
+    assert processor._process_list_value(None) == []
     assert processor._process_list_value("[]") == []
     assert processor._process_list_value("None") == []
     assert processor._process_list_value("['elem1']") == ["elem1"]
@@ -216,6 +217,7 @@ def test_process_list_value_function(processor):
 def test_process_dictionary_value_function(processor):
     # Test values that will be successfully converted to dictionary
     assert processor._process_dictionary_value("") == {}
+    assert processor._process_dictionary_value(None) == {}
     assert processor._process_dictionary_value("{}") == {}
     assert processor._process_dictionary_value("None") == {}
     assert processor._process_dictionary_value("{'key': 'value'}") == {"key": "value"}

--- a/elyra/pipeline/tests/test_processor_kfp.py
+++ b/elyra/pipeline/tests/test_processor_kfp.py
@@ -195,6 +195,7 @@ def test_collect_envs(processor):
 
 def test_process_list_value_function(processor):
     # Test values that will be successfully converted to list
+    assert processor._process_list_value("") == []
     assert processor._process_list_value("[]") == []
     assert processor._process_list_value("['elem1']") == ["elem1"]
     assert processor._process_list_value("['elem1', 'elem2', 'elem3']") == ["elem1", "elem2", "elem3"]
@@ -204,7 +205,6 @@ def test_process_list_value_function(processor):
     assert processor._process_list_value("[{'obj': 'val', 'obj2': 'val2'}, {}]") == [{'obj': 'val', 'obj2': 'val2'}, {}]
 
     # Test values that will not be successfully converted to list
-    assert processor._process_list_value("") == ""
     assert processor._process_list_value("[[]") == "[[]"
     assert processor._process_list_value("[elem1, elem2]") == "[elem1, elem2]"
     assert processor._process_list_value("elem1, elem2") == "elem1, elem2"
@@ -214,6 +214,7 @@ def test_process_list_value_function(processor):
 
 def test_process_dictionary_value_function(processor):
     # Test values that will be successfully converted to dictionary
+    assert processor._process_dictionary_value("") == {}
     assert processor._process_dictionary_value("{}") == {}
     assert processor._process_dictionary_value("{'key': 'value'}") == {"key": "value"}
 
@@ -248,7 +249,6 @@ def test_process_dictionary_value_function(processor):
     assert processor._process_dictionary_value(dict_as_str) == expected_value
 
     # Test values that will not be successfully converted to dictionary
-    assert processor._process_dictionary_value("") == ""
     assert processor._process_dictionary_value("{{}") == "{{}"
     assert processor._process_dictionary_value("{key1: value, key2: value}") == "{key1: value, key2: value}"
     assert processor._process_dictionary_value("  { key1: value, key2: value }  ") == "{ key1: value, key2: value }"

--- a/elyra/pipeline/tests/test_processor_kfp.py
+++ b/elyra/pipeline/tests/test_processor_kfp.py
@@ -197,7 +197,7 @@ def test_process_list_value_function(processor):
     # Test values that will be successfully converted to list
     assert processor._process_list_value("") == []
     assert processor._process_list_value("[]") == []
-    assert processor._process_list_value("None") is None
+    assert processor._process_list_value("None") == []
     assert processor._process_list_value("['elem1']") == ["elem1"]
     assert processor._process_list_value("['elem1', 'elem2', 'elem3']") == ["elem1", "elem2", "elem3"]
     assert processor._process_list_value("  ['elem1',   'elem2' , 'elem3']  ") == ["elem1", "elem2", "elem3"]
@@ -217,7 +217,7 @@ def test_process_dictionary_value_function(processor):
     # Test values that will be successfully converted to dictionary
     assert processor._process_dictionary_value("") == {}
     assert processor._process_dictionary_value("{}") == {}
-    assert processor._process_dictionary_value("None") is None
+    assert processor._process_dictionary_value("None") == {}
     assert processor._process_dictionary_value("{'key': 'value'}") == {"key": "value"}
 
     dict_as_str = "{'key1': 'value', 'key2': 'value'}"


### PR DESCRIPTION
When testing the Airflow `BashOperator`, I came across a new error while the pipeline was running. In the node properties, the `env` parameter was left empty, resulting in the below log output that indicates a dictionary value is expected. I'm almost positive that we've tested this operator before with an empty value and have not had this error result.

<details><summary>Airflow Log Output</summary>
<pre>
[2021-09-10 16:34:07,681] {taskinstance.py:1150} ERROR - 'str' object has no attribute 'update'
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/models/taskinstance.py", line 984, in _run_raw_task
    result = task_copy.execute(context=context)
  File "/home/airflow/.local/lib/python3.6/site-packages/airflow/operators/bash_operator.py", line 123, in execute
    env.update(airflow_context_vars)
AttributeError: 'str' object has no attribute 'update'
</pre>
</details>

### What changes were proposed in this pull request?
This adds a check to the `_process_list_value()` and `process_dictionary_value()` processor functions for empty strings or a  string of `"None"`. 

Because list and dictionary-typed values are considered strings for the purposes of the node properties panel, the pipeline payload contains string values for these parameters when submitting/exporting.  If the user has not entered a value for a list or dictionary-typed parameter or has explicitly entered the value of `None` in the node properties panel, the payload will include `""` or `"None"` for that parameters value, respectively. This PR converts these values to either an empty list `[]` or an empty dictionary `{}` as appropriate.

### How was this pull request tested?
The test cases that cover these two functions have been updated. This has also been tested manually by submitting pipelines.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
