### PR TITLE
Fix caching to update immediately after component registry modifications

### DIFF
--- a/elyra/metadata/handlers.py
+++ b/elyra/metadata/handlers.py
@@ -175,7 +175,7 @@ class MetadataResourceHandler(HttpErrorMixin, APIHandler):
         self.finish()
 
     def on_finish(self):
-        if self.path_kwargs.get("namespace") == "component-registries":
+        if self.path_kwargs.get("namespace") == MetadataManager.NAMESPACE_COMPONENT_REGISTRIES:
             PipelineProcessorManager.instance().update_component_cache()
         super().on_finish()
 

--- a/elyra/metadata/handlers.py
+++ b/elyra/metadata/handlers.py
@@ -25,7 +25,6 @@ from elyra.metadata.error import SchemaNotFoundError
 from elyra.metadata.manager import MetadataManager
 from elyra.metadata.metadata import Metadata
 from elyra.metadata.schema import SchemaManager
-from elyra.pipeline.processor import PipelineProcessorManager
 from elyra.util.http import HttpErrorMixin
 
 
@@ -173,11 +172,6 @@ class MetadataResourceHandler(HttpErrorMixin, APIHandler):
 
         self.set_status(204)
         self.finish()
-
-    def on_finish(self):
-        if self.path_kwargs.get("namespace") == MetadataManager.NAMESPACE_COMPONENT_REGISTRIES:
-            PipelineProcessorManager.instance().update_component_cache()
-        super().on_finish()
 
 
 class SchemaHandler(HttpErrorMixin, APIHandler):

--- a/elyra/metadata/handlers.py
+++ b/elyra/metadata/handlers.py
@@ -25,6 +25,7 @@ from elyra.metadata.error import SchemaNotFoundError
 from elyra.metadata.manager import MetadataManager
 from elyra.metadata.metadata import Metadata
 from elyra.metadata.schema import SchemaManager
+from elyra.pipeline.processor import PipelineProcessorManager
 from elyra.util.http import HttpErrorMixin
 
 
@@ -172,6 +173,11 @@ class MetadataResourceHandler(HttpErrorMixin, APIHandler):
 
         self.set_status(204)
         self.finish()
+
+    def on_finish(self):
+        if self.path_kwargs.get("namespace") == "component-registries":
+            PipelineProcessorManager.instance().update_component_cache()
+        super().on_finish()
 
 
 class SchemaHandler(HttpErrorMixin, APIHandler):

--- a/elyra/metadata/metadata.py
+++ b/elyra/metadata/metadata.py
@@ -60,8 +60,24 @@ class Metadata(object):
         """
         pass
 
+    def post_save(self, **kwargs: Any) -> None:
+        """Called by MetadataManager following the save of the instance.
+
+        :param kwargs: additional arguments
+        Keyword Args:
+            for_update (bool): indicates if this save operation if for update (True) or create (False)
+        """
+        pass
+
     def pre_delete(self, **kwargs: Any) -> None:
         """Called by MetadataManager prior to deleting the instance.
+
+        :param kwargs: additional arguments
+        """
+        pass
+
+    def post_delete(self, **kwargs: Any) -> None:
+        """Called by MetadataManager following the deletion of the instance.
 
         :param kwargs: additional arguments
         """

--- a/elyra/metadata/schemas/component-registry.json
+++ b/elyra/metadata/schemas/component-registry.json
@@ -4,7 +4,8 @@
   "name": "component-registry",
   "display_name": "Pipeline Component",
   "namespace": "component-registries",
-  "schema_filter_class_name": "elyra.pipeline.component_registry.RegistrySchemaFilter",
+  "metadata_class_name": "elyra.pipeline.component_metadata.ComponentRegistryMetadata",
+  "schema_filter_class_name": "elyra.pipeline.component_metadata.RegistrySchemaFilter",
   "uihints": {
     "title": "Pipeline Components",
     "icon": "",

--- a/elyra/pipeline/airflow/tests/test_component_parser_airflow.py
+++ b/elyra/pipeline/airflow/tests/test_component_parser_airflow.py
@@ -47,7 +47,7 @@ def test_component_registry_can_load_components_from_registries():
 def test_modify_component_registries():
     # Get initial set of components from the current active registries
     parser = AirflowComponentParser()
-    component_registry = ComponentRegistry(parser)
+    component_registry = ComponentRegistry(parser, caching_enabled=False)
     initial_components = component_registry.get_all_components()
 
     metadata_manager = MetadataManager(namespace=MetadataManager.NAMESPACE_COMPONENT_REGISTRIES)
@@ -110,7 +110,7 @@ def test_modify_component_registries():
 def test_directory_based_component_registry():
     # Get initial set of components from the current active registries
     parser = AirflowComponentParser()
-    component_registry = ComponentRegistry(parser)
+    component_registry = ComponentRegistry(parser, caching_enabled=False)
     initial_components = component_registry.get_all_components()
 
     metadata_manager = MetadataManager(namespace=MetadataManager.NAMESPACE_COMPONENT_REGISTRIES)

--- a/elyra/pipeline/component_metadata.py
+++ b/elyra/pipeline/component_metadata.py
@@ -57,11 +57,13 @@ class ComponentRegistryMetadata(Metadata):
 
         # Get processor instance and update its cache
         processor = PipelineProcessorRegistry.instance().get_processor(processor_type=processor_type)
-        processor.component_registry.update_cache()
+        if processor.component_registry.caching_enabled:
+            processor.component_registry.update_cache()
 
     def post_delete(self, **kwargs: Any) -> None:
         processor_type = self.to_dict()['metadata']['runtime']
 
         # Get processor instance and update its cache
         processor = PipelineProcessorRegistry.instance().get_processor(processor_type=processor_type)
-        processor.component_registry.update_cache()
+        if processor.component_registry.caching_enabled:
+            processor.component_registry.update_cache()

--- a/elyra/pipeline/component_metadata.py
+++ b/elyra/pipeline/component_metadata.py
@@ -53,17 +53,23 @@ class ComponentRegistryMetadata(Metadata):
     """
 
     def post_save(self, **kwargs: Any) -> None:
-        processor_type = self.to_dict()['metadata']['runtime']
+        processor_type = self.metadata.get('runtime')
 
         # Get processor instance and update its cache
-        processor = PipelineProcessorRegistry.instance().get_processor(processor_type=processor_type)
-        if processor.component_registry.caching_enabled:
-            processor.component_registry.update_cache()
+        try:
+            processor = PipelineProcessorRegistry.instance().get_processor(processor_type=processor_type)
+            if processor.component_registry.caching_enabled:
+                processor.component_registry.update_cache()
+        except Exception:
+            pass
 
     def post_delete(self, **kwargs: Any) -> None:
-        processor_type = self.to_dict()['metadata']['runtime']
+        processor_type = self.metadata.get('runtime')
 
         # Get processor instance and update its cache
-        processor = PipelineProcessorRegistry.instance().get_processor(processor_type=processor_type)
-        if processor.component_registry.caching_enabled:
-            processor.component_registry.update_cache()
+        try:
+            processor = PipelineProcessorRegistry.instance().get_processor(processor_type=processor_type)
+            if processor.component_registry.caching_enabled:
+                processor.component_registry.update_cache()
+        except Exception:
+            pass

--- a/elyra/pipeline/component_metadata.py
+++ b/elyra/pipeline/component_metadata.py
@@ -1,0 +1,67 @@
+#
+# Copyright 2018-2021 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from typing import Any
+from typing import Dict
+
+import entrypoints
+
+from elyra.metadata.metadata import Metadata
+from elyra.metadata.schema import SchemaFilter
+from elyra.pipeline.processor import PipelineProcessorRegistry
+
+
+class RegistrySchemaFilter(SchemaFilter):
+    """
+    This class exists to ensure that the component registry schema's runtime
+    metadata appropriately reflects the available runtimes.
+    """
+
+    def post_load(self, name: str, schema_json: Dict) -> Dict:
+        """Ensure available runtimes are present and add to schema as necessary."""
+
+        filtered_schema = super().post_load(name, schema_json)
+
+        # Get processor names
+        runtime_enum = []
+        for processor_name in entrypoints.get_group_named('elyra.pipeline.processors').keys():
+            if processor_name == "local":
+                continue
+            runtime_enum.append(processor_name)
+
+        # Add runtimes to schema
+        filtered_schema['properties']['metadata']['properties']['runtime']['enum'] = runtime_enum
+        return filtered_schema
+
+
+class ComponentRegistryMetadata(Metadata):
+    """
+    This class contains methods to trigger cache updates on modification
+    and deletion of component registry metadata instances.
+    """
+
+    def post_save(self, **kwargs: Any) -> None:
+        processor_type = self.to_dict()['metadata']['runtime']
+
+        # Get processor instance and update its cache
+        processor = PipelineProcessorRegistry.instance().get_processor(processor_type=processor_type)
+        processor.component_registry.update_cache()
+
+    def post_delete(self, **kwargs: Any) -> None:
+        processor_type = self.to_dict()['metadata']['runtime']
+
+        # Get processor instance and update its cache
+        processor = PipelineProcessorRegistry.instance().get_processor(processor_type=processor_type)
+        processor.component_registry.update_cache()

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -20,7 +20,6 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-import entrypoints
 from jinja2 import Environment
 from jinja2 import PackageLoader
 from jsonschema import ValidationError
@@ -28,7 +27,6 @@ from traitlets.config import LoggingConfigurable
 
 from elyra.metadata.error import MetadataNotFoundError
 from elyra.metadata.manager import MetadataManager
-from elyra.metadata.schema import SchemaFilter
 from elyra.pipeline.component import Component
 from elyra.pipeline.component import ComponentParser
 from elyra.pipeline.component import ComponentReader
@@ -282,26 +280,3 @@ class CachedComponentRegistry(ComponentRegistry):
                 is_expired = False
 
         return is_expired
-
-
-class RegistrySchemaFilter(SchemaFilter):
-    """
-    This class exists to ensure that the component registry schema's runtime
-    metadata appropriately reflects the available runtimes.
-    """
-
-    def post_load(self, name: str, schema_json: Dict) -> Dict:
-        """Ensure available runtimes are present and add to schema as necessary."""
-
-        filtered_schema = super().post_load(name, schema_json)
-
-        # Get processor names
-        runtime_enum = []
-        for processor_name in entrypoints.get_group_named('elyra.pipeline.processors').keys():
-            if processor_name == "local":
-                continue
-            runtime_enum.append(processor_name)
-
-        # Add runtimes to schema
-        filtered_schema['properties']['metadata']['properties']['runtime']['enum'] = runtime_enum
-        return filtered_schema

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -249,14 +249,14 @@ class CachedComponentRegistry(ComponentRegistry):
         self.cache_ttl_in_seconds = cache_ttl_in_seconds
 
         # Initialize the cache
-        self._update_cache()
+        self.update_cache()
 
     def get_all_components(self) -> List[Component]:
         """
         Retrieve all components from the component registry cache
         """
         if self._is_cache_expired():
-            self._update_cache()
+            self.update_cache()
 
         return list(self._cached_components.values())
 
@@ -265,11 +265,11 @@ class CachedComponentRegistry(ComponentRegistry):
         Retrieve the component with a given component_id.
         """
         if self._is_cache_expired():
-            self._update_cache()
+            self.update_cache()
 
         return self._cached_components.get(component_id)
 
-    def _update_cache(self):
+    def update_cache(self):
         self._cached_components = super()._read_component_registries()
         self._last_updated = time.time()
 

--- a/elyra/pipeline/kfp/tests/test_component_parser_kfp.py
+++ b/elyra/pipeline/kfp/tests/test_component_parser_kfp.py
@@ -47,7 +47,7 @@ def test_component_registry_can_load_components_from_registries():
 def test_modify_component_registries():
     # Get initial set of components from the current active registries
     parser = KfpComponentParser()
-    component_registry = ComponentRegistry(parser)
+    component_registry = ComponentRegistry(parser, caching_enabled=False)
     initial_components = component_registry.get_all_components()
 
     metadata_manager = MetadataManager(namespace=MetadataManager.NAMESPACE_COMPONENT_REGISTRIES)
@@ -108,7 +108,7 @@ def test_modify_component_registries():
 def test_directory_based_component_registry():
     # Get initial set of components from the current active registries
     parser = KfpComponentParser()
-    component_registry = ComponentRegistry(parser)
+    component_registry = ComponentRegistry(parser, caching_enabled=False)
     initial_components = component_registry.get_all_components()
 
     metadata_manager = MetadataManager(namespace=MetadataManager.NAMESPACE_COMPONENT_REGISTRIES)

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -80,6 +80,10 @@ class PipelineProcessorRegistry(SingletonConfigurable):
     def is_valid_processor(self, processor_type: str) -> bool:
         return processor_type in self._processors.keys()
 
+    @property
+    def processor_instances(self):
+        return list(self._processors.values())
+
 
 class PipelineProcessorManager(SingletonConfigurable):
     _registry: PipelineProcessorRegistry
@@ -95,6 +99,11 @@ class PipelineProcessorManager(SingletonConfigurable):
 
     def is_supported_runtime(self, processor_type: str) -> bool:
         return self._registry.is_valid_processor(processor_type)
+
+    def update_component_cache(self):
+        for processor in self._registry.processor_instances:
+            if isinstance(processor.component_registry, CachedComponentRegistry):
+                processor.component_registry.update_cache()
 
     async def get_components(self, processor_type):
         processor = self._get_processor_for_runtime(processor_type)
@@ -304,6 +313,10 @@ class RuntimePipelineProcessor(PipelineProcessor):
     @property
     def component_parser(self) -> ComponentParser:
         return self._component_parser
+
+    @property
+    def component_registry(self) -> CachedComponentRegistry:
+        return self._component_registry
 
     def __init__(self, root_dir: str, component_parser: ComponentParser, **kwargs):
         super().__init__(root_dir, **kwargs)

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -80,10 +80,6 @@ class PipelineProcessorRegistry(SingletonConfigurable):
     def is_valid_processor(self, processor_type: str) -> bool:
         return processor_type in self._processors.keys()
 
-    @property
-    def processor_instances(self):
-        return list(self._processors.values())
-
 
 class PipelineProcessorManager(SingletonConfigurable):
     _registry: PipelineProcessorRegistry
@@ -99,11 +95,6 @@ class PipelineProcessorManager(SingletonConfigurable):
 
     def is_supported_runtime(self, processor_type: str) -> bool:
         return self._registry.is_valid_processor(processor_type)
-
-    def update_component_cache(self):
-        for processor in self._registry.processor_instances:
-            if isinstance(processor.component_registry, CachedComponentRegistry):
-                processor.component_registry.update_cache()
 
     async def get_components(self, processor_type):
         processor = self._get_processor_for_runtime(processor_type)

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -36,7 +36,6 @@ from urllib3.exceptions import MaxRetryError
 from elyra.metadata.manager import MetadataManager
 from elyra.pipeline.component import Component
 from elyra.pipeline.component import ComponentParser
-from elyra.pipeline.component_registry import CachedComponentRegistry
 from elyra.pipeline.component_registry import ComponentRegistry
 from elyra.pipeline.pipeline import GenericOperation
 from elyra.pipeline.pipeline import Operation
@@ -306,14 +305,14 @@ class RuntimePipelineProcessor(PipelineProcessor):
         return self._component_parser
 
     @property
-    def component_registry(self) -> Union[CachedComponentRegistry, ComponentRegistry]:
+    def component_registry(self) -> ComponentRegistry:
         return self._component_registry
 
     def __init__(self, root_dir: str, component_parser: ComponentParser, **kwargs):
         super().__init__(root_dir, **kwargs)
 
         self._component_parser = component_parser
-        self._component_registry = CachedComponentRegistry(component_parser)
+        self._component_registry = ComponentRegistry(component_parser)
 
     def _get_dependency_archive_name(self, operation):
         artifact_name = os.path.basename(operation.filename)

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -315,7 +315,7 @@ class RuntimePipelineProcessor(PipelineProcessor):
         return self._component_parser
 
     @property
-    def component_registry(self) -> CachedComponentRegistry:
+    def component_registry(self) -> Union[CachedComponentRegistry, ComponentRegistry]:
         return self._component_registry
 
     def __init__(self, root_dir: str, component_parser: ComponentParser, **kwargs):


### PR DESCRIPTION
This provides the backend support for #2152. Frontend support that closes the issue to come in a followup PR.

This is a unique issue because metadata instances are updated via API calls to the `elyra/metadata` endpoint, but component registries are currently only parsed on API calls to the `elyra/pipeline/components` endpoint (if the cache is not expired). 

### What changes were proposed in this pull request?
This PR adds `post_save` and `post_delete` methods onto the `Metadata` class. The new `ComponentRegistryMetadata` class then implements these methods to update the component registry cache using the runtime processor information present in the registry metadata instance.

`ComponentRegistryMetadata` and `RegistrySchemaFilter` are moved into their own `component_metadata.py` file to avoid a circular dependency in `import` statements (e.g. avoiding `processor.py` importing `ComponentRegistry` from `component_registry.py` and `component_registry.py` importing `PipelineProcessorRegistry` from `processor.py`). 

Additionally, the `CachedComponentRegistry` functionality has been moved into the `ComponentRegistry`, avoiding the need for both classes.

Another item for discussion is that this change in itself does not fix the issue. In order to see the updates on the UI, you have to either refresh lab or close and open a pipeline (i.e. anything that triggers a call to the `elyra/pipeline/components` endpoint) on the frontend.

### How was this pull request tested?
After making the changes, I don't know that a new test case is required for this. The changes are fairly minor, and we would have to force the test cases to run the metadata 'post_save' and ' post_delete' asynchronously which sort of defeats the purpose of this behind-the-scenes cache update. 

Additionally, the old test cases ended up needing to be updated as a result of the latest change, so we do have existing test coverage of the 'Metadata' + 'ComponentRegistry' functionality. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
