### PR TITLE
UI Python/R Editor integration tests

### DIFF
--- a/tests/assets/helloworld.r
+++ b/tests/assets/helloworld.r
@@ -1,1 +1,1 @@
-print("Hello Elyra")
+print('Hello Elyra')


### PR DESCRIPTION
This PR implements integration tests for the script editor aspect of the UI, as per #536. The following items are addressed with this PR:
- Editor icons visible from: launcher/other, file->new->python/r file, file browser when a `.py` or `.r` file is listed
- open a `.py` or `.r` file should open Python/R Editor with expected content
- check content of menu when right click the editor tab (options should include `Python/R File`)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
