### PR TITLE
Add Daily Dev meeting info to documentation

### DIFF
--- a/docs/source/getting_started/getting-help.md
+++ b/docs/source/getting_started/getting-help.md
@@ -31,5 +31,11 @@ If you encounter a problem or have suggestions for improvements please [open an 
 
 The Elyra community meeting is held [online](https://ibm.webex.com/meet/akchin) every Thursday at [9AM Pacific](https://www.thetimezoneconverter.com/?t=9%3A00%20am&tz=San%20Francisco&) (excluding holidays).
 
+### Join the daily development meetings
+
+Join us for our daily scrum (except Thursdays) to discuss development items you're working on or have questions about. Everyone is welcome and participation is optional.
+
+The daily dev meetings are held [online](https://ibm.webex.com/meet/akchin) every Monday, Tuesday, Wednesday, and Friday at [8:30AM Pacific](https://www.thetimezoneconverter.com/?t=8%3A30%20am&tz=San%20Francisco&) (excluding holidays).
+
 ### Elyra chat room
 You can reach many Elyra contributors in the [Elyra community on gitter](https://gitter.im/elyra-ai/community).


### PR DESCRIPTION


### What changes were proposed in this pull request?
This PR updates the Elyra `readthedocs` with info about the daily dev meeting now being open to the community. This brings the documentation in line with the README changes from #2172

### How was this pull request tested?
Manual review after `make docs`.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
