### PR TITLE
Parallelize reading of component definitions in registry

### DIFF
--- a/elyra/pipeline/airflow/tests/test_component_parser_airflow.py
+++ b/elyra/pipeline/airflow/tests/test_component_parser_airflow.py
@@ -49,6 +49,7 @@ def test_modify_component_registries():
     parser = AirflowComponentParser()
     component_registry = ComponentRegistry(parser, caching_enabled=False)
     initial_components = component_registry.get_all_components()
+    initial_components = sorted(initial_components, key=lambda component: component.id)
 
     metadata_manager = MetadataManager(namespace=MetadataManager.NAMESPACE_COMPONENT_REGISTRIES)
 
@@ -94,6 +95,7 @@ def test_modify_component_registries():
     # Delete the test registry
     metadata_manager.remove("new_registry")
     post_delete_components = component_registry.get_all_components()
+    post_delete_components = sorted(post_delete_components, key=lambda component: component.id)
     assert len(post_delete_components) == len(initial_components)
 
     # Check that the list of component ids is the same as before addition of the test registry
@@ -151,7 +153,7 @@ def test_parse_airflow_component_file():
 
     # Get path to component definition file and read contents
     path = _get_resource_path('airflow_test_operator.py')
-    component_definition = reader.read_component_definition(path)
+    component_definition = reader.read_component_definition(path, {})[path]
 
     # Build entry for parsing
     entry = {
@@ -217,7 +219,7 @@ def test_parse_airflow_component_url():
 
     # Get path to component definition file and read contents
     path = 'https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/bash_operator.py'  # noqa: E501
-    component_definition = reader.read_component_definition(path)
+    component_definition = reader.read_component_definition(path, {})[path]
 
     # Build entry for parsing
     entry = {
@@ -249,7 +251,7 @@ def test_parse_airflow_component_file_no_inputs():
 
     # Get path to component definition file and read contents
     path = _get_resource_path('airflow_test_operator_no_inputs.py')
-    component_definition = reader.read_component_definition(path)
+    component_definition = reader.read_component_definition(path, {})[path]
 
     # Build entry for parsing
     entry = {
@@ -285,8 +287,8 @@ async def test_parse_components_url_invalid_location():
 
     # Get path to an invalid component definition file and read contents
     invalid_path = 'https://nourl.py'
-    component_definition = reader.read_component_definition(invalid_path)
-    assert component_definition is None
+    component_definition = reader.read_component_definition(invalid_path, {})
+    assert component_definition == {}
 
     # Build entry for parsing
     entry = {

--- a/elyra/pipeline/airflow/tests/test_component_parser_airflow.py
+++ b/elyra/pipeline/airflow/tests/test_component_parser_airflow.py
@@ -299,7 +299,7 @@ def test_parse_airflow_component_file_no_inputs():
     'https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/\
      pipeline/tests/resources/components/invalid_file.py'  # test an invalid file
 ], indirect=True)
-async def test_parse_components_url_invalid_host(invalid_url):
+async def test_parse_components_invalid_url(invalid_url):
     # Define the appropriate reader for a Url-type component definition
     airflow_supported_file_types = [".py"]
     reader = UrlComponentReader(airflow_supported_file_types)

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -22,10 +22,8 @@ from typing import Optional
 
 from jinja2 import Environment
 from jinja2 import PackageLoader
-from jsonschema import ValidationError
 from traitlets.config import LoggingConfigurable
 
-from elyra.metadata.error import MetadataNotFoundError
 from elyra.metadata.manager import MetadataManager
 from elyra.pipeline.component import Component
 from elyra.pipeline.component import ComponentParser
@@ -200,42 +198,24 @@ class ComponentRegistry(LoggingConfigurable):
         """
         component_dict: Dict[str, Component] = {}
 
-        try:
-            metadata_manager = MetadataManager(namespace=MetadataManager.NAMESPACE_COMPONENT_REGISTRIES)
-            all_registries = [r.to_dict(trim=True) for r in metadata_manager.get_all()]
-
-            # Filter registries according to processor type
-            runtime_registries = filter(lambda r: r['metadata']['runtime'] == self._parser.component_platform,
-                                        all_registries)
-        except (ValidationError, ValueError):
-            raise
-        except MetadataNotFoundError:
-            raise
-        except Exception:
-            raise
-
+        runtime_registries = self._get_registries_for_runtime()
         for registry in runtime_registries:
-            registry_name = registry['display_name']
-            self.log.debug(f"Component registry: processing components in registry '{registry_name}'")
+            self.log.debug(f"Component registry: processing components in registry '{registry['display_name']}'")
+
+            registry_categories = registry['metadata'].get("categories", [])
+            registry_location_type = registry['metadata']['location_type'].lower()
 
             # Assign reader based on the location type of the registry (file, directory, url)
-            registry_type = registry['metadata']['location_type'].lower()
-            reader = self._get_reader(registry_type, self._parser.file_types)
+            reader = self._get_reader(registry_location_type, self._parser.file_types)
 
-            # Read the path array to get the absolute paths of all components associated with this registry
-            component_paths = reader.get_absolute_locations(registry['metadata']['paths'])
-            for path in component_paths:
-                # TODO Figure out what would be the best path to display to the user
-                # TODO when accessing the node properties panel, since components can
-                # TODO now come from myriad locations
-
-                # Read in contents of the component
-                component_definition = reader.read_component_definition(path)
+            # Get content of component definition file for each component in this registry
+            component_definitions = reader.read_component_definitions(registry['metadata']['paths'])
+            for path, component_definition in component_definitions.items():
 
                 component_entry = {
                     "location_type": reader.resource_type,
                     "location": path,
-                    "categories": registry['metadata'].get("categories", []),
+                    "categories": registry_categories,
                     "component_definition": component_definition
                 }
 
@@ -245,6 +225,24 @@ class ComponentRegistry(LoggingConfigurable):
                     component_dict[component.id] = component
 
         return component_dict
+
+    def _get_registries_for_runtime(self) -> List[Dict]:
+        """
+        Retrieve the registries relevant to the calling processor instance
+        """
+        runtime_registries = []
+        try:
+            metadata_manager = MetadataManager(namespace=MetadataManager.NAMESPACE_COMPONENT_REGISTRIES)
+            all_registries = [r.to_dict(trim=True) for r in metadata_manager.get_all()]
+
+            # Filter registries according to processor type
+            runtime_registries = list(
+                filter(lambda r: r['metadata']['runtime'] == self._parser.component_platform, all_registries)
+            )
+        except Exception:
+            self.log.error(f"Could not access registries for processor: {self._parser._component_platform}")
+
+        return runtime_registries
 
     def _get_reader(self, registry_location_type: str, file_types: List[str]) -> ComponentReader:
         """

--- a/elyra/pipeline/kfp/tests/test_component_parser_kfp.py
+++ b/elyra/pipeline/kfp/tests/test_component_parser_kfp.py
@@ -306,7 +306,7 @@ def test_parse_kfp_component_file_no_inputs():
     assert properties_json['current_parameters']['component_source'] == component_entry.location
 
 
-async def test_parse_components_filesystem_invalid_location():
+async def test_parse_components_invalid_file():
     # Define the appropriate reader for a filesystem-type component definition
     kfp_supported_file_types = [".yaml"]
     reader = FilesystemComponentReader(kfp_supported_file_types)

--- a/elyra/pipeline/kfp/tests/test_component_parser_kfp.py
+++ b/elyra/pipeline/kfp/tests/test_component_parser_kfp.py
@@ -49,6 +49,7 @@ def test_modify_component_registries():
     parser = KfpComponentParser()
     component_registry = ComponentRegistry(parser, caching_enabled=False)
     initial_components = component_registry.get_all_components()
+    initial_components = sorted(initial_components, key=lambda component: component.id)
 
     metadata_manager = MetadataManager(namespace=MetadataManager.NAMESPACE_COMPONENT_REGISTRIES)
 
@@ -92,6 +93,7 @@ def test_modify_component_registries():
     # Delete the test registry
     metadata_manager.remove("new_registry")
     post_delete_components = component_registry.get_all_components()
+    post_delete_components = sorted(post_delete_components, key=lambda component: component.id)
     assert len(post_delete_components) == len(initial_components)
 
     # Check that the list of component ids is the same as before addition of the test registry
@@ -150,7 +152,7 @@ def test_parse_kfp_component_file():
 
     # Get path to component definition file and read contents
     path = _get_resource_path('kfp_test_operator.yaml')
-    component_definition = reader.read_component_definition(path)
+    component_definition = reader.read_component_definition(path, {})[path]
 
     # Build entry for parsing
     entry = {
@@ -235,7 +237,7 @@ def test_parse_kfp_component_url():
 
     # Get path to component definition file and read contents
     path = 'https://raw.githubusercontent.com/kubeflow/pipelines/1.4.1/components/notebooks/Run_notebook_using_papermill/component.yaml'  # noqa: E501
-    component_definition = reader.read_component_definition(path)
+    component_definition = reader.read_component_definition(path, {})[path]
 
     # Build entry for parsing
     entry = {
@@ -267,7 +269,7 @@ def test_parse_kfp_component_file_no_inputs():
 
     # Get path to component definition file and read contents
     path = _get_resource_path('kfp_test_operator_no_inputs.yaml')
-    component_definition = reader.read_component_definition(path)
+    component_definition = reader.read_component_definition(path, {})[path]
 
     # Build entry for parsing
     entry = {
@@ -303,8 +305,8 @@ async def test_parse_components_filesystem_invalid_location():
 
     # Get path to an invalid component definition file and read contents
     path = _get_resource_path('kfp_test_operator_invalid.yaml')
-    component_definition = reader.read_component_definition(path)
-    assert component_definition is None
+    component_definition = reader.read_component_definition(path, {})
+    assert component_definition == {}
 
     # Build entry for parsing
     entry = {

--- a/elyra/pipeline/kfp/tests/test_component_parser_kfp.py
+++ b/elyra/pipeline/kfp/tests/test_component_parser_kfp.py
@@ -49,6 +49,8 @@ def test_modify_component_registries():
     parser = KfpComponentParser()
     component_registry = ComponentRegistry(parser, caching_enabled=False)
     initial_components = component_registry.get_all_components()
+
+    # Components must be sorted by id for the equality comparison with later component lists
     initial_components = sorted(initial_components, key=lambda component: component.id)
 
     metadata_manager = MetadataManager(namespace=MetadataManager.NAMESPACE_COMPONENT_REGISTRIES)
@@ -150,8 +152,10 @@ def test_parse_kfp_component_file():
     kfp_supported_file_types = [".yaml"]
     reader = FilesystemComponentReader(kfp_supported_file_types)
 
-    # Get path to component definition file and read contents
     path = _get_resource_path('kfp_test_operator.yaml')
+
+    # Read contents of given path -- read_component_definition() returns a
+    # a dictionary of component definition content indexed by path
     component_definition = reader.read_component_definition(path, {})[path]
 
     # Build entry for parsing
@@ -235,8 +239,10 @@ def test_parse_kfp_component_url():
     kfp_supported_file_types = [".yaml"]
     reader = UrlComponentReader(kfp_supported_file_types)
 
-    # Get path to component definition file and read contents
     path = 'https://raw.githubusercontent.com/kubeflow/pipelines/1.4.1/components/notebooks/Run_notebook_using_papermill/component.yaml'  # noqa: E501
+
+    # Read contents of given path -- read_component_definition() returns a
+    # a dictionary of component definition content indexed by path
     component_definition = reader.read_component_definition(path, {})[path]
 
     # Build entry for parsing
@@ -267,8 +273,10 @@ def test_parse_kfp_component_file_no_inputs():
     kfp_supported_file_types = [".yaml"]
     reader = FilesystemComponentReader(kfp_supported_file_types)
 
-    # Get path to component definition file and read contents
     path = _get_resource_path('kfp_test_operator_no_inputs.yaml')
+
+    # Read contents of given path -- read_component_definition() returns a
+    # a dictionary of component definition content indexed by path
     component_definition = reader.read_component_definition(path, {})[path]
 
     # Build entry for parsing


### PR DESCRIPTION
Overall, this PR will speed up reading of component definition by parallelizing `read_component_definition` for each path in a registry.

### What changes were proposed in this pull request?
A function, `read_component_definitions`, is added to the `ComponentReader` base class and called from `read_component_registries()`. For each component path in a registry, this new function creates and starts a thread that will execute `read_component_definition(self, location: str, location_to_def: Dict[str, str])` for its component location.

If the read succeeds, the `location_to_def` dictionary that is passed to `read_component_definition()` is updated with a new key-value pair, where the key is the component location and the value is the component content. Due to dictionary mutability and the fact that keys (component paths) will be unique, this is the means by which the component content for each thread's read is persisted. Once all threads have executed, this dictionary is returned to `read_component_registries()`, which will loop through each key-value pair in order to construct a `Component` object exactly as before.

For the `elyra-airflow-url-preconfig` registry, which includes 5 url-based component paths, the read has been sped up by a factor of ~7-8x (from ~1.5 seconds to read and parse the given components to ~0.2 seconds) in my tests. 

Other minor changes include:

- Moved the `get_absolute_locations()` logic into the new `read_component_definitions()` function and out of the registry  logic
- Removes the return of `None` from the component readers in favor of just not adding a new key-value pair to the `location_to_def` object (end-to-end functionality is equivalent in that an 'unreadable' component will be skipped and not have a `Component` object created for it)
- Separated out the code that retrieves all the registries for a given runtime into its own function (`get_registries_for_runtime()`) in order to clean up `read_component_registries()` 

### How was this pull request tested?
Existing tests have been updated accordingly. I'll probably want to add comments or otherwise tweak those tests to clarify why variables are being accessed the way that they are.

Not sure if this warrants any new tests.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
