### PR TITLE
Proof of concept - load component specifications from an MLX repository

### DIFF
--- a/elyra/metadata/schemas/component-registry.json
+++ b/elyra/metadata/schemas/component-registry.json
@@ -61,7 +61,7 @@
           "title": "Location Type",
           "description": "The type of location from which this registry's component definitions will be accessed",
           "type": "string",
-          "enum": ["URL", "Filename", "Directory"],
+          "enum": ["URL", "Filename", "Directory", "MLX"],
           "uihints": {
             "field_type": "dropdown",
             "category": "Source"

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -31,6 +31,7 @@ from elyra.pipeline.component import ComponentParser
 from elyra.pipeline.component import ComponentReader
 from elyra.pipeline.component import DirectoryComponentReader
 from elyra.pipeline.component import FilesystemComponentReader
+from elyra.pipeline.component import MLXComponentReader
 from elyra.pipeline.component import UrlComponentReader
 
 
@@ -252,7 +253,8 @@ class ComponentRegistry(LoggingConfigurable):
         readers = {
             FilesystemComponentReader.location_type: FilesystemComponentReader(file_types),
             DirectoryComponentReader.location_type: DirectoryComponentReader(file_types),
-            UrlComponentReader.location_type: UrlComponentReader(file_types)
+            UrlComponentReader.location_type: UrlComponentReader(file_types),
+            MLXComponentReader.location_type: MLXComponentReader(file_types)
         }
 
         reader = readers.get(registry_location_type)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Proof of concept only that illustrates how to utilize a Machine Learning Exchange repository as a remote component registry entry:

Component registry entry for MLX:

![image](https://user-images.githubusercontent.com/13068832/137227168-addbbecb-509f-4249-9c98-bc49fd0ae497.png)


Components in palette:

![image](https://user-images.githubusercontent.com/13068832/137226967-a61168cd-05ae-4cfc-9ded-b497ffb8fdcc.png)

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
