### PR TITLE
Remove unnecessary files from Elyra python distro

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,17 +22,18 @@ global-exclude .git
 global-exclude .ipynb_checkpoints
 global-exclude .DS_Store
 global-exclude *.sh
+global-exclude docs
+global-exclude tests
 
 # explicit includes
+include CONTRIBUTING.md
 include README.md
 include LICENSE
 include dist/*.tgz
 
-recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
-recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
 recursive-include elyra/metadata/schemas *
 recursive-include elyra/templates *
 recursive-include etc/config/components/ *.json


### PR DESCRIPTION
Documentation images and other unnecessary files were
scaping the filters and reaching out to the source
release which was making the package very large.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
