### PR TITLE
Fix issues in pipeline migration hook

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -308,6 +308,7 @@ const PipelineWrapper: React.FC<IProps> = ({
       if (isDialogAlreadyShowing.current) {
         return; // bail, we are already showing a dialog.
       }
+      isDialogAlreadyShowing.current = true;
       if (error instanceof PipelineOutOfDateError) {
         showDialog({
           title: 'Migrate pipeline?',
@@ -332,17 +333,20 @@ const PipelineWrapper: React.FC<IProps> = ({
           if (result.button.accept) {
             // proceed with migration
             console.log('migrating pipeline');
-            const migratedPipeline = migrate(pipeline, pipeline => {
-              // function for updating to relative paths in v2
-              // uses location of filename as expected in v1
-              for (const node of pipeline.nodes) {
-                node.app_data.filename = PipelineService.getPipelineRelativeNodePath(
-                  contextRef.current.path,
-                  node.app_data.filename
-                );
+            const migratedPipeline = migrate(
+              contextRef.current.model.toJSON(),
+              pipeline => {
+                // function for updating to relative paths in v2
+                // uses location of filename as expected in v1
+                for (const node of pipeline.nodes) {
+                  node.app_data.filename = PipelineService.getPipelineRelativeNodePath(
+                    contextRef.current.path,
+                    node.app_data.filename
+                  );
+                }
+                return pipeline;
               }
-              return pipeline;
-            });
+            );
             contextRef.current.model.fromString(
               JSON.stringify(migratedPipeline, null, 2)
             );
@@ -361,7 +365,7 @@ const PipelineWrapper: React.FC<IProps> = ({
         });
       }
     },
-    [pipeline, shell.currentWidget]
+    [shell.currentWidget]
   );
 
   const onFileRequested = async (args: any): Promise<string[] | undefined> => {


### PR DESCRIPTION
Fixes two bugs with the migration: multiple dialogs opening and
sometimes setting the runtime image property of the nodes to the
display name instead of the value.

The first bug was partial fixed in #2045 but the code setting the
flag to true was lost during revision.

The second bug described in #2208 was due to a mistake I made in #1860
by using  the transient copy of the pipeline used by the GUI instead of
the persisted content when running the migration.
This caused a race condition when the API call to get the runtime
images returned and triggered the changeHandler to update to the
display names before the user clicked the migrate button in the dialog.

Fixes #2208

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
