### PR TITLE
Clean up KFP DSL export template

### DIFF
--- a/elyra/templates/kfp/kfp_template.jinja2
+++ b/elyra/templates/kfp/kfp_template.jinja2
@@ -5,6 +5,7 @@ import kfp_tekton
 {% if kf_secured %}
 import requests
 import sys
+import urllib
 {% endif %}
 {% if cos_secret %}
 from kfp.aws import use_aws_secret
@@ -108,7 +109,7 @@ def get_istio_auth_session(url: str, username: str, password: str) -> dict:
         ################
         # Get Dex Login URL (that allows us to POST credentials)
         ################
-        redirect_url_obj = urlsplit(auth_session["redirect_url"])
+        redirect_url_obj = urllib.parse.urlsplit(auth_session["redirect_url"])
 
         # we expect a "Dex Login" URL to have `/auth` in the HTTP path
         if "/auth" not in redirect_url_obj.path:
@@ -166,6 +167,7 @@ if __name__ == "__main__":
 
     print('Trying to authenticate with Kubeflow server ...')
     api_endpoint = '{{ api_endpoint }}'.rstrip('/')
+    api_username, api_password = sys.argv[1], sys.argv[2]
 
     try:
         # attempt to create a session cookies using the provided `api_username` and `api_password`


### PR DESCRIPTION
This PR adds some changes to get submission of pipelines from KFP DSL export working properly.

### What changes were proposed in this pull request?

- Adds assignment for `api_username` and `api_password` variables if authentication is required
- Adds import statement for `urllib` and amends the `urlsplit` function to `urllib.parse.urlsplit()`

### How was this pull request tested?
Tested manually to ensure pipeline submission from DSL export is working
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
