### PR TITLE
Use tmpdir fixture instead of /tmp/lib in bootstrapper test

### DIFF
--- a/elyra/tests/kfp/test_bootstrapper.py
+++ b/elyra/tests/kfp/test_bootstrapper.py
@@ -555,7 +555,7 @@ def test_package_installation(monkeypatch, virtualenv):
         assert virtual_env_dict[package] == version
 
 
-def test_package_installation_with_target_path(monkeypatch, virtualenv):
+def test_package_installation_with_target_path(monkeypatch, virtualenv, tmpdir):
     # TODO : Need to add test for direct-source e.g. ' @ '
     elyra_dict = {'ipykernel': '5.3.0',
                   'ansiwrap': '0.8.4',
@@ -579,15 +579,15 @@ def test_package_installation_with_target_path(monkeypatch, virtualenv):
     monkeypatch.setattr(sys, "executable", virtualenv.python)
 
     virtualenv.run("python3 -m pip install --upgrade pip")
-    virtualenv.run("python3 -m pip install --target='/tmp/lib/' bleach==3.1.5")
-    virtualenv.run("python3 -m pip install --target='/tmp/lib/' ansiwrap==0.7.0")
-    virtualenv.run("python3 -m pip install --target='/tmp/lib/' packaging==20.9")
-    virtualenv.run("python3 -m pip install --target='/tmp/lib/' git+https://github.com/akchinSTC/"
+    virtualenv.run(f"python3 -m pip install --target={tmpdir} bleach==3.1.5")
+    virtualenv.run(f"python3 -m pip install --target={tmpdir} ansiwrap==0.7.0")
+    virtualenv.run(f"python3 -m pip install --target={tmpdir} packaging==20.9")
+    virtualenv.run(f"python3 -m pip install --target={tmpdir} git+https://github.com/akchinSTC/"
                    "text-extensions-for-pandas@3de5ce17ab0493dcdf88b51e8727f580c08d6997")
 
-    bootstrapper.OpUtil.package_install(user_volume_path='/tmp/lib/')
+    bootstrapper.OpUtil.package_install(user_volume_path=str(tmpdir))
     virtual_env_dict = {}
-    output = virtualenv.run("python3 -m pip freeze --path=/tmp/lib/", capture=True)
+    output = virtualenv.run(f"python3 -m pip freeze --path={tmpdir}", capture=True)
     print("This is the [pip freeze] output :\n" + output)
     for line in output.strip().split('\n'):
         if " @ " in line:


### PR DESCRIPTION
This pull request simply replaces the use of `/tmp/lib` with the `tmpdir` fixture that equates to an ephemeral temporary directory.  This should prevent subsequent test invocations from side-effecting others on dev systems.

### How was this pull request tested?
The bootstrapper tests were run and I ensured `/tmp/lib` was not created during the tests.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
