### PR TITLE
Improve CLI option handling

### DIFF
--- a/elyra/metadata/metadata_app_utils.py
+++ b/elyra/metadata/metadata_app_utils.py
@@ -50,7 +50,12 @@ class Option(object):
 
     def set_value(self, value):
         try:
-            if self.type in ['array', 'object']:
+            if self.type == 'array':
+                new_value = value
+                if value[0] != '[' and value[-1] != ']':  # attempt to coerce to list
+                    new_value = str(value.split(","))
+                self.value = ast.literal_eval(new_value)
+            elif self.type == 'object':
                 self.value = ast.literal_eval(value)
             elif self.type == 'integer':
                 self.value = int(value)
@@ -89,7 +94,7 @@ class Option(object):
         if self.one_of:
             msg = f"must be one of: {self.one_of}"
         elif self.type == 'array':
-            msg = "\"['item1', 'item2']\""
+            msg = "\"['item1', 'item2']\" or \"item1,item2\""
         elif self.type == 'object':
             msg = "\"{'key1': 'value1', 'key2': 'value2'}\""
         elif self.type == 'integer':

--- a/elyra/metadata/metadata_app_utils.py
+++ b/elyra/metadata/metadata_app_utils.py
@@ -85,11 +85,16 @@ class Option(object):
         new_value = value
         if value[0] != '[' and value[-1] != ']':  # attempt to coerce to list
             new_value = str(value.split(","))
-        elif value[0] == '[' and value[-1] == ']':
-            # we have brackets.  If not internal quotes split within the brackets.
-            # This handles the common (but invalid) "[item1,item2]" format.
-            if value[1] not in ["'", '"'] and value[-2] not in ["'", '"']:
-                new_value = str(value[1:-1].split(","))
+        # The following assumes the array items should be strings and will break
+        # non-quoted items like integers, numbers and booleans.  Its being left
+        # here in case we want to support that scenario, which would likely mean
+        # checking the entries to ensure they are expecting string values before
+        # splitting.
+        # elif value[0] == '[' and value[-1] == ']':
+        #     # we have brackets.  If not internal quotes split within the brackets.
+        #     # This handles the common (but invalid) "[item1,item2]" format.
+        #     if value[1] not in ["'", '"'] and value[-2] not in ["'", '"']:
+        #         new_value = str(value[1:-1].split(","))
         return ast.literal_eval(new_value)
 
     @staticmethod


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pull request introduces three improvements:
1. It adds formatting information, along with the failing option, to error text and no longer displays the stack trace.  Note that calls into the metadata service itself may still produce a stack trace, but functionality within the CLI tool that handles parameter values prior to submission should be cleaner.
2. For array types, it will also tolerate plain string values and properly interpret comma-separated values.  This alleviates the user from having to format an array with proper quotations, so the value "['item1','item2']" can now be expressed as "item1,item2".
3. When displaying help information for all options, it includes an indicator of whether the parameter is required, its type-appropriate formatting hint, or, if associated with an enum, the set of expected values.

Here are some example commands and their outputs:

For bad string value that is associated with an enum:
```
$ elyra-metadata install component-registries --display_name=abc --description="Load data from external data sources" --runtime=ttt --location_type=www --paths=ppp
Parameter '--runtime' requires one of the following values: ['airflow', 'kfp']

Install a metadata instance into namespace 'component-registries'.

Options
-------

--replace
	Replace existing instance
--schema_name=<string> (Required. Format: sequence of characters)
	The schema_name of the metadata instance to install (defaults to 'component-registry')
--name=<string> (Format: sequence of characters)
	The name of the metadata instance to install
--display_name=<string> (Required. Format: sequence of characters)
	Display name of this Component Registry
--description=<string> (Format: sequence of characters)
	Description of this Component Registry
--categories=<array> (Format: "['item1', 'item2']" or "item1,item2")
	Category names associated with this Component Registry (the components defined in this registry will be organized in the component palette according to these categories)
--runtime=<string> (Required. Format: must be one of: ['airflow', 'kfp'])
	The runtime associated with this Component Registry
--location_type=<string> (Required. Format: must be one of: ['URL', 'Filename', 'Directory'])
	The type of location from which this registry's component definitions will be accessed
--paths=<array> (Required. Format: "['item1', 'item2']" or "item1,item2")
	A list of absolute paths to individual component specification files or to repositories containing multiple component files (e.g., a directory in the file system)
```

For a malformed array:
```
$ elyra-metadata install component-registries --display_name=abc --description="Load data from external data sources" --runtime=kfp --location_type=Directory --paths="[jjj,eee"
Parameter '--paths' requires an array with format: "['item1', 'item2']" or "item1,item2" and "[jjj,eee" was given.  Please try again with an appropriate value.

Install a metadata instance into namespace 'component-registries'.

Options
-------

--replace
	Replace existing instance
--schema_name=<string> (Required. Format: sequence of characters)
	The schema_name of the metadata instance to install (defaults to 'component-registry')
--name=<string> (Format: sequence of characters)
	The name of the metadata instance to install
--display_name=<string> (Required. Format: sequence of characters)
	Display name of this Component Registry
--description=<string> (Format: sequence of characters)
	Description of this Component Registry
--categories=<array> (Format: "['item1', 'item2']" or "item1,item2")
	Category names associated with this Component Registry (the components defined in this registry will be organized in the component palette according to these categories)
--runtime=<string> (Required. Format: must be one of: ['airflow', 'kfp'])
	The runtime associated with this Component Registry
--location_type=<string> (Required. Format: must be one of: ['URL', 'Filename', 'Directory'])
	The type of location from which this registry's component definitions will be accessed
--paths=<array> (Required. Format: "['item1', 'item2']" or "item1,item2")
	A list of absolute paths to individual component specification files or to repositories containing multiple component files (e.g., a directory in the file system)
```



Resolves #2153 #2154
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
