### PR TITLE
Reformat the processor registration logging

### DIFF
--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -59,11 +59,13 @@ class PipelineProcessorRegistry(SingletonConfigurable):
             try:
                 # instantiate an actual instance of the processor
                 processor_instance = processor.load()(self.root_dir, parent=kwargs.get('parent'))  # Load an instance
-                self.log.info(f'Registering processor "{processor}" with type -> {processor_instance.type}')
+                self.log.info(f'Registering {processor.name} processor '
+                              f'"{processor.module_name}.{processor.object_name}"...')
                 self.add_processor(processor_instance)
             except Exception as err:
                 # log and ignore initialization errors
-                self.log.error('Error registering processor "{}" - {}'.format(processor, err))
+                self.log.error(f'Error registering {processor.name} processor '
+                               f'"{processor.module_name}.{processor.object_name}" - {err}')
 
     def add_processor(self, processor):
         self.log.debug(f'Registering processor {processor.type}')


### PR DESCRIPTION
While looking into how to conditionally load runtime processor entrypoints, I decided to clean up the logging that is performed to make it more readable to the user.  I don't think we meant to dump the EntryPoint instance itself.  This change picks out parts from the entrypoint attributes.

Here's the logging before the change:
```
Before:
[I 2021-09-16 15:34:19.545 ElyraApp] Registering processor "EntryPoint('airflow', 'elyra.pipeline.processor_airflow', 'AirflowPipelineProcessor', Distribution('elyra', '3.2.0.dev0'))" with type -> airflow
[I 2021-09-16 15:34:19.569 ElyraApp] Registering processor "EntryPoint('kfp', 'elyra.pipeline.processor_kfp', 'KfpPipelineProcessor', Distribution('elyra', '3.2.0.dev0'))" with type -> kfp
[I 2021-09-16 15:34:19.730 ElyraApp] Registering processor "EntryPoint('local', 'elyra.pipeline.processor_local', 'LocalPipelineProcessor', Distribution('elyra', '3.2.0.dev0'))" with type -> local

with errors:
[E 2021-09-16 15:34:58.575 ElyraApp] Error registering processor "EntryPoint('airflow', 'elyra.pipeline.processor_airflow', 'AirflowPipelineProcessor', Distribution('elyra', '3.2.0.dev0'))" - cannot import name 'Client' from 'kfp' (unknown location)
[E 2021-09-16 15:34:58.576 ElyraApp] Error registering processor "EntryPoint('kfp', 'elyra.pipeline.processor_kfp', 'KfpPipelineProcessor', Distribution('elyra', '3.2.0.dev0'))" - cannot import name 'Client' from 'kfp' (unknown location)
[I 2021-09-16 15:34:58.726 ElyraApp] Registering processor "EntryPoint('local', 'elyra.pipeline.processor_local', 'LocalPipelineProcessor', Distribution('elyra', '3.2.0.dev0'))" with type -> local
```

and after the change:
```
[I 2021-09-16 15:39:33.045 ElyraApp] Registering airflow processor "elyra.pipeline.processor_airflow.AirflowPipelineProcessor"...
[I 2021-09-16 15:39:33.075 ElyraApp] Registering kfp processor "elyra.pipeline.processor_kfp.KfpPipelineProcessor"...
[I 2021-09-16 15:39:33.240 ElyraApp] Registering local processor "elyra.pipeline.processor_local.LocalPipelineProcessor"...

with errors:
[E 2021-09-16 15:40:27.684 ElyraApp] Error registering airflow processor "elyra.pipeline.processor_airflow.AirflowPipelineProcessor" - cannot import name 'Client' from 'kfp' (unknown location)
[E 2021-09-16 15:40:27.685 ElyraApp] Error registering kfp processor "elyra.pipeline.processor_kfp.KfpPipelineProcessor" - cannot import name 'Client' from 'kfp' (unknown location)
[I 2021-09-16 15:40:27.810 ElyraApp] Registering local processor "elyra.pipeline.processor_local.LocalPipelineProcessor"...
```

### How was this pull request tested?
Only manual invocations, with and without errors, were done to confirm these changes.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
