### PR TITLE
Update/add fixtures to setup factory metadata instances

### DIFF
--- a/elyra/pipeline/tests/conftest.py
+++ b/elyra/pipeline/tests/conftest.py
@@ -1,0 +1,40 @@
+#
+# Copyright 2018-2021 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+import shutil
+
+import pytest
+
+
+@pytest.fixture
+def setup_factory_data(jp_environ, jp_env_jupyter_path):
+    """Copies the factory metadata instances for runtime-images and compontent-registries to test hierarchy."""
+    source = os.path.join(os.path.dirname(__file__), '../../../etc/config/metadata')
+    destination = os.path.join(jp_env_jupyter_path, 'metadata')
+    shutil.copytree(source, destination)
+    yield destination  # this return value probably won't be used, but here nonetheless
+
+
+# Set Elyra server extension as enabled (overriding server_config fixture from jupyter_server)
+@pytest.fixture
+def jp_server_config(setup_factory_data):
+    return {
+        "ServerApp": {
+            "jpserver_extensions": {
+                "elyra": True
+            }
+        }
+    }

--- a/elyra/pipeline/tests/test_handlers.py
+++ b/elyra/pipeline/tests/test_handlers.py
@@ -16,8 +16,6 @@
 
 import json
 
-import pytest
-
 from elyra.pipeline.tests import resources
 
 # from jupyter_server.tests.utils import expected_http_error
@@ -28,18 +26,6 @@ try:
 except ImportError:
     # Try backported to PY<37 `importlib_resources`.
     import importlib_resources as pkg_resources
-
-
-# Set Elyra server extension as enabled (overriding server_config fixture from jupyter_server)
-@pytest.fixture
-def jp_server_config():
-    return {
-        "ServerApp": {
-            "jpserver_extensions": {
-                "elyra": True
-            }
-        }
-    }
 
 
 async def test_get_components(jp_fetch):

--- a/elyra/pipeline/tests/test_processor_airflow.py
+++ b/elyra/pipeline/tests/test_processor_airflow.py
@@ -32,7 +32,7 @@ PIPELINE_FILE = 'resources/sample_pipelines/pipeline_dependency_complex.json'
 
 
 @pytest.fixture
-def processor():
+def processor(setup_factory_data):
     processor = AirflowPipelineProcessor(os.getcwd())
     return processor
 

--- a/elyra/pipeline/tests/test_processor_kfp.py
+++ b/elyra/pipeline/tests/test_processor_kfp.py
@@ -33,7 +33,7 @@ from elyra.pipeline.tests.test_pipeline_parser import _read_pipeline_resource
 
 
 @pytest.fixture
-def processor():
+def processor(setup_factory_data):
     processor = KfpPipelineProcessor(os.getcwd())
     return processor
 

--- a/elyra/pipeline/tests/test_validation.py
+++ b/elyra/pipeline/tests/test_validation.py
@@ -37,7 +37,7 @@ def load_pipeline():
 
 
 @pytest.fixture
-def validation_manager():
+def validation_manager(setup_factory_data):
     root = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__), "resources/validation_pipelines"))
     yield PipelineValidationManager.instance(root_dir=root)
     PipelineValidationManager.clear_instance()


### PR DESCRIPTION
### What changes were proposed in this pull request?
Our tests should run in virtual/temporary directory hierarchies so as to not side-effect dev systems.  Only the metadata and handlers tests (that rely on the `fp_fetch` fixture) do this.   With the move of component registries into the metadata service, the handler tests would always run w/o seeing any factory data.  This didn't affect the handler tests because they don't rely on anything like that.  However, the validation tests, when run after handlers, would get side-effected because the set of valid components was incorrect (and too few).  This caused discriminating tests to fail.

This change introduces some new fixtures, the primary one of which sets up the factory metadata instances for runtime-images and component-registries into these temporary hierarchies.  The applicable fixtures and tests have been updated and the validation tests now pass when following the handlers test completion.

### How was this pull request tested?
This change can only be verified via manual testing, although running the complete set of pipeline tests is also sufficient.

Closes #2129
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
