### PR TITLE
Generalize component reading and processing for BYO catalog-types

### DIFF
--- a/docs/source/user_guide/pipeline-components.md
+++ b/docs/source/user_guide/pipeline-components.md
@@ -114,9 +114,9 @@ $ elyra-metadata list component-registries
 
 Available metadata instances for component-registries (includes invalid):
 
-Schema               Instance                          Resource                                                                                                        
-------               --------                          --------                                                                                                        
-component-registry   elyra-airflow-filename-preconfig  .../jupyter/metadata/component-registries/elyra-airflow-filename-preconfig.json   
+Schema               Instance                            Resource
+------               --------                            --------
+component-registry   elyra-airflow-filesystem-preconfig  .../jupyter/metadata/component-registries/elyra-airflow-filesystem-preconfig.json
 ```
 
 #### Adding components to the registry

--- a/elyra/contents/parser.py
+++ b/elyra/contents/parser.py
@@ -86,7 +86,7 @@ class NotebookReader(FileReader):
                 yield cell.source.split('\n')
 
 
-class ScriptParser:
+class ScriptParser(object):
     """
     Base class for parsing individual lines of code. Subclasses implement a search_expressions()
     function that returns language-specific regexes to match against code lines.

--- a/elyra/elyra_app.py
+++ b/elyra/elyra_app.py
@@ -30,7 +30,6 @@ from elyra.metadata.handlers import SchemaspaceResourceHandler
 from elyra.metadata.manager import MetadataManager
 from elyra.metadata.schema import SchemaManager
 from elyra.metadata.storage import FileMetadataCache
-from elyra.pipeline.airflow.processor_airflow import AirflowPipelineProcessor
 from elyra.pipeline.catalog_connector import ComponentCatalogConnector
 from elyra.pipeline.component_registry import ComponentRegistry
 from elyra.pipeline.handlers import PipelineComponentHandler
@@ -57,8 +56,7 @@ class ElyraApp(ExtensionAppJinjaMixin, ExtensionApp):
     extension_url = '/lab'
     load_other_extensions = True
 
-    classes = [FileMetadataCache, MetadataManager, PipelineProcessor, AirflowPipelineProcessor,
-               ComponentCatalogConnector, ComponentRegistry]
+    classes = [FileMetadataCache, MetadataManager, PipelineProcessor, ComponentCatalogConnector, ComponentRegistry]
 
     # Local path to static files directory.
     # static_paths = [

--- a/elyra/elyra_app.py
+++ b/elyra/elyra_app.py
@@ -73,7 +73,7 @@ class ElyraApp(ExtensionAppJinjaMixin, ExtensionApp):
         resource_regex = r"(?P<resource>[\w\.\-]+)"
         path_regex = r"(?P<path>[\w\.\/\-\%]+)"
         processor_regex = r"(?P<processor>[\w]+)"
-        component_regex = r"(?P<component_id>[\w\.\-]+)"
+        component_regex = r"(?P<component_id>[\w\.\-:]+)"
 
         self.handlers.extend([
             (f'/{self.name}/{YamlSpecHandler.get_resource_metadata()[0]}', YamlSpecHandler),

--- a/elyra/elyra_app.py
+++ b/elyra/elyra_app.py
@@ -31,6 +31,7 @@ from elyra.metadata.manager import MetadataManager
 from elyra.metadata.schema import SchemaManager
 from elyra.metadata.storage import FileMetadataCache
 from elyra.pipeline.airflow.processor_airflow import AirflowPipelineProcessor
+from elyra.pipeline.catalog_connector import ComponentCatalogConnector
 from elyra.pipeline.handlers import PipelineComponentHandler
 from elyra.pipeline.handlers import PipelineComponentPropertiesHandler
 from elyra.pipeline.handlers import PipelineExportHandler
@@ -55,7 +56,8 @@ class ElyraApp(ExtensionAppJinjaMixin, ExtensionApp):
     extension_url = '/lab'
     load_other_extensions = True
 
-    classes = [FileMetadataCache, MetadataManager, PipelineProcessor, AirflowPipelineProcessor]
+    classes = [FileMetadataCache, MetadataManager, PipelineProcessor, AirflowPipelineProcessor,
+               ComponentCatalogConnector]
 
     # Local path to static files directory.
     # static_paths = [

--- a/elyra/metadata/metadata.py
+++ b/elyra/metadata/metadata.py
@@ -46,8 +46,8 @@ class Metadata(object):
         self.resource = kwargs.get('resource')
         self.reason = kwargs.get('reason')
 
-    def post_load(self, **kwargs: Any) -> None:
-        """Called by MetadataManager after fetching the instance.
+    def on_load(self, **kwargs: Any) -> None:
+        """Called by MetadataManager after fetching the instance and prior to validation.
 
         :param kwargs: additional arguments
         """

--- a/elyra/metadata/schemas/component-registry.json
+++ b/elyra/metadata/schemas/component-registry.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/metadata/schemas/meta-schema.json",
+  "$id": "https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/metadata/schemas/component-registry.json",
+  "title": "Component Registry",
+  "name": "component-registry",
+  "display_name": "Pipeline Component",
+  "schemaspace": "component-registries",
+  "schemaspace_id": "ae79159a-489d-4656-83a6-1adfbc567c70",
+  "metadata_class_name": "elyra.pipeline.component_metadata.ComponentRegistryMetadata",
+  "uihints": {
+    "title": "Pipeline Components",
+    "icon": "",
+    "reference_url": "https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html"
+  },
+  "properties": {
+    "schema_name": {
+      "title": "Schema Name",
+      "description": "The schema associated with this instance",
+      "type": "string",
+      "const": "component-registry"
+    },
+    "display_name": {
+      "title": "Display Name",
+      "description": "Display name of this Component Registry",
+      "type": "string",
+      "minLength": 1
+    },
+    "metadata": {
+      "description": "Additional data specific to this metadata",
+      "type": "object",
+      "properties": {
+        "description": {
+          "title": "Description",
+          "description": "Description of this Component Registry",
+          "type": "string"
+        },
+        "categories": {
+          "title": "Category Names",
+          "description": "Category names associated with this Component Registry (the components defined in this registry will be organized in the component palette according to these categories)",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "maxLength": 18
+          },
+          "uihints": {
+            "field_type": "array",
+            "category": "Component Categories"
+          }
+        },
+        "runtime": {
+          "title": "Runtime",
+          "description": "The runtime associated with this Component Registry",
+          "type": "string",
+          "$comment": "This enum is dynamically generated to contain the available runtime values.",
+          "enum": ["{currently-configured-runtimes}"],
+          "uihints": {
+            "field_type": "dropdown",
+            "category": "Source"
+          }
+        },
+        "location_type": {
+          "title": "Location Type",
+          "description": "The type of location from which this registry's component definitions will be accessed",
+          "type": "string",
+          "enum": ["URL", "Filename", "Directory"],
+          "uihints": {
+            "field_type": "dropdown",
+            "category": "Source"
+          }
+        },
+        "paths": {
+          "title": "Paths",
+          "description": "A list of absolute paths to individual component specification files or to repositories containing multiple component files (e.g., a directory in the file system)",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uihints": {
+            "field_type": "array",
+            "category": "Source"
+          }
+        }
+      },
+      "required": ["runtime", "location_type", "paths"]
+    }
+  },
+  "required": ["schema_name", "display_name", "metadata"]
+}

--- a/elyra/metadata/schemas/component-registry.json
+++ b/elyra/metadata/schemas/component-registry.json
@@ -7,6 +7,7 @@
   "schemaspace": "component-registries",
   "schemaspace_id": "ae79159a-489d-4656-83a6-1adfbc567c70",
   "metadata_class_name": "elyra.pipeline.component_metadata.ComponentRegistryMetadata",
+  "deprecated": true,
   "uihints": {
     "title": "Pipeline Components",
     "icon": "",

--- a/elyra/metadata/schemas/local-directory-catalog.json
+++ b/elyra/metadata/schemas/local-directory-catalog.json
@@ -102,9 +102,18 @@
             "field_type": "numeric",
             "category": "Configuration"
           }
+        },
+        "required_number_field": {
+          "title": "Test Required Number",
+          "description": "Test an Number",
+          "type": "number",
+          "uihints": {
+            "field_type": "numeric",
+            "category": "Configuration"
+          }
         }
       },
-      "required": ["runtime", "paths"]
+      "required": ["runtime", "paths", "required_number_field"]
     }
   },
   "required": ["schema_name", "display_name", "version", "metadata"]

--- a/elyra/metadata/schemas/local-directory-catalog.json
+++ b/elyra/metadata/schemas/local-directory-catalog.json
@@ -84,33 +84,6 @@
             "placeholder": "false",
             "category": "Configuration"
           }
-        },
-        "int_field": {
-          "title": "Test Field Integer",
-          "description": "Test an integer",
-          "type": "integer",
-          "uihints": {
-            "field_type": "numeric",
-            "category": "Configuration"
-          }
-        },
-        "number_field": {
-          "title": "Test Field Number",
-          "description": "Test an Number",
-          "type": "number",
-          "uihints": {
-            "field_type": "numeric",
-            "category": "Configuration"
-          }
-        },
-        "required_number_field": {
-          "title": "Test Required Number",
-          "description": "Test an Number",
-          "type": "number",
-          "uihints": {
-            "field_type": "numeric",
-            "category": "Configuration"
-          }
         }
       },
       "required": ["runtime", "paths", "required_number_field"]

--- a/elyra/metadata/schemas/local-directory-catalog.json
+++ b/elyra/metadata/schemas/local-directory-catalog.json
@@ -74,6 +74,15 @@
             "field_type": "array",
             "category": "Configuration"
           }
+        },
+        "include_subdirs": {
+          "title": "Include Subdirectories",
+          "description": "Indicates whether a recursive search for component specification files should be performed on subdirectories",
+          "type": "boolean",
+          "uihints": {
+            "placeholder": "false",
+            "category": "Configuration"
+          }
         }
       },
       "required": ["runtime", "paths"]

--- a/elyra/metadata/schemas/local-directory-catalog.json
+++ b/elyra/metadata/schemas/local-directory-catalog.json
@@ -16,7 +16,7 @@
       "title": "Schema Name",
       "description": "The schema associated with this instance",
       "type": "string",
-      "const": "component-registry"
+      "const": "local-directory-catalog"
     },
     "display_name": {
       "title": "Display Name",

--- a/elyra/metadata/schemas/local-directory-catalog.json
+++ b/elyra/metadata/schemas/local-directory-catalog.json
@@ -56,16 +56,28 @@
             "category": "Component Categories"
           }
         },
-        "path": {
-          "title": "Path",
-          "description": "A path to a directory in the local file system that contains one or more component specification files",
+        "base_path": {
+          "title": "Optional Base Directory",
+          "description": "An optional base directory from which the given path can be resolved.",
           "type": "string",
           "uihints": {
             "category": "Source"
           }
+        },
+        "paths": {
+          "title": "Paths",
+          "description": "A list of paths to directories in the local file system that each contain one or more component specification files",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uihints": {
+            "field_type": "array",
+            "category": "Source"
+          }
         }
       },
-      "required": ["runtime", "path"]
+      "required": ["runtime", "paths"]
     }
   },
   "required": ["schema_name", "display_name", "metadata"]

--- a/elyra/metadata/schemas/local-directory-catalog.json
+++ b/elyra/metadata/schemas/local-directory-catalog.json
@@ -84,6 +84,24 @@
             "placeholder": "false",
             "category": "Configuration"
           }
+        },
+        "int_field": {
+          "title": "Test Field Integer",
+          "description": "Test an integer",
+          "type": "integer",
+          "uihints": {
+            "field_type": "numeric",
+            "category": "Configuration"
+          }
+        },
+        "number_field": {
+          "title": "Test Field Number",
+          "description": "Test an Number",
+          "type": "number",
+          "uihints": {
+            "field_type": "numeric",
+            "category": "Configuration"
+          }
         }
       },
       "required": ["runtime", "paths"]

--- a/elyra/metadata/schemas/local-directory-catalog.json
+++ b/elyra/metadata/schemas/local-directory-catalog.json
@@ -65,7 +65,7 @@
         },
         "paths": {
           "title": "Directories",
-          "description": "A list of paths to directories in the local file system that each contain one or more component specification files",
+          "description": "A list of paths to directories in the local filesystem that each contain one or more component specification files",
           "type": "array",
           "items": {
             "type": "string"

--- a/elyra/metadata/schemas/local-directory-catalog.json
+++ b/elyra/metadata/schemas/local-directory-catalog.json
@@ -86,7 +86,7 @@
           }
         }
       },
-      "required": ["runtime", "paths", "required_number_field"]
+      "required": ["runtime", "paths"]
     }
   },
   "required": ["schema_name", "display_name", "version", "metadata"]

--- a/elyra/metadata/schemas/local-directory-catalog.json
+++ b/elyra/metadata/schemas/local-directory-catalog.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/metadata/schemas/meta-schema.json",
-  "$id": "https://raw.githubusercontent.com/kiersten-stokes/elyra/registry-updates/elyra/metadata/schemas/local-directory-catalog.json",
+  "$id": "https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/metadata/schemas/local-directory-catalog.json",
   "title": "Directory Component Catalog",
   "name": "local-directory-catalog",
   "display_name": "Directory Component Catalog",

--- a/elyra/metadata/schemas/local-directory-catalog.json
+++ b/elyra/metadata/schemas/local-directory-catalog.json
@@ -47,7 +47,8 @@
           "$comment": "This enum is dynamically generated to contain the available runtime values.",
           "enum": ["{currently-configured-runtimes}"],
           "uihints": {
-            "field_type": "dropdown"
+            "field_type": "dropdown",
+            "category": "Runtime"
           }
         },
         "categories": {
@@ -63,14 +64,6 @@
             "category": "Component Categories"
           }
         },
-        "base_path": {
-          "title": "Optional Base Directory",
-          "description": "An optional base directory from which the given path can be resolved.",
-          "type": "string",
-          "uihints": {
-            "category": "Source"
-          }
-        },
         "paths": {
           "title": "Directories",
           "description": "A list of paths to directories in the local file system that each contain one or more component specification files",
@@ -80,7 +73,7 @@
           },
           "uihints": {
             "field_type": "array",
-            "category": "Source"
+            "category": "Configuration"
           }
         }
       },

--- a/elyra/metadata/schemas/local-directory-catalog.json
+++ b/elyra/metadata/schemas/local-directory-catalog.json
@@ -80,6 +80,7 @@
           "description": "Indicates whether a recursive search for component specification files should be performed on subdirectories",
           "type": "boolean",
           "uihints": {
+            "field_type": "boolean",
             "placeholder": "false",
             "category": "Configuration"
           }

--- a/elyra/metadata/schemas/local-directory-catalog.json
+++ b/elyra/metadata/schemas/local-directory-catalog.json
@@ -8,7 +8,6 @@
   "schemaspace_id": "ae79159a-489d-4656-83a6-1adfbc567c70",
   "metadata_class_name": "elyra.pipeline.component_metadata.DirectoryCatalogMetadata",
   "uihints": {
-    "title": "Directory Component Catalogs",
     "icon": "",
     "reference_url": "https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html"
   },

--- a/elyra/metadata/schemas/local-file-catalog.json
+++ b/elyra/metadata/schemas/local-file-catalog.json
@@ -8,7 +8,6 @@
   "schemaspace_id": "ae79159a-489d-4656-83a6-1adfbc567c70",
   "metadata_class_name": "elyra.pipeline.component_metadata.FilenameCatalogMetadata",
   "uihints": {
-    "title": "Filesystem Component Catalogs",
     "icon": "",
     "reference_url": "https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html"
   },

--- a/elyra/metadata/schemas/local-file-catalog.json
+++ b/elyra/metadata/schemas/local-file-catalog.json
@@ -65,7 +65,7 @@
         },
         "base_path": {
           "title": "Optional Base Directory",
-          "description": "An optional base directory from which the given values of Paths can be resolved.",
+          "description": "An optional base directory from which the given values of Paths can be resolved",
           "type": "string",
           "uihints": {
             "category": "Configuration"
@@ -73,7 +73,7 @@
         },
         "paths": {
           "title": "Paths",
-          "description": "A list of paths to individual component specification files in the local file system",
+          "description": "A list of paths to individual component specification files in the local filesystem",
           "type": "array",
           "items": {
             "type": "string"

--- a/elyra/metadata/schemas/local-file-catalog.json
+++ b/elyra/metadata/schemas/local-file-catalog.json
@@ -56,9 +56,17 @@
             "category": "Component Categories"
           }
         },
+        "base_path": {
+          "title": "Optional Base Directory",
+          "description": "An optional base directory from which the given values of Paths can be resolved.",
+          "type": "string",
+          "uihints": {
+            "category": "Source"
+          }
+        },
         "paths": {
           "title": "Paths",
-          "description": "A list of absolute paths to individual component specification files in the local file system",
+          "description": "A list of paths to individual component specification files in the local file system",
           "type": "array",
           "items": {
             "type": "string"

--- a/elyra/metadata/schemas/local-file-catalog.json
+++ b/elyra/metadata/schemas/local-file-catalog.json
@@ -6,6 +6,7 @@
   "display_name": "Filesystem Component Catalog",
   "schemaspace": "component-registries",
   "schemaspace_id": "ae79159a-489d-4656-83a6-1adfbc567c70",
+  "metadata_class_name": "elyra.pipeline.component_metadata.FilenameCatalogMetadata",
   "uihints": {
     "title": "Filesystem Component Catalogs",
     "icon": "",
@@ -46,7 +47,8 @@
           "$comment": "This enum is dynamically generated to contain the available runtime values.",
           "enum": ["{currently-configured-runtimes}"],
           "uihints": {
-            "field_type": "dropdown"
+            "field_type": "dropdown",
+            "category": "Runtime"
           }
         },
         "categories": {
@@ -67,7 +69,7 @@
           "description": "An optional base directory from which the given values of Paths can be resolved.",
           "type": "string",
           "uihints": {
-            "category": "Source"
+            "category": "Configuration"
           }
         },
         "paths": {
@@ -79,7 +81,7 @@
           },
           "uihints": {
             "field_type": "array",
-            "category": "Source"
+            "category": "Configuration"
           }
         }
       },

--- a/elyra/metadata/schemas/local-file-catalog.json
+++ b/elyra/metadata/schemas/local-file-catalog.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/metadata/schemas/meta-schema.json",
-  "$id": "https://raw.githubusercontent.com/kiersten-stokes/elyra/registry-updates/elyra/metadata/schemas/local-file-catalog.json",
+  "$id": "https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/metadata/schemas/local-file-catalog.json",
   "title": "Filesystem Component Catalog",
   "name": "local-file-catalog",
   "display_name": "Filesystem Component Catalog",

--- a/elyra/metadata/schemas/local-file-catalog.json
+++ b/elyra/metadata/schemas/local-file-catalog.json
@@ -16,7 +16,7 @@
       "title": "Schema Name",
       "description": "The schema associated with this instance",
       "type": "string",
-      "const": "component-registry"
+      "const": "local-file-catalog"
     },
     "display_name": {
       "title": "Display Name",

--- a/elyra/metadata/schemas/meta-schema.json
+++ b/elyra/metadata/schemas/meta-schema.json
@@ -24,6 +24,11 @@
       "description": "Class used by metadata service to alter instances on load, save, and deletion.",
       "type": "string"
     },
+    "deprecated": {
+      "title": "Deprecated",
+      "description": "Indicates this schema is deprecated.  When deprecated, the schema can only be retrieved by name.",
+      "type": "boolean"
+    },
     "properties": {
       "type": "object",
       "required": ["schema_name", "display_name", "metadata"],

--- a/elyra/metadata/schemas/url-catalog.json
+++ b/elyra/metadata/schemas/url-catalog.json
@@ -16,7 +16,7 @@
       "title": "Schema Name",
       "description": "The schema associated with this instance",
       "type": "string",
-      "const": "component-registry"
+      "const": "url-catalog"
     },
     "display_name": {
       "title": "Display Name",

--- a/elyra/metadata/schemas/url-catalog.json
+++ b/elyra/metadata/schemas/url-catalog.json
@@ -8,7 +8,6 @@
   "schemaspace_id": "ae79159a-489d-4656-83a6-1adfbc567c70",
   "metadata_class_name": "elyra.pipeline.component_metadata.UrlCatalogMetadata",
   "uihints": {
-    "title": "Url Component Catalogs",
     "icon": "",
     "reference_url": "https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html"
   },

--- a/elyra/metadata/schemas/url-catalog.json
+++ b/elyra/metadata/schemas/url-catalog.json
@@ -56,7 +56,7 @@
             "category": "Component Categories"
           }
         },
-        "urls": {
+        "paths": {
           "title": "URLs",
           "description": "A list of URLs to individual component specification files",
           "type": "array",
@@ -70,7 +70,7 @@
           }
         }
       },
-      "required": ["runtime", "urls"]
+      "required": ["runtime", "paths"]
     }
   },
   "required": ["schema_name", "display_name", "metadata"]

--- a/elyra/metadata/schemas/url-catalog.json
+++ b/elyra/metadata/schemas/url-catalog.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/metadata/schemas/meta-schema.json",
   "$id": "https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/metadata/schemas/url-catalog.json",
-  "title": "Url Component Catalog",
+  "title": "URL Component Catalog",
   "name": "url-catalog",
-  "display_name": "Url Component Catalog",
+  "display_name": "URL Component Catalog",
   "schemaspace": "component-registries",
   "schemaspace_id": "ae79159a-489d-4656-83a6-1adfbc567c70",
   "metadata_class_name": "elyra.pipeline.component_metadata.UrlCatalogMetadata",

--- a/elyra/metadata/schemas/url-catalog.json
+++ b/elyra/metadata/schemas/url-catalog.json
@@ -6,6 +6,7 @@
   "display_name": "Url Component Catalog",
   "schemaspace": "component-registries",
   "schemaspace_id": "ae79159a-489d-4656-83a6-1adfbc567c70",
+  "metadata_class_name": "elyra.pipeline.component_metadata.UrlCatalogMetadata",
   "uihints": {
     "title": "Url Component Catalogs",
     "icon": "",
@@ -46,7 +47,8 @@
           "$comment": "This enum is dynamically generated to contain the available runtime values.",
           "enum": ["{currently-configured-runtimes}"],
           "uihints": {
-            "field_type": "dropdown"
+            "field_type": "dropdown",
+            "category": "Runtime"
           }
         },
         "categories": {
@@ -72,7 +74,7 @@
           },
           "uihints": {
             "field_type": "array",
-            "category": "Source"
+            "category": "Configuration"
           }
         }
       },

--- a/elyra/metadata/schemas/url-catalog.json
+++ b/elyra/metadata/schemas/url-catalog.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/metadata/schemas/meta-schema.json",
-  "$id": "https://raw.githubusercontent.com/kiersten-stokes/elyra/registry-updates/elyra/metadata/schemas/url-catalog.json",
+  "$id": "https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/metadata/schemas/url-catalog.json",
   "title": "Url Component Catalog",
   "name": "url-catalog",
   "display_name": "Url Component Catalog",

--- a/elyra/metadata/schemaspaces.py
+++ b/elyra/metadata/schemaspaces.py
@@ -13,8 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import entrypoints
 from typing import Dict
+
+import entrypoints
 
 from elyra.metadata.schema import Schemaspace
 

--- a/elyra/metadata/schemaspaces.py
+++ b/elyra/metadata/schemaspaces.py
@@ -93,6 +93,6 @@ class ComponentRegistries(Schemaspace):
         # If none is provided, use the ComponentCatalogMetadata class, which implements
         # post_save and post_delete hooks for improved component caching performance
         if not schema.get('metadata_class_name'):
-            schema['metadata_class_name'] = "elyra.pipeline.component_metadata.UrlCatalogMetadata"
+            schema['metadata_class_name'] = "elyra.pipeline.component_metadata.ComponentCatalogMetadata"
 
         return schema

--- a/elyra/metadata/schemaspaces.py
+++ b/elyra/metadata/schemaspaces.py
@@ -88,4 +88,11 @@ class ComponentRegistries(Schemaspace):
 
         if runtime.get('enum') == ["{currently-configured-runtimes}"]:
             runtime['enum'] = list(self._runtime_processor_names)
+
+        # Component catalogs should have an associated 'metadata' class name
+        # If none is provided, use the ComponentCatalogMetadata class, which implements
+        # post_save and post_delete hooks for improved component caching performance
+        if not schema.get('metadata_class_name'):
+            schema['metadata_class_name'] = "elyra.pipeline.component_metadata.UrlCatalogMetadata"
+
         return schema

--- a/elyra/metadata/schemasproviders.py
+++ b/elyra/metadata/schemasproviders.py
@@ -101,8 +101,7 @@ class CodeSnippetsSchemas(ElyraSchemasProvider):
 class ComponentRegistriesSchemas(ElyraSchemasProvider):
     """Returns schemas relative to Component Registries schemaspace."""
     def get_schemas(self) -> List[Dict]:
-        schema_names = [catalog_type + '-catalog'
-                        for catalog_type in entrypoints.get_group_named('elyra.component.catalog_types')]
+        schema_names = [catalog_type for catalog_type in entrypoints.get_group_named('elyra.component.catalog_types')]
         schemas = self.get_schemas_by_name(schema_names)
 
         # Update runtime enum with set of currently registered runtimes

--- a/elyra/metadata/schemasproviders.py
+++ b/elyra/metadata/schemasproviders.py
@@ -101,11 +101,6 @@ class CodeSnippetsSchemas(ElyraSchemasProvider):
 class ComponentRegistriesSchemas(ElyraSchemasProvider):
     """Returns schemas relative to Component Registries schemaspace."""
     def get_schemas(self) -> List[Dict]:
-        schema_names = [catalog_type for catalog_type in entrypoints.get_group_named('elyra.component.catalog_types')]
-        schemas = self.get_schemas_by_name(schema_names)
-
-        # Update runtime enum with set of currently registered runtimes
-        for schema in schemas:
-            schema['properties']['metadata']['properties']['runtime']['enum'] = list(self._runtime_processor_names)
-
+        schemas = self.get_schemas_by_name(['component-registry', 'local-file-catalog',
+                                            'local-directory-catalog', 'url-catalog'])
         return schemas

--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -29,12 +29,6 @@ class AirflowComponentParser(ComponentParser):
     _component_platform = "airflow"
     _file_types = [".py"]
 
-    def get_catalog_entry_id_for_component(self, component_id: str) -> str:
-        # Component ids are structure differently in Airflow to handle the case
-        # where there are multiple classes in one operator file. The id queried
-        # must be adjusted to match the id expected in the component_entry catalog.
-        return component_id.split('_')[0]
-
     def parse(self, registry_entry: SimpleNamespace) -> Optional[List[Component]]:
         components: List[Component] = list()
 
@@ -46,7 +40,6 @@ class AirflowComponentParser(ComponentParser):
         component_classes = self._get_all_classes(component_definition)
         for component_class in component_classes.keys():
             # Create a Component object for each class
-            # component_id = self.get_component_id(registry_entry.location, component_class)
             component_properties = self._parse_properties(component_definition, component_class)
             components.append(Component(id=registry_entry.component_id,
                                         name=component_class,

--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -38,26 +38,34 @@ class AirflowComponentParser(ComponentParser):
 
         # Parse the component definition for all defined classes
         component_classes = self._get_all_classes(component_definition)
-        for component_class in component_classes.keys():
+
+        for component_class, component_content in component_classes.items():
             # Create a Component object for each class
-            component_properties = self._parse_properties(component_definition, component_class)
-            components.append(Component(id=registry_entry.component_id,
-                                        name=component_class,
-                                        description='',
-                                        runtime=self.component_platform,
-                                        catalog_type=registry_entry.catalog_type,
-                                        location=registry_entry.component_metadata.get('location'),
-                                        properties=component_properties,
-                                        categories=registry_entry.categories,
-                                        metadata=registry_entry.component_metadata))
+            component_properties = self._parse_properties(component_content)
+
+            components.append(
+                Component(
+                    id=registry_entry.component_id,
+                    name=component_class,
+                    description='',
+                    catalog_type=registry_entry.catalog_type,
+                    location=registry_entry.component_identifier.get('location'),
+                    definition=self.get_class_def_as_string(component_content),
+                    runtime=self.component_platform,
+                    categories=registry_entry.categories,
+                    properties=component_properties
+                )
+            )
 
         return components
 
     def _get_all_classes(self, component_definition: str) -> Dict[str, Dict]:
-        # Organize lines according to the class to which they belong
-        classes = {}
+        # Organize lines and arguments according to the class to which they belong
+        class_to_content = {
+            "no_class": {"lines": [], "args": []}
+        }
+
         class_name = "no_class"
-        classes["no_class"] = {"content": [], "args": []}
         class_regex = re.compile(r"class ([\w]+)\(\w*\):")
         for line in component_definition.split('\n'):
             # Remove any inline comments (must follow the '2 preceding spaces and one following space'
@@ -66,43 +74,30 @@ class AirflowComponentParser(ComponentParser):
             match = class_regex.search(line)
             if match:
                 class_name = match.group(1)
-                classes[class_name] = {"content": [], "args": []}
-            classes[class_name]['content'].append(line)
+                class_to_content[class_name] = {"lines": [], "args": []}
+            class_to_content[class_name]['lines'].append(line)
 
-        classes.pop("no_class")
-        return classes
+        class_to_content.pop("no_class")
 
-    def _get_class_with_classname(self, classname: str, component_definition: str) -> Dict[str, List]:
-        classes = self._get_all_classes(component_definition)
-
-        if classname not in classes.keys():
-            raise ValueError(f"Component with class name {classname} not found")
-
-        # Loop through classes to find init function for each class; grab init parameters as properties
         init_regex = re.compile(r"def __init__\(([\s\d\w,=\-\'\"\*\s\#.\\\/:?]*)\):")
-        for class_name in classes:
-            if class_name != classname:
-                continue
-
+        for class_name, content in class_to_content.items():
             # Concatenate class body and search for __init__ function
-            class_content = ''.join(classes[class_name]['content'])
+            class_content = self.get_class_def_as_string(content)
             for match in init_regex.finditer(class_content):
                 # Get list of parameter:default-value pairs
-                classes[class_name]['args'] = [x.strip() for x in match.group(1).split(',')]
+                class_to_content[class_name]['args'] = [x.strip() for x in match.group(1).split(',')]
 
-        return classes[classname]
+        return class_to_content
 
-    def _parse_properties(self, component_definition: str, component_class: str) -> List[ComponentParameter]:
+    def _parse_properties(self, content: Dict[str, List]) -> List[ComponentParameter]:
         properties: List[ComponentParameter] = list()
 
         # NOTE: Currently no runtime-specific properties are needed, including runtime image. See
         # justification here: https://github.com/elyra-ai/elyra/issues/1912#issuecomment-879424452
         # properties.extend(self.get_runtime_specific_properties())
 
-        # Retrieve the content of the specified class only
-        component_definition = self._get_class_with_classname(component_class, component_definition)
-        class_content = ''.join(component_definition.get('content'))
-        for arg in component_definition.get('args'):
+        class_definition = self.get_class_def_as_string(content)
+        for arg in content.get('args'):
             # For each argument to the init function, build a new parameter and add to existing
             if arg in ['self', '*args', '**kwargs']:
                 continue
@@ -114,17 +109,15 @@ class AirflowComponentParser(ComponentParser):
                 if value and "\n" in str(value):
                     value = value.replace("\n", " ")
 
-            # Search for :type [param] information in class docstring
+            # Search for data type (':type [param]:') in class docstring
             type_regex = re.compile(f":type {arg}:" + r"([\s\S]*?(?=:type|:param|\"\"\"|'''|\.\.))")
-            match = type_regex.search(class_content)
+            match = type_regex.search(class_definition)
             data_type = match.group(1).strip() if match else "string"
 
-            # Search for :param [param] in class doctring to get description
-            description = ""
+            # Search for description (':param [param]:') in class docstring
             param_regex = re.compile(f":param {arg}:" + r"([\s\S]*?(?=:type|:param|\"\"\"|'''|\.\.))")
-            match = param_regex.search(class_content)
-            if match:
-                description = match.group(1).strip().replace("\"", "'")
+            match = param_regex.search(class_definition)
+            description = match.group(1).strip().replace("\"", "'") if match else ""
 
             # Amend description to include type information
             description = self._format_description(description=description, data_type=data_type)
@@ -134,13 +127,24 @@ class AirflowComponentParser(ComponentParser):
                 self.log.warning(f"Data type from parsed data ('{data_type}') could not be determined. "
                                  f"Proceeding as if 'string' was detected.")
 
-            properties.append(ComponentParameter(id=arg,
-                                                 name=arg,
-                                                 data_type=data_type_info.data_type,
-                                                 value=(value or data_type_info.default_value),
-                                                 description=description,
-                                                 control_id=data_type_info.control_id))
+            properties.append(
+                ComponentParameter(
+                    id=arg,
+                    name=arg,
+                    data_type=data_type_info.data_type,
+                    value=(value or data_type_info.default_value),
+                    description=description,
+                    control_id=data_type_info.control_id
+                )
+            )
+
         return properties
+
+    def get_class_def_as_string(self, content: Dict[str, List[str]]) -> str:
+        """
+        TODO
+        """
+        return ''.join(content['lines'])
 
     def get_runtime_specific_properties(self) -> List[ComponentParameter]:
         """

--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -56,8 +56,7 @@ class AirflowComponentParser(ComponentParser):
                                         location=registry_entry.component_metadata.get('location'),
                                         properties=component_properties,
                                         categories=registry_entry.categories,
-                                        metadata=registry_entry.component_metadata,
-                                        reader=registry_entry.reader))
+                                        metadata=registry_entry.component_metadata))
 
         return components
 

--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -142,7 +142,8 @@ class AirflowComponentParser(ComponentParser):
 
     def get_class_def_as_string(self, content: Dict[str, List[str]]) -> str:
         """
-        TODO
+        Take the list of lines that make up a component definition and join
+        them to make one continuous string.
         """
         return ''.join(content['lines'])
 

--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -49,7 +49,7 @@ class AirflowComponentParser(ComponentParser):
                     name=component_class,
                     description='',
                     catalog_type=registry_entry.catalog_type,
-                    location=registry_entry.component_identifier.get('location'),
+                    location=registry_entry.component_identifier,
                     definition=self.get_class_def_as_string(component_content),
                     runtime=self.component_platform,
                     categories=registry_entry.categories,

--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -46,16 +46,18 @@ class AirflowComponentParser(ComponentParser):
         component_classes = self._get_all_classes(component_definition)
         for component_class in component_classes.keys():
             # Create a Component object for each class
-            component_id = self.get_component_id(registry_entry.location, component_class)
+            # component_id = self.get_component_id(registry_entry.location, component_class)
             component_properties = self._parse_properties(component_definition, component_class)
-            components.append(Component(id=component_id,
+            components.append(Component(id=registry_entry.component_id,
                                         name=component_class,
                                         description='',
                                         runtime=self.component_platform,
                                         location_type=registry_entry.location_type,
-                                        location=registry_entry.location,
+                                        location=registry_entry.component_metadata.get('location'),
                                         properties=component_properties,
-                                        categories=registry_entry.categories))
+                                        categories=registry_entry.categories,
+                                        metadata=registry_entry.component_metadata,
+                                        reader=registry_entry.reader))
 
         return components
 

--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -45,7 +45,7 @@ class AirflowComponentParser(ComponentParser):
                                         name=component_class,
                                         description='',
                                         runtime=self.component_platform,
-                                        location_type=registry_entry.location_type,
+                                        catalog_type=registry_entry.catalog_type,
                                         location=registry_entry.component_metadata.get('location'),
                                         properties=component_properties,
                                         categories=registry_entry.categories,

--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -49,7 +49,7 @@ class AirflowComponentParser(ComponentParser):
                     name=component_class,
                     description='',
                     catalog_type=registry_entry.catalog_type,
-                    location=registry_entry.component_identifier,
+                    source_identifier=registry_entry.component_identifier,
                     definition=self.get_class_def_as_string(component_content),
                     runtime=self.component_platform,
                     categories=registry_entry.categories,

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -273,15 +273,17 @@ class AirflowPipelineProcessor(RuntimePipelineProcessor):
                 operation.component_params_as_dict.pop("outputs")
 
                 # Get component class from operation name
-                component_class = operation.classifier.split('_')[-1]
+                # component_class = operation.classifier.split('_')[-1]
 
                 unique_operation_name = self._get_unique_operation_name(operation_name=operation.name,
                                                                         operation_list=target_ops)
 
+                # TODO Figure out how to get the module name for non-standard component catalog types
+                location = component.location
                 target_op = {'notebook': unique_operation_name,
                              'id': operation.id,
-                             'module_name': component.location.rsplit('/', 1)[-1].split('.')[0],
-                             'class_name': component_class,
+                             'module_name': location.rsplit('/', 1)[-1].split('.')[0],
+                             'class_name': component.name,
                              'parent_operation_ids': operation.parent_operation_ids,
                              'component_params': operation.component_params_as_dict,
                              'operator_source': component.location,

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -272,13 +272,10 @@ class AirflowPipelineProcessor(RuntimePipelineProcessor):
                 operation.component_params_as_dict.pop("inputs")
                 operation.component_params_as_dict.pop("outputs")
 
-                # Get component class from operation name
-                # component_class = operation.classifier.split('_')[-1]
-
                 unique_operation_name = self._get_unique_operation_name(operation_name=operation.name,
                                                                         operation_list=target_ops)
 
-                # TODO Figure out how to get the module name for non-standard component catalog types
+                # TODO Will need to figure out how to get the module name for non-standard component catalog types
                 location = component.location
                 target_op = {'notebook': unique_operation_name,
                              'id': operation.id,
@@ -289,6 +286,7 @@ class AirflowPipelineProcessor(RuntimePipelineProcessor):
                              'operator_source': component.location,
                              'is_generic_operator': False
                              }
+                #
                 if operation.classifier in ['spark-submit-operator', 'spark-jdbc-operator',
                                             'spark-sql-operator', 'ssh-operator']:
                     target_op['is_contrib_operator'] = True

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -277,8 +277,8 @@ class AirflowPipelineProcessor(RuntimePipelineProcessor):
                                                                         operation_list=target_ops)
 
                 # Get the reader class associated with this component and construct the appropriate import statements
-                catalog_reader = entrypoints.get_single('elyra.component.catalog_types', component.location_type)
-                reader = catalog_reader.load()(component.location_type, self.component_parser.file_types)
+                catalog_reader = entrypoints.get_single('elyra.component.catalog_types', component.catalog_type)
+                reader = catalog_reader.load()(component.catalog_type, self.component_parser.file_types)
 
                 modules = reader.get_component_import_statement(component)
 

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -327,7 +327,7 @@ be fully qualified (i.e., prefixed with their package names).
                              'class_name': component.name,
                              'parent_operation_ids': operation.parent_operation_ids,
                              'component_params': operation.component_params_as_dict,
-                             'operator_source': component.location,
+                             'operator_source': component.source_identifier,
                              'is_generic_operator': False
                              }
 

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -29,8 +29,6 @@ from typing import Optional
 from jupyter_core.paths import ENV_JUPYTER_PATH
 import requests
 from traitlets.config import LoggingConfigurable
-from traitlets.traitlets import CUnicode
-from traitlets.traitlets import Dict as DictTrait
 from traitlets.traitlets import Integer
 
 from elyra.metadata.metadata import Metadata
@@ -41,23 +39,9 @@ class ComponentCatalogConnector(LoggingConfigurable):
     Abstract class to model component_entry readers that can read components from different locations
     """
 
-    # Data structure to encapsulate various capabilities & flags for a connector class
-    configuration = DictTrait(
-        default_value={
-            "max_readers": 3  # Sets the number of reader threads in read_component_definitions()
-        },
-        per_key_traits={
-            "max_readers": Integer()
-        },
-        key_trait=CUnicode(),
-        help="""A dictionary of configurable settings for a ComponentCatalogConnector class.
-        Subclasses can override these settings as needed.
-
-        Settings:
-            'max_readers': Integer; sets the maximum number of reader threads to be used to read
-                           catalog entries in parallel in read_component_definitions(); default 3
-        """
-    ).tag(config=True)
+    max_readers = Integer(3, config=True, allow_none=True,
+                          help="""Sets the maximum number of reader threads to be used to read
+                          catalog entries in parallel""")
 
     def __init__(self, file_types: List[str], **kwargs):
         super().__init__(**kwargs)
@@ -306,7 +290,7 @@ class ComponentCatalogConnector(LoggingConfigurable):
 
         # Start 'max_reader' reader threads if catalog includes more than 'max_reader'
         # number of catalog entries, else start one thread per entry
-        num_threads = min(catalog_entry_q.qsize(), self.configuration['max_readers'])
+        num_threads = min(catalog_entry_q.qsize(), self.max_readers)
         for i in range(num_threads):
             Thread(target=read_with_thread).start()
 

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -131,7 +131,7 @@ class ComponentCatalogConnector(LoggingConfigurable):
         will be used to construct a unique hash id for each entry with the given catalog type.
 
         To ensure the hash is unique, no two catalog entries can have the same key-value pairs
-        over set of the keys returned by this function.
+        over the set of keys returned by this function.
 
         Example:
         Given a set of keys ['key1', 'key2', 'key3'], the below two catalog_entry_data dictionaries

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -67,8 +67,9 @@ class ComponentCatalogConnector(LoggingConfigurable):
     def get_catalog_entries(self, catalog_metadata: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
         Returns a list of catalog_entry_data dictionary instances, one per entry in the given catalog.
-        The form that each catalog_entry_data takes is determined by the unique requirements of the
-        reader class.
+        Each catalog_entry_data dictionary contains the information needed to access a single component
+        definition. The form that each catalog_entry_data takes is determined by the unique requirements
+        of the reader class. No two catalog entries can have equivalent catalog_entry_data dictionaries.
 
         The catalog_metadata dictionary will take the following form:
 
@@ -95,8 +96,8 @@ class ComponentCatalogConnector(LoggingConfigurable):
                            catalog_entry_data: Dict[str, Any],
                            catalog_metadata: Dict[str, Any]) -> Optional[str]:
         """
-        Read a component definition for a single catalog entry using the its data (as returned from
-        get_catalog_entries()) and the catalog metadata, if needed
+        Reads a component definition for a single catalog entry using the catalog_entry_data returned
+        from get_catalog_entries() and, if needed, the catalog metadata.
 
         :param catalog_entry_data: a dictionary that contains the information needed to read the content
                                    of the component definition
@@ -113,8 +114,23 @@ class ComponentCatalogConnector(LoggingConfigurable):
     @abstractmethod
     def get_hash_keys(self) -> List[Any]:
         """
-        Provides a list of keys available in the 'catalog_entry_data' dictionary whose values
-        will be used to construct a unique hash id for each entry with the given catalog type
+        Provides a list of keys, available in the 'catalog_entry_data' dictionary, whose values
+        will be used to construct a unique hash id for each entry with the given catalog type.
+
+        To ensure the hash is unique, no two catalog entries can have the same key-value pairs
+        over set of the keys returned by this function.
+
+        Example:
+        Given a set of keys ['key1', 'key2', 'key3'] returned here, the below two catalog_entry_data
+        dictionaries will produce unique hashes. The same can not be said, however, if the set of
+        keys returned is ['key2', 'key3'].
+
+        component_entry_data for entry1:        component_entry_data for entry2:
+        {                                       {
+            'key1': 'value1',                       'key1': 'value4',
+            'key2': 'value2',                       'key2': 'value2',
+            'key3': 'value3'                        'key3': 'value3'
+        }                                       {
 
         :returns: a list of keys
         """
@@ -292,10 +308,8 @@ class FilesystemComponentCatalogConnector(ComponentCatalogConnector):
     def get_catalog_entries(self, catalog_metadata: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
         Returns a list of catalog_entry_data dictionary instances, one per entry in the given catalog.
-        The form that each catalog_entry_data takes is determined by the unique requirements of the
-        reader class.
 
-        :returns: a list of component_entry_data, for the FilesystemComponentCatalogConnector class this
+        :returns: a list of component_entry_data; for the FilesystemComponentCatalogConnector class this
                   takes the form { 'path': 'abspath_to_component_definition_in_local_fs' }
         """
         catalog_entry_data = []
@@ -347,11 +361,9 @@ class DirectoryComponentCatalogConnector(FilesystemComponentCatalogConnector):
     def get_catalog_entries(self, catalog_metadata: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
         Returns a list of catalog_entry_data dictionary instances, one per entry in the given catalog.
-        The form that each catalog_entry_data takes is determined by the unique requirements of the
-        reader class.
 
-        :returns: a list of component_entry_data, for the DirectoryComponentCatalogConnector class this takes
-                  the form { 'path': 'abspath_to_component_definition_in_local_fs' }
+        :returns: a list of component_entry_data; for the DirectoryComponentCatalogConnector class this
+                  takes the form { 'path': 'abspath_to_component_definition_in_local_fs' }
         """
         catalog_entry_data = []
         for path in catalog_metadata.get('paths'):
@@ -378,10 +390,8 @@ class UrlComponentCatalogConnector(ComponentCatalogConnector):
     def get_catalog_entries(self, catalog_metadata: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
         Returns a list of catalog_entry_data dictionary instances, one per entry in the given catalog.
-        The form that each catalog_entry_data takes is determined by the unique requirements of the
-        reader class.
 
-        :returns: a list of component_entry_data, for the UrlComponentCatalogConnector class this takes
+        :returns: a list of component_entry_data; for the UrlComponentCatalogConnector class this takes
                   the form { 'url': 'url_of_remote_component_definition' }
         """
         return [{'url': url} for url in catalog_metadata.get('paths')]

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -227,14 +227,12 @@ class ComponentCatalogConnector(LoggingConfigurable):
                 catalog_entry_q.put_nowait(entry_data)
 
         except NotImplementedError as e:
-            err_msg = f"{self.__class__.__name__} does not meet the requirements of a catalog connector class: {e}."
+            err_msg = f"{self.__class__.__name__} does not meet the requirements of a catalog connector class: {e}"
             self.log.warning(err_msg)
-            raise NotImplementedError(err_msg)
         except Exception as e:
             err_msg = f"Could not get catalog entry information for catalog '{catalog_instance.display_name}': {e}"
             # Dump stack trace with error message
             self.log.exception(err_msg)
-            raise RuntimeError(err_msg)
 
         def read_with_thread():
             """
@@ -273,7 +271,6 @@ class ComponentCatalogConnector(LoggingConfigurable):
                 except NotImplementedError as e:
                     msg = f"{self.__class__.__name__} does not meet the requirements of a catalog connector class: {e}."
                     self.log.warning(msg)
-                    raise NotImplementedError(msg)
                 except Exception as e:
                     # Dump stack trace with error message and continue
                     self.log.exception(f"Could not read definition for catalog entry with identifying information: "

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -105,7 +105,8 @@ class ComponentCatalogConnector(LoggingConfigurable):
                                  stored; in addition to catalog_entry_data, catalog_metadata may also be
                                  needed to read the component definition for certain types of catalogs
 
-        :returns: the content of the given catalog entry's definition in string form
+        :returns: the content of the given catalog entry's definition in string form, if found, or None;
+                  if None is returned, this catalog entry is skipped and a warning message logged
         """
         raise NotImplementedError(
             "abstract method 'read_catalog_entry()' must be implemented"

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -359,7 +359,7 @@ class FilesystemComponentCatalogConnector(ComponentCatalogConnector):
                                  field to read individual catalog entries
 
         """
-        path = os.path.join(catalog_entry_data.get('base_dir'), catalog_entry_data.get('path'))
+        path = os.path.join(catalog_entry_data.get('base_dir', ''), catalog_entry_data.get('path'))
         if not os.path.exists(path):
             self.log.warning(f"Invalid location for component: {path}")
         else:

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -312,8 +312,7 @@ class FilesystemComponentCatalogConnector(ComponentCatalogConnector):
             return path
 
         # If path is still not absolute, default to the Jupyter share location
-        path = os.path.join(ENV_JUPYTER_PATH[0], 'components', path)
-        return path
+        return os.path.join(ENV_JUPYTER_PATH[0], 'components', path)
 
     def get_catalog_entries(self, catalog_metadata: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
@@ -337,8 +336,9 @@ class FilesystemComponentCatalogConnector(ComponentCatalogConnector):
                 return catalog_entry_data
 
         for path in catalog_metadata.get('paths'):
-            if not base_dir:
-                path = self.get_absolute_path(path)  # Assume absolute paths if no base_dir
+            path = os.path.expanduser(path)
+            if not base_dir and not os.path.isabs(path):
+                base_dir = os.path.join(ENV_JUPYTER_PATH[0], 'components')
 
             catalog_entry_data.append({
                 'base_dir': base_dir,
@@ -382,7 +382,7 @@ class DirectoryComponentCatalogConnector(FilesystemComponentCatalogConnector):
     Read component definitions from a local directory
     """
 
-    def get_relative_path(self, base_dir: str, file_path: str) -> str:
+    def get_relative_path_from_base(self, base_dir: str, file_path: str) -> str:
         """
         Determines the relative portion of a path from the given base directory.
 
@@ -432,7 +432,7 @@ class DirectoryComponentCatalogConnector(FilesystemComponentCatalogConnector):
                 catalog_entry_data.extend([
                     {
                         'base_dir': base_dir,
-                        'path': self.get_relative_path(base_dir, str(absolute_path))
+                        'path': self.get_relative_path_from_base(base_dir, str(absolute_path))
                     } for absolute_path in Path(base_dir).glob(file_pattern)
                 ])
 

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -59,8 +59,8 @@ class ComponentCatalogConnector(LoggingConfigurable):
         """
     ).tag(config=True)
 
-    def __init__(self, file_types: List[str]):
-        super().__init__()
+    def __init__(self, file_types: List[str], **kwargs):
+        super().__init__(**kwargs)
         self._file_types = file_types
 
     @abstractmethod

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -167,7 +167,7 @@ class ComponentCatalogConnector(LoggingConfigurable):
         :param catalog_hash_keys: the list of keys (present in the catalog_entry_data dict)
                                   whose values will be used to construct the hash
 
-        :returns: a unique component id of the form '<catalog-type>:<hash_of_given_metadata>'
+        :returns: a unique component id of the form '<catalog-type>:<hash_of_entry_data>'
         """
         hash_str = ""
         for key in catalog_hash_keys:
@@ -248,7 +248,7 @@ class ComponentCatalogConnector(LoggingConfigurable):
                     continue
 
                 try:
-                    # Read the entry definition given its returned data and the catalog metadata
+                    # Read the entry definition given its returned data and the catalog entry data
                     self.log.debug(f"Attempting read of definition for catalog entry with identifying information: "
                                    f"{str(catalog_entry_data)}...")
                     definition = self.read_catalog_entry(catalog_entry_data=catalog_entry_data,

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -67,22 +67,25 @@ class ComponentCatalogConnector(LoggingConfigurable):
     def get_catalog_entries(self, catalog_metadata: Dict[str, Any]) -> List[Dict[str, Any]]:
         """
         Returns a list of catalog_entry_data dictionary instances, one per entry in the given catalog.
+
         Each catalog_entry_data dictionary contains the information needed to access a single component
         definition. The form that each catalog_entry_data takes is determined by the unique requirements
-        of the reader class. No two catalog entries can have equivalent catalog_entry_data dictionaries.
+        of the reader class.
 
-        The catalog_metadata dictionary will take the following form:
+        No two catalog entries can have equivalent catalog_entry_data dictionaries.
 
-            {
-                "description": "...",  # only present if a description is added
-                "runtime": "...",  # must be present
-                "categories": ["category1", "category2", ...],  # may also be an empty array
-                "your_property1": value1,
-                "your_property2": value2,
-                ...
-            }
+        :param catalog_metadata: the dictionary form of the metadata associated with a single catalog;
+                                 the general structure is given in the example below
 
-        :param catalog_metadata: the dictionary form of the metadata associated with a single catalog
+                example:
+                    {
+                        "description": "...",  # only present if a description is added
+                        "runtime_type": "...",  # must be present
+                        "categories": ["category1", "category2", ...],  # may be an empty array
+                        "your_property1": value1,
+                        "your_property2": value2,
+                        ...
+                    }
 
         :returns: a list of catalog entry dictionaries, each of which contains the information
                   needed to access a component definition in read_catalog_entry()
@@ -100,9 +103,18 @@ class ComponentCatalogConnector(LoggingConfigurable):
         from get_catalog_entries() and, if needed, the catalog metadata.
 
         :param catalog_entry_data: a dictionary that contains the information needed to read the content
-                                   of the component definition
+                                   of the component definition; below is an example data structure returned
+                                   from get_catalog_entries()
+
+                example:
+                    {
+                        "directory_path": "/Users/path/to/directory",
+                        "relative_path": "subdir/file.py"
+                    }
+
         :param catalog_metadata: the metadata associated with the catalog in which this catalog entry is
-                                 stored; in addition to catalog_entry_data, catalog_metadata may also be
+                                 stored; this is the same dictionary that is passed into get_catalog_entries();
+                                 in addition to catalog_entry_data, catalog_metadata may also be
                                  needed to read the component definition for certain types of catalogs
 
         :returns: the content of the given catalog entry's definition in string form, if found, or None;
@@ -122,16 +134,16 @@ class ComponentCatalogConnector(LoggingConfigurable):
         over set of the keys returned by this function.
 
         Example:
-        Given a set of keys ['key1', 'key2', 'key3'] returned here, the below two catalog_entry_data
-        dictionaries will produce unique hashes. The same can not be said, however, if the set of
-        keys returned is ['key2', 'key3'].
+        Given a set of keys ['key1', 'key2', 'key3'], the below two catalog_entry_data dictionaries
+        will produce unique hashes. The same can not be said, however, if the set of keys
+        returned is ['key2', 'key3'].
 
-        component_entry_data for entry1:        component_entry_data for entry2:
-        {                                       {
-            'key1': 'value1',                       'key1': 'value4',
-            'key2': 'value2',                       'key2': 'value2',
-            'key3': 'value3'                        'key3': 'value3'
-        }                                       {
+            component_entry_data for entry1:        component_entry_data for entry2:
+            {                                       {
+                'key1': 'value1',                       'key1': 'value4',
+                'key2': 'value2',                       'key2': 'value2',
+                'key3': 'value3'                        'key3': 'value3'
+            }                                       {
 
         :returns: a list of keys
         """
@@ -145,12 +157,13 @@ class ComponentCatalogConnector(LoggingConfigurable):
                                   catalog_hash_keys: List[Any]) -> str:
         """
         Constructs a unique hash for the given component based on the name of the catalog
-        connector class and any information specific to that component/catalog-type combination
-        as given in catalog_hash_keys.
+        connector class and any information specific to that component-and-catalog-type
+        combination as given in catalog_hash_keys.
 
         :param catalog_type: the identifying type of this Connector class, as taken from the
                              schema_name of the related schema (e.g., url-catalog)
-        :param catalog_entry_data: the metadata associated with the component
+        :param catalog_entry_data: the identifying data associated with the catalog entry; this data
+                                   structure is one of the dicts returned from get_catalog_entries()
         :param catalog_hash_keys: the list of keys (present in the catalog_entry_data dict)
                                   whose values will be used to construct the hash
 
@@ -171,8 +184,8 @@ class ComponentCatalogConnector(LoggingConfigurable):
         """
         This function compiles the definitions of all catalog entries in a given catalog.
 
-        Catalog entry data is first retrieved for each entry in the catalog. This data is added to a
-        queue, and a number of reader threads ('max_reader' or fewer) are started.
+        Catalog entry data is first retrieved for each entry in the given catalog. This data is added
+        to a queue, and a number of reader threads ('max_reader' or fewer) are started.
 
         Each reader thread pulls the data for a singe catalog entry from the queue and uses it to read
         the definition associated with that entry.
@@ -181,21 +194,23 @@ class ComponentCatalogConnector(LoggingConfigurable):
         each thread. If a thread is able to successfully read the content of the given catalog entry,
         a unique hash is created for the entry and a mapping is added to the catalog_entry_map.
 
-        The catalog_instance Metadata parameter will have the following attributes of interest in addition
-        to a few additional attributes used internally:
+        The catalog_instance Metadata parameter will have the following attributes of interest in
+        addition to a few additional attributes used internally:
 
-            display_name: str = "Catalog Name"
-            schema_name: str = "connector-type"
-            metadata: Dict[str, Any] = {
-                "description": "...",  # only present if a description is added
-                "runtime": "...",  # must be present
-                "categories": ["category1", "category2", ...],  # may also be an empty array
-                "your_property1": value1,
-                "your_property2": value2,
-                ...
-            }
 
-        :param catalog_instance: the Metadata instance for this catalog
+        :param catalog_instance: the Metadata instance for this catalog; below is an example instance
+
+                example:
+                    display_name: str = "Catalog Name"
+                    schema_name: str = "connector-type"
+                    metadata: Dict[str, Any] = {
+                        "description": "...",  # only present if a description is added
+                        "runtime": "...",  # must be present
+                        "categories": ["category1", "category2", ...],  # may be an empty array
+                        "your_property1": value1,
+                        "your_property2": value2,
+                        ...
+                    }
 
         :returns: a mapping of a unique component ids to their definition and identifying data
         """
@@ -284,7 +299,7 @@ class FilesystemComponentCatalogConnector(ComponentCatalogConnector):
     Read a singular component definition from the local filesystem
     """
 
-    def get_absolute_path(self, path: str, base_path: Optional[str] = None) -> str:
+    def get_absolute_path(self, path: str) -> str:
         """
         Determines the absolute location of a given path. Error checking is delegated to
         the calling function
@@ -296,12 +311,6 @@ class FilesystemComponentCatalogConnector(ComponentCatalogConnector):
         if os.path.isabs(path):
             return path
 
-        # Concatenate paths with the base_path and check for absolute path again
-        if base_path:
-            concat_path = os.path.join(os.path.expanduser(base_path), path)
-            if os.path.isabs(concat_path):
-                return concat_path
-
         # If path is still not absolute, default to the Jupyter share location
         path = os.path.join(ENV_JUPYTER_PATH[0], 'components', path)
         return path
@@ -311,19 +320,29 @@ class FilesystemComponentCatalogConnector(ComponentCatalogConnector):
         Returns a list of catalog_entry_data dictionary instances, one per entry in the given catalog.
 
         :returns: a list of component_entry_data; for the FilesystemComponentCatalogConnector class this
-                  takes the form { 'path': 'abspath_to_component_definition_in_local_fs' }
+                  takes the form:
+
+                    {
+                        'base_dir': 'base/directory/for/file',  # can be empty
+                        'path': 'path/to/definition_in_local_fs.ext'  # may be relative or absolute
+                    }
         """
         catalog_entry_data = []
-        for path in catalog_metadata.get('paths'):
-            absolute_path = self.get_absolute_path(path, catalog_metadata.get('base_path'))
-            if not os.path.exists(absolute_path):
-                self.log.warning(f"File does not exist -> {absolute_path}")
-                continue
+        base_dir = catalog_metadata.get('base_path', '')
+        if base_dir:
+            base_dir = self.get_absolute_path(base_dir)
+            if not os.path.exists(base_dir):
+                # If the base directory is not found, skip this catalog
+                self.log.warning(f"Base directory does not exist -> {base_dir}")
+                return catalog_entry_data
 
-            # Use the relative path for the catalog_entry_data
+        for path in catalog_metadata.get('paths'):
+            if not base_dir:
+                path = self.get_absolute_path(path)  # Assume absolute paths if no base_dir
+
             catalog_entry_data.append({
-                'absolute_path': absolute_path,
-                'relative_path': path
+                'base_dir': base_dir,
+                'path': path
             })
         return catalog_entry_data
 
@@ -331,16 +350,16 @@ class FilesystemComponentCatalogConnector(ComponentCatalogConnector):
                            catalog_entry_data: Dict[str, Any],
                            catalog_metadata: Dict[str, Any]) -> Optional[str]:
         """
-        Read a component definition for a single catalog entry using the its data (as returned from
-        get_catalog_entries()) and the catalog metadata, if needed
+        Reads a component definition for a single catalog entry using the catalog_entry_data returned
+        from get_catalog_entries() and, if needed, the catalog metadata.
 
         :param catalog_entry_data: for the Filesystem- and DirectoryComponentCatalogConnector classes,
-                                   this takes the form { 'path': 'abspath_to_component_definition_in_local_fs' }
+                                   this includes 'path' and 'base_dir' keys
         :param catalog_metadata: Filesystem- and DirectoryComponentCatalogConnector classes do not need this
                                  field to read individual catalog entries
 
         """
-        path = catalog_entry_data.get('absolute_path')
+        path = os.path.join(catalog_entry_data.get('base_dir'), catalog_entry_data.get('path'))
         if not os.path.exists(path):
             self.log.warning(f"Invalid location for component: {path}")
         else:
@@ -355,7 +374,7 @@ class FilesystemComponentCatalogConnector(ComponentCatalogConnector):
         'path' value is needed from the catalog_entry_data dictionary to construct a
         unique hash id for a single catalog entry
         """
-        return ['relative_path']
+        return ['path']
 
 
 class DirectoryComponentCatalogConnector(FilesystemComponentCatalogConnector):
@@ -391,13 +410,18 @@ class DirectoryComponentCatalogConnector(FilesystemComponentCatalogConnector):
         Returns a list of catalog_entry_data dictionary instances, one per entry in the given catalog.
 
         :returns: a list of component_entry_data; for the DirectoryComponentCatalogConnector class this
-                  takes the form { 'path': 'abspath_to_component_definition_in_local_fs' }
+                  takes the form
+
+                    {
+                        'base_dir': 'base/directory/for/files',  # given in base_path
+                        'path': 'path/to/definition_in_local_fs.ext'  # may be relative or absolute
+                    }
         """
         catalog_entry_data = []
-        for path in catalog_metadata.get('paths'):
-            base_path = self.get_absolute_path(path, catalog_metadata.get('base_path'))
-            if not os.path.exists(base_path):
-                self.log.warning(f"Invalid directory -> {base_path}")
+        for dir_path in catalog_metadata.get('paths'):
+            base_dir = self.get_absolute_path(dir_path)
+            if not os.path.exists(base_dir):
+                self.log.warning(f"Invalid directory -> {base_dir}")
                 continue
 
             # Include '**/' in the glob pattern if files in subdirectories should be included
@@ -407,9 +431,9 @@ class DirectoryComponentCatalogConnector(FilesystemComponentCatalogConnector):
             for file_pattern in patterns:
                 catalog_entry_data.extend([
                     {
-                        'absolute_path': str(absolute_path),
-                        'relative_path': self.get_relative_path(base_path, str(absolute_path))
-                    } for absolute_path in Path(base_path).glob(file_pattern)
+                        'base_dir': base_dir,
+                        'path': self.get_relative_path(base_dir, str(absolute_path))
+                    } for absolute_path in Path(base_dir).glob(file_pattern)
                 ])
 
         return catalog_entry_data
@@ -425,7 +449,11 @@ class UrlComponentCatalogConnector(ComponentCatalogConnector):
         Returns a list of catalog_entry_data dictionary instances, one per entry in the given catalog.
 
         :returns: a list of component_entry_data; for the UrlComponentCatalogConnector class this takes
-                  the form { 'url': 'url_of_remote_component_definition' }
+                  the form:
+
+                    {
+                        'url': 'url_of_remote_component_definition'
+                    }
         """
         return [{'url': url} for url in catalog_metadata.get('paths')]
 
@@ -433,11 +461,10 @@ class UrlComponentCatalogConnector(ComponentCatalogConnector):
                            catalog_entry_data: Dict[str, Any],
                            catalog_metadata: Dict[str, Any]) -> Optional[str]:
         """
-        Read a component definition for a single catalog entry using the its data (as returned from
-        get_catalog_entries()) and the catalog metadata, if needed
+        Reads a component definition for a single catalog entry using the catalog_entry_data returned
+        from get_catalog_entries() and, if needed, the catalog metadata.
 
-        :param catalog_entry_data: for the UrlComponentCatalogConnector class this takes the form
-                                   { 'url': 'url_of_remote_component_definition' }
+        :param catalog_entry_data: for the UrlComponentCatalogConnector class this includes a 'url' key
         :param catalog_metadata: UrlComponentCatalogConnector does not need this field to read
                                  individual catalog entries
 

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -24,8 +24,6 @@ from typing import Optional
 
 from traitlets.config import LoggingConfigurable
 
-from elyra.pipeline.component_reader import ComponentReader
-
 
 class ComponentParameter(object):
     """
@@ -141,7 +139,7 @@ class Component(object):
         :param op: The operation name of the component; used by generic components in rendering the palette
         :param categories: A list of categories that this component belongs to
         :param properties: The set of properties for the component
-        :TODO add metadata
+        :param metadata: Metadata associated with this component for use in reading its definition
         :param extensions: The file extension used by the component
         """
 

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -197,7 +197,7 @@ class Component(object):
 
     @property
     def location(self) -> str:
-        return self._location
+        return str(self._location)
 
     @property
     def definition(self) -> str:

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -121,6 +121,7 @@ class Component(object):
                  description: Optional[str],
                  catalog_type: str,
                  location: str,
+                 definition: Optional[str] = None,  # TODO Fix this
                  runtime: Optional[str] = None,
                  op: Optional[str] = None,
                  categories: Optional[List[str]] = None,

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -17,7 +17,6 @@ from abc import abstractmethod
 from logging import Logger
 from types import SimpleNamespace
 from typing import Any
-from typing import Dict
 from typing import List
 from typing import Optional
 
@@ -121,13 +120,12 @@ class Component(object):
                  name: str,
                  description: Optional[str],
                  catalog_type: str,
-                 location: str,
+                 location: Any,
                  definition: Optional[str] = None,
                  runtime: Optional[str] = None,
                  op: Optional[str] = None,
                  categories: Optional[List[str]] = None,
                  properties: Optional[List[ComponentParameter]] = None,
-                 metadata: Optional[Dict[str, Any]] = None,
                  extensions: Optional[List[str]] = None,
                  parameter_refs: Optional[dict] = None):
         """

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -119,7 +119,7 @@ class Component(object):
 
     def __init__(self, id: str, name: str,
                  description: Optional[str],
-                 location_type: str,
+                 catalog_type: str,
                  location: str,
                  runtime: Optional[str] = None,
                  op: Optional[str] = None,
@@ -132,7 +132,7 @@ class Component(object):
         :param id: Unique identifier for a component
         :param name: The name of the component for display
         :param description: The description of the component
-        :param location_type: Indicates the type of component definition resource
+        :param catalog_type: Indicates the type of component definition resource
                               location; one of ['url', filename', 'directory]
         :param location: The location of the component definition
         :param runtime: The runtime of the component (e.g. KFP or Airflow)
@@ -151,7 +151,7 @@ class Component(object):
         self._id = id
         self._name = name
         self._description = description
-        self._location_type = location_type
+        self._location_type = catalog_type
         self._location = location
 
         self._runtime = runtime
@@ -189,7 +189,7 @@ class Component(object):
         return self._description
 
     @property
-    def location_type(self) -> str:
+    def catalog_type(self) -> str:
         return self._location_type
 
     @property

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -194,8 +194,15 @@ class Component(object):
         return self._catalog_type
 
     @property
-    def source_identifier(self) -> str:
-        return str(self._source_identifier)
+    def source_identifier(self) -> Any:
+        return self._source_identifier
+
+    @property
+    def component_source(self) -> str:
+        return str({
+            "catalog_type": self.catalog_type,
+            "component_ref": self.source_identifier
+        })
 
     @property
     def definition(self) -> str:

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -128,7 +128,6 @@ class Component(object):
                  categories: Optional[List[str]] = None,
                  properties: Optional[List[ComponentParameter]] = None,
                  metadata: Optional[Dict[str, Any]] = None,
-                 reader: Optional[ComponentReader] = None,
                  extensions: Optional[List[str]] = None,
                  parameter_refs: Optional[dict] = None):
         """
@@ -142,7 +141,7 @@ class Component(object):
         :param op: The operation name of the component; used by generic components in rendering the palette
         :param categories: A list of categories that this component belongs to
         :param properties: The set of properties for the component
-        :TODO add metadata and reader
+        :TODO add metadata
         :param extensions: The file extension used by the component
         """
 
@@ -162,7 +161,6 @@ class Component(object):
         self._categories = categories or []
         self._properties = properties
         self._metadata = metadata or {}
-        self._reader = reader
 
         if not parameter_refs:
             if self._location_type == "elyra":
@@ -222,10 +220,6 @@ class Component(object):
     @property
     def metadata(self) -> Dict[str, Any]:
         return self._metadata
-
-    @property
-    def reader(self) -> ComponentReader:
-        return self._reader
 
     @property
     def extensions(self) -> Optional[List[str]]:

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -15,7 +15,6 @@
 #
 from abc import abstractmethod
 from logging import Logger
-import os
 from types import SimpleNamespace
 from typing import Any
 from typing import Dict
@@ -117,11 +116,13 @@ class Component(object):
     Represents a generic or runtime-specific component
     """
 
-    def __init__(self, id: str, name: str,
+    def __init__(self,
+                 id: str,
+                 name: str,
                  description: Optional[str],
                  catalog_type: str,
                  location: str,
-                 definition: Optional[str] = None,  # TODO Fix this
+                 definition: Optional[str] = None,
                  runtime: Optional[str] = None,
                  op: Optional[str] = None,
                  categories: Optional[List[str]] = None,
@@ -136,11 +137,12 @@ class Component(object):
         :param catalog_type: Indicates the type of component definition resource
                               location; one of ['url', filename', 'directory]
         :param location: The location of the component definition
+        :param definition: The content of the specification file for this component
         :param runtime: The runtime of the component (e.g. KFP or Airflow)
         :param op: The operation name of the component; used by generic components in rendering the palette
-        :param categories: A list of categories that this component belongs to
+        :param categories: A list of categories that this component belongs to; used to organize component
+                           in the palette
         :param properties: The set of properties for the component
-        :param metadata: Metadata associated with this component for use in reading its definition
         :param extensions: The file extension used by the component
         """
 
@@ -155,11 +157,11 @@ class Component(object):
         self._location_type = catalog_type
         self._location = location
 
+        self._definition = definition
         self._runtime = runtime
         self._op = op
         self._categories = categories or []
         self._properties = properties
-        self._metadata = metadata or {}
 
         if not parameter_refs:
             if self._location_type == "elyra":
@@ -198,6 +200,10 @@ class Component(object):
         return self._location
 
     @property
+    def definition(self) -> str:
+        return self._definition
+
+    @property
     def runtime(self) -> Optional[str]:
         return self._runtime
 
@@ -215,10 +221,6 @@ class Component(object):
     @property
     def properties(self) -> Optional[List[ComponentParameter]]:
         return self._properties
-
-    @property
-    def metadata(self) -> Dict[str, Any]:
-        return self._metadata
 
     @property
     def extensions(self) -> Optional[List[str]]:
@@ -254,16 +256,6 @@ class ComponentParser(LoggingConfigurable):  # ABC
         a list of fully-qualified Component objects
         """
         raise NotImplementedError()
-
-    def get_component_id(self, location: str, name: str) -> str:
-        """
-        Get a unique id for a component based on its file basename and
-        it's given name.
-        """
-        file_basename = os.path.basename(location)
-        filename = os.path.splitext(file_basename)[0]
-        component_name = f"{filename}_{name.replace(' ', '')}"
-        return component_name
 
     def _format_description(self, description: str, data_type: str) -> str:
         """

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -120,7 +120,7 @@ class Component(object):
                  name: str,
                  description: Optional[str],
                  catalog_type: str,
-                 location: Any,
+                 source_identifier: Any,
                  definition: Optional[str] = None,
                  runtime: Optional[str] = None,
                  op: Optional[str] = None,
@@ -134,7 +134,7 @@ class Component(object):
         :param description: The description of the component
         :param catalog_type: Indicates the type of component definition resource
                               location; one of ['url', filename', 'directory]
-        :param location: The location of the component definition
+        :param source_identifier: Source information to help locate the component definition
         :param definition: The content of the specification file for this component
         :param runtime: The runtime of the component (e.g. KFP or Airflow)
         :param op: The operation name of the component; used by generic components in rendering the palette
@@ -152,8 +152,8 @@ class Component(object):
         self._id = id
         self._name = name
         self._description = description
-        self._location_type = catalog_type
-        self._location = location
+        self._catalog_type = catalog_type
+        self._source_identifier = source_identifier
 
         self._definition = definition
         self._runtime = runtime
@@ -162,7 +162,7 @@ class Component(object):
         self._properties = properties
 
         if not parameter_refs:
-            if self._location_type == "elyra":
+            if self._catalog_type == "elyra":
                 parameter_refs = {
                     "filehandler": "filename"
                 }
@@ -191,11 +191,11 @@ class Component(object):
 
     @property
     def catalog_type(self) -> str:
-        return self._location_type
+        return self._catalog_type
 
     @property
-    def location(self) -> str:
-        return str(self._location)
+    def source_identifier(self) -> str:
+        return str(self._source_identifier)
 
     @property
     def definition(self) -> str:

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -14,22 +14,17 @@
 # limitations under the License.
 #
 from abc import abstractmethod
-from http import HTTPStatus
 from logging import Logger
 import os
-from queue import Empty
-from queue import Queue
-from threading import Thread
 from types import SimpleNamespace
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
 
-from jupyter_core.paths import ENV_JUPYTER_PATH
-import requests
 from traitlets.config import LoggingConfigurable
-from traitlets.traitlets import Integer
+
+from elyra.pipeline.component_reader import ComponentReader
 
 
 class ComponentParameter(object):
@@ -132,6 +127,8 @@ class Component(object):
                  op: Optional[str] = None,
                  categories: Optional[List[str]] = None,
                  properties: Optional[List[ComponentParameter]] = None,
+                 metadata: Optional[Dict[str, Any]] = None,
+                 reader: Optional[ComponentReader] = None,
                  extensions: Optional[List[str]] = None,
                  parameter_refs: Optional[dict] = None):
         """
@@ -145,6 +142,7 @@ class Component(object):
         :param op: The operation name of the component; used by generic components in rendering the palette
         :param categories: A list of categories that this component belongs to
         :param properties: The set of properties for the component
+        :TODO add metadata and reader
         :param extensions: The file extension used by the component
         """
 
@@ -163,6 +161,8 @@ class Component(object):
         self._op = op
         self._categories = categories or []
         self._properties = properties
+        self._metadata = metadata or {}
+        self._reader = reader
 
         if not parameter_refs:
             if self._location_type == "elyra":
@@ -220,6 +220,14 @@ class Component(object):
         return self._properties
 
     @property
+    def metadata(self) -> Dict[str, Any]:
+        return self._metadata
+
+    @property
+    def reader(self) -> ComponentReader:
+        return self._reader
+
+    @property
     def extensions(self) -> Optional[List[str]]:
         return self._extensions
 
@@ -233,213 +241,6 @@ class Component(object):
             logger.warning(msg)
         else:
             print(f"WARNING: {msg}")
-
-
-class ComponentReader(LoggingConfigurable):
-    """
-    Abstract class to model component_entry readers that can read components from different locations
-    """
-    location_type: str = None
-
-    max_readers = Integer(3, config=True, allow_none=True,
-                          help="""Sets the number of reader threads""")
-
-    def __init__(self, file_types: List[str]):
-        super().__init__()
-        self.file_types = file_types
-
-    @property
-    def resource_type(self):
-        """
-        The RuntimePipelineProcessor accesses this property in order to
-        process components on pipeline submit/export. The value must be
-        one of ('filename', 'url').
-        """
-        return self.location_type
-
-    @abstractmethod
-    def read_component_definition(self,
-                                  location: str,
-                                  location_to_def: Dict[str, str]) -> Dict[str, str]:
-        """
-        Read an absolute location to get the contents of a component specification file
-
-        :param location: an absolute path to the specification file to read
-        :param location_to_def: a mapping of component locations to file contents
-
-        :returns: the given 'location_to_def' object, optionally including a new
-                  key-value pair if the given component location is successfully read
-        """
-        raise NotImplementedError()
-
-    def read_component_definitions(self, locations: List[str]) -> Dict[str, str]:
-        """
-        This function starts a number of threads ('max_reader' or fewer) that read component
-        definitions in parallel.
-
-        The 'location_to_def' variable is a mapping of a component location to its content.
-        As a mutable object, this dictionary provides a means to retrieve a return value for
-        each thread. If a thread is able to successfully read the content of the given
-        component file location, a location-to-content mapping is added to 'location_to_def'.
-        """
-        location_to_def = {}
-
-        loc_q = Queue()
-        for location in self.get_absolute_locations(locations):
-            loc_q.put_nowait(location)
-
-        def read_with_thread():
-            """Get a location from the queue and read contents"""
-            while not loc_q.empty():
-                try:
-                    self.log.debug("Retrieving component definition file location from queue...")
-                    loc = loc_q.get(timeout=.1)
-                except Empty:
-                    continue
-
-                try:
-                    self.log.debug(f"Attempting read of component definition file at location '{loc}'...")
-                    self.read_component_definition(loc, location_to_def)
-                except Exception:
-                    self.log.warning(f"Could not read component definition file at location '{loc}'. Skipping...")
-
-                loc_q.task_done()
-
-        # Start 'max_reader' reader threads if registry includes more than 'max_reader'
-        # number of locations, else start one thread per location
-        num_threads = min(loc_q.qsize(), self.max_readers)
-        for i in range(num_threads):
-            Thread(target=read_with_thread).start()
-
-        # Wait for all queued locations to be processed
-        loc_q.join()
-
-        return location_to_def
-
-    @abstractmethod
-    def get_absolute_locations(self, paths: List[str]) -> List[str]:
-        """
-        Returns a list of absolute paths to component specification file(s)
-        based on the array of potentially relative locations given
-        """
-        raise NotImplementedError()
-
-
-class FilesystemComponentReader(ComponentReader):
-    """
-    Read a singular component definition from the local filesystem
-    """
-    location_type = 'filename'
-
-    def determine_location(self, location_path: str) -> str:
-        """
-        Determines the absolute location of a given path. Error
-        checking is delegated to the calling function
-        """
-        # Expand path to include user home if necessary
-        path = os.path.expanduser(location_path)
-
-        # Check for absolute path
-        if os.path.isabs(path):
-            return path
-
-        # If path is not absolute, default to the Jupyter share location
-        path = os.path.join(ENV_JUPYTER_PATH[0], 'components', path)
-        return path
-
-    def read_component_definition(self,
-                                  location: str,
-                                  location_to_def: Dict[str, str]) -> Dict[str, str]:
-        if not os.path.exists(location):
-            self.log.warning(f"Invalid location for component: {location}")
-        else:
-            with open(location, 'r') as f:
-                location_to_def[location] = f.read()
-
-        return location_to_def
-
-    def get_absolute_locations(self, paths: List[str]) -> List[str]:
-        absolute_paths = []
-        for path in paths:
-            absolute_path = self.determine_location(path)
-            if not os.path.exists(absolute_path):
-                self.log.warning(f"File does not exist -> {absolute_path}")
-            absolute_paths.append(absolute_path)
-        return absolute_paths
-
-
-class DirectoryComponentReader(FilesystemComponentReader):
-    """
-    Read component definitions from a local directory
-    """
-    location_type = 'directory'
-
-    def get_absolute_locations(self, paths: List[str]) -> List[str]:
-        absolute_paths = []
-        for path in paths:
-            absolute_path = self.determine_location(path)
-            if not os.path.exists(absolute_path):
-                self.log.warning(f"Invalid directory -> {absolute_path}")
-                continue
-
-            for filename in os.listdir(absolute_path):
-                if filename.endswith(tuple(self.file_types)):
-                    absolute_paths.append(os.path.join(absolute_path, filename))
-
-        return absolute_paths
-
-    @property
-    def resource_type(self):
-        """
-        The RuntimePipelineProcessor accesses this property in order to process
-        components on pipeline submit/export. The superclass location_type is
-        used because the value must be one of ('filename', 'url').
-        """
-        return super().location_type
-
-
-class UrlComponentReader(ComponentReader):
-    """
-    Read a singular component definition from a url
-    """
-    location_type = 'url'
-
-    def read_component_definition(self,
-                                  location: str,
-                                  location_to_def: Dict[str, str]) -> Dict[str, str]:
-        try:
-            res = requests.get(location)
-        except Exception as e:
-            self.log.warning(f"Failed to connect to URL for component: {location}: {str(e)}")
-        else:
-            if res.status_code != HTTPStatus.OK:
-                self.log.warning(f"Invalid location for component: {location} (HTTP code {res.status_code})")
-            else:
-                location_to_def[location] = res.text
-
-        return location_to_def
-
-    def get_absolute_locations(self, paths: List[str]) -> List[str]:
-        return paths
-
-
-class GitHubComponentReader(UrlComponentReader):
-    """
-    Read component definitions from a github repo
-    """
-    location_type = 'github'
-
-    def get_absolute_locations(self, paths: List[str]) -> List[str]:
-        pass
-
-    @property
-    def resource_type(self):
-        """
-        The RuntimePipelineProcessor accesses this property in order to process
-        components on pipeline submit/export. The superclass location_type is
-        used because the value must be one of ('filename', 'url').
-        """
-        return super().location_type
 
 
 class ComponentParser(LoggingConfigurable):  # ABC

--- a/elyra/pipeline/component_metadata.py
+++ b/elyra/pipeline/component_metadata.py
@@ -44,7 +44,8 @@ class ComponentRegistryMetadata(Metadata):
         self.metadata.pop('location_type')
         self.version = 1
 
-        getLogger('ServerApp').info(f"Migrating 'component-registry' instance '{self.name}' to schema '{self.schema_name}'...")
+        getLogger('ServerApp').info(f"Migrating 'component-registry' instance '{self.name}' "
+                                    f"to schema '{self.schema_name}'...")
         MetadataManager(schemaspace="component-registries").update(self.name, self, for_migration=True)
 
     def post_save(self, **kwargs: Any) -> None:

--- a/elyra/pipeline/component_metadata.py
+++ b/elyra/pipeline/component_metadata.py
@@ -27,8 +27,8 @@ class ComponentRegistryMetadata(Metadata):
     and deletion of component registry metadata instances.
     """
 
-    def post_load(self, **kwargs: Any) -> None:
-        """Since this class is tied to an schema, use post_load to trigger migration """
+    def on_load(self, **kwargs: Any) -> None:
+        """Since this class is tied to a deprecated schema, use on_load to trigger migration """
 
         if self.metadata['location_type'] == 'URL':
             self.schema_name = "url-catalog"

--- a/elyra/pipeline/component_reader.py
+++ b/elyra/pipeline/component_reader.py
@@ -52,7 +52,7 @@ class ComponentCatalogConnector(LoggingConfigurable):
         return self._catalog_type
 
     @abstractmethod
-    def get_component_hash_keys(self) -> List[Any]:
+    def get_hash_keys(self) -> List[Any]:
         """
         Provides a list of keys available in the 'catalog_entry_data' dictionary whose values
         will be used to construct a unique hash id for each entry with the given catalog type
@@ -141,7 +141,7 @@ class ComponentCatalogConnector(LoggingConfigurable):
 
         # Retrieve list of keys that will be used to construct
         # the catalog entry hash for each entry in the catalog
-        keys_to_hash = self.get_component_hash_keys()
+        keys_to_hash = self.get_hash_keys()
 
         try:
             # Add catalog entry data dictionaries to the thread queue

--- a/elyra/pipeline/component_reader.py
+++ b/elyra/pipeline/component_reader.py
@@ -1,0 +1,319 @@
+#
+# Copyright 2018-2021 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from abc import abstractmethod
+from http import HTTPStatus
+import os
+from queue import Empty
+from queue import Queue
+from threading import Thread
+from typing import Dict
+from typing import List
+from typing import Tuple
+
+from jupyter_core.paths import ENV_JUPYTER_PATH
+import requests
+from traitlets.config import LoggingConfigurable
+from traitlets.traitlets import Integer
+
+from elyra.metadata.metadata import Metadata
+
+
+class ComponentReader(LoggingConfigurable):
+    """
+    Abstract class to model component_entry readers that can read components from different locations
+    """
+    catalog_type: str = None
+
+    max_readers = Integer(3, config=True, allow_none=True,
+                          help="""Sets the number of reader threads""")
+
+    def __init__(self, file_types: List[str]):
+        super().__init__()
+        self.file_types = file_types
+
+    @property
+    def resource_type(self):
+        """
+        The RuntimePipelineProcessor accesses this property in order to
+        process components on pipeline submit/export. The value must be
+        one of ('filename', 'url').
+        """
+        return self.catalog_type
+
+    @abstractmethod
+    def get_absolute_locations(self, paths: List[str]) -> List[str]:
+        """
+        Returns a list of absolute paths to component specification file(s)
+        based on the array of potentially relative locations given
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_component_metadata_from_registry(self, registry_metadata: List[Metadata]) -> List[Tuple[str, Dict]]:
+        """
+        TODO
+        Formerly get_absolute_locations
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def read_component_definition(self,
+                                  location: str,
+                                  location_to_def: Dict[str, str]) -> Dict[str, Dict]:
+        """
+        Read an absolute location to get the contents of a component specification file
+
+        :param location: an absolute path to the specification file to read
+        :param location_to_def: a mapping of component locations to file contents
+
+        :returns: the given 'location_to_def' object, optionally including a new
+                  key-value pair if the given component location is successfully read
+        """
+        raise NotImplementedError()
+
+    def get_unique_component_hash(self, location_type, *args) -> str:
+        """
+        TODO
+        """
+        hash_str = location_type
+        for arg in args:
+            hash_str = f"{hash_str}:{arg}"
+
+        return str(hash(hash_str))
+
+    def read_component_definitions(self, registry_metadata: List[Metadata]) -> Dict[str, Dict]:
+        """
+        This function starts a number of threads ('max_reader' or fewer) that read component
+        definitions in parallel.
+
+        The 'location_to_def' variable is a mapping of a component location to its content.
+        As a mutable object, this dictionary provides a means to retrieve a return value for
+        each thread. If a thread is able to successfully read the content of the given
+        component file location, a location-to-content mapping is added to 'location_to_def'.
+        """
+        # location_to_def = {}
+
+        hash_to_metadata = {}
+
+        loc_q = Queue()
+        # for location in self.get_absolute_locations(locations):
+        #    loc_q.put_nowait(location)
+        for component_metadata in self.get_component_metadata_from_registry(registry_metadata):
+            loc_q.put_nowait(component_metadata)
+
+        def read_with_thread():
+            """Get a location from the queue and read contents"""
+            while not loc_q.empty():
+                try:
+                    self.log.debug("Retrieving component definition file location from queue...")
+                    component_metadata = loc_q.get(timeout=.1)
+                except Empty:
+                    continue
+
+                try:
+                    # self.log.debug(f"Attempting read of component definition file at location '{loc}'...")
+                    # component_hash = list(component_metadata.keys())[0]
+                    # location_to_def[component_hash] = {}
+                    # self.read_component_definition(component_metadata, location_to_def)
+                    self.read_component_definition(component_metadata, hash_to_metadata)
+                except Exception:
+                    # self.log.warning(f"Could not read component definition file at location '{loc}'. Skipping...")
+                    pass
+
+                loc_q.task_done()
+
+        # Start 'max_reader' reader threads if registry includes more than 'max_reader'
+        # number of locations, else start one thread per location
+        num_threads = min(loc_q.qsize(), self.max_readers)
+        for i in range(num_threads):
+            Thread(target=read_with_thread).start()
+
+        # Wait for all queued locations to be processed
+        loc_q.join()
+
+        return hash_to_metadata
+
+
+class FilesystemComponentReader(ComponentReader):
+    """
+    Read a singular component definition from the local filesystem
+    """
+    catalog_type = 'local-file-catalog'
+    rendering_type = 'filename'
+
+    def get_component_metadata_from_registry(self, registry_metadata: List[Metadata]) -> List[Tuple[str, Dict]]:
+        """
+        TODO
+        """
+        hash_to_metadata = []
+        for path in registry_metadata['paths']:
+            absolute_path = self.determine_location(path)
+            if not os.path.exists(absolute_path):
+                self.log.warning(f"File does not exist -> {absolute_path}")
+
+            component_hash = self.get_unique_component_hash(self.__class__, absolute_path or "")
+            hash_to_metadata.append((component_hash, {'location': absolute_path}))
+        return hash_to_metadata
+
+    def determine_location(self, location_path: str) -> str:
+        """
+        Determines the absolute location of a given path. Error
+        checking is delegated to the calling function
+        """
+        # Expand path to include user home if necessary
+        path = os.path.expanduser(location_path)
+
+        # Check for absolute path
+        if os.path.isabs(path):
+            return path
+
+        # If path is not absolute, default to the Jupyter share location
+        path = os.path.join(ENV_JUPYTER_PATH[0], 'components', path)
+        return path
+
+    def read_component_definition(self,
+                                  component_metadata: Tuple[str, Dict],
+                                  hash_to_metadata: Dict[str, Dict]) -> Dict[str, Dict]:
+        location = component_metadata[1]['location']
+        if not os.path.exists(location):
+            self.log.warning(f"Invalid location for component: {location}")
+        else:
+            with open(location, 'r') as f:
+                component_hash = component_metadata[0]
+                hash_to_metadata[component_hash] = {
+                    'definition': f.read(),
+                    'metadata': component_metadata[1]
+                }
+
+        return hash_to_metadata
+
+    def get_absolute_locations(self, paths: List[str]) -> List[str]:
+        absolute_paths = []
+        for path in paths:
+            absolute_path = self.determine_location(path)
+            if not os.path.exists(absolute_path):
+                self.log.warning(f"File does not exist -> {absolute_path}")
+            absolute_paths.append(absolute_path)
+        return absolute_paths
+
+
+class DirectoryComponentReader(FilesystemComponentReader):
+    """
+    Read component definitions from a local directory
+    """
+    catalog_type = 'local-directory-catalog'
+    rendering_type = 'filename'
+
+    def get_component_metadata_from_registry(self, registry_metadata: List[Metadata]) -> List[Tuple[str, Dict]]:
+        """
+        TODO
+        """
+        hash_to_metadata = []
+        for path in registry_metadata['paths']:
+            absolute_path = self.determine_location(path)
+            if not os.path.exists(absolute_path):
+                self.log.warning(f"Invalid directory -> {absolute_path}")
+                continue
+
+            for filename in os.listdir(absolute_path):
+                if filename.endswith(tuple(self.file_types)):
+                    component_hash = self.get_unique_component_hash(self.__class__, filename or "")
+                    hash_to_metadata.append((component_hash, {'location': os.path.join(absolute_path, filename)}))
+
+        return hash_to_metadata
+
+    def get_absolute_locations(self, paths: List[str]) -> List[str]:
+        absolute_paths = []
+        for path in paths:
+            absolute_path = self.determine_location(path)
+            if not os.path.exists(absolute_path):
+                self.log.warning(f"Invalid directory -> {absolute_path}")
+                continue
+
+            for filename in os.listdir(absolute_path):
+                if filename.endswith(tuple(self.file_types)):
+                    absolute_paths.append(os.path.join(absolute_path, filename))
+
+        return absolute_paths
+
+    @property
+    def resource_type(self):
+        """
+        The RuntimePipelineProcessor accesses this property in order to process
+        components on pipeline submit/export. The superclass location_type is
+        used because the value must be one of ('filename', 'url').
+        """
+        return super().location_type
+
+
+class UrlComponentReader(ComponentReader):
+    """
+    Read a singular component definition from a url
+    """
+    catalog_type = 'url-catalog'
+    rendering_type = 'url'
+
+    def get_component_metadata_from_registry(self, registry_metadata: List[Metadata]) -> List[Tuple[str, Dict]]:
+        """
+        TODO
+        """
+        hash_to_metadata = []
+        for path in registry_metadata['paths']:
+            component_hash = self.get_unique_component_hash(self.__class__, path or "")
+            hash_to_metadata.append((component_hash, {'location': path}))
+        return hash_to_metadata
+
+    def read_component_definition(self,
+                                  component_metadata: Tuple[str, Dict],
+                                  hash_to_metadata: Dict[str, Dict]) -> Dict[str, Dict]:
+        location = component_metadata[1]['location']
+        try:
+            res = requests.get(location)
+        except Exception as e:
+            self.log.warning(f"Failed to connect to URL for component: {location}: {e}")
+        else:
+            if res.status_code != HTTPStatus.OK:
+                self.log.warning(f"Invalid location for component: {location} (HTTP code {res.status_code})")
+            else:
+                component_hash = component_metadata[0]
+                hash_to_metadata[component_hash] = {
+                    'definition': res.text,
+                    'metadata': component_metadata[1]
+                }
+
+        return hash_to_metadata
+
+    def get_absolute_locations(self, paths: List[str]) -> List[str]:
+        return paths
+
+
+class GitHubComponentReader(UrlComponentReader):
+    """
+    Read component definitions from a github repo
+    """
+    location_type = 'github'
+
+    def get_absolute_locations(self, paths: List[str]) -> List[str]:
+        pass
+
+    @property
+    def resource_type(self):
+        """
+        The RuntimePipelineProcessor accesses this property in order to process
+        components on pipeline submit/export. The superclass location_type is
+        used because the value must be one of ('filename', 'url').
+        """
+        return super().location_type

--- a/elyra/pipeline/component_reader.py
+++ b/elyra/pipeline/component_reader.py
@@ -230,7 +230,7 @@ class FilesystemComponentCatalogConnector(ComponentCatalogConnector):
         path = os.path.join(ENV_JUPYTER_PATH[0], 'components', path)
         return path
 
-    def get_component_hash_keys(self) -> List[Any]:
+    def get_hash_keys(self) -> List[Any]:
         return ['path']
 
     def get_catalog_entries(self, catalog_metadata: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -310,7 +310,7 @@ class UrlComponentCatalogConnector(ComponentCatalogConnector):
     Read a singular component definition from a url
     """
 
-    def get_component_hash_keys(self) -> List[Any]:
+    def get_hash_keys(self) -> List[Any]:
         return ['url']
 
     def get_catalog_entries(self, catalog_metadata: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/elyra/pipeline/component_reader.py
+++ b/elyra/pipeline/component_reader.py
@@ -214,7 +214,6 @@ class FilesystemComponentReader(ComponentReader):
         """
         TODO and add abstractmethod
         """
-        # TODO Add a try-catch?
         return {self.rendering_type: component.metadata.get('location')}
 
 

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -48,7 +48,7 @@ class ComponentRegistry(LoggingConfigurable):
                               description="Run notebook file",
                               op="execute-notebook-node",
                               catalog_type="elyra",
-                              location="elyra",
+                              source_identifier="elyra",
                               extensions=[".ipynb"],
                               categories=[_generic_category_label]),
         "python-script": Component(id="python-script",
@@ -56,7 +56,7 @@ class ComponentRegistry(LoggingConfigurable):
                                    description="Run Python script",
                                    op="execute-python-node",
                                    catalog_type="elyra",
-                                   location="elyra",
+                                   source_identifier="elyra",
                                    extensions=[".py"],
                                    categories=[_generic_category_label]),
         "r-script": Component(id="r-script",
@@ -64,7 +64,7 @@ class ComponentRegistry(LoggingConfigurable):
                               description="Run R script",
                               op="execute-r-node",
                               catalog_type="elyra",
-                              location="elyra",
+                              source_identifier="elyra",
                               extensions=[".r"],
                               categories=[_generic_category_label])}
 

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -46,7 +46,7 @@ class ComponentRegistry(LoggingConfigurable):
                               name="Notebook",
                               description="Run notebook file",
                               op="execute-notebook-node",
-                              location_type="elyra",
+                              catalog_type="elyra",
                               location="elyra",
                               extensions=[".ipynb"],
                               categories=[_generic_category_label]),
@@ -54,7 +54,7 @@ class ComponentRegistry(LoggingConfigurable):
                                    name="Python Script",
                                    description="Run Python script",
                                    op="execute-python-node",
-                                   location_type="elyra",
+                                   catalog_type="elyra",
                                    location="elyra",
                                    extensions=[".py"],
                                    categories=[_generic_category_label]),
@@ -62,7 +62,7 @@ class ComponentRegistry(LoggingConfigurable):
                               name="R Script",
                               description="Run R script",
                               op="execute-r-node",
-                              location_type="elyra",
+                              catalog_type="elyra",
                               location="elyra",
                               extensions=[".r"],
                               categories=[_generic_category_label])}
@@ -213,7 +213,7 @@ class ComponentRegistry(LoggingConfigurable):
 
                 component_entry = {
                     "component_id": component_hash,
-                    "location_type": reader.catalog_type,
+                    "catalog_type": reader.catalog_type,
                     "categories": registry_categories,
                     "component_definition": component_metadata_dict.get('definition'),
                     "component_metadata": component_metadata_dict['metadata']

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -210,6 +210,9 @@ class ComponentRegistry(LoggingConfigurable):
             # Get content of component definition file for each component in this registry
             hash_to_metadata = reader.read_component_definitions(registry['metadata'])
             for component_hash, component_metadata_dict in hash_to_metadata.items():
+                # Ignore this entry if no definition content is returned
+                if not component_metadata_dict.get('definition'):
+                    continue
 
                 component_entry = {
                     "component_id": component_hash,

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -217,12 +217,11 @@ class ComponentRegistry(LoggingConfigurable):
 
                 component_entry = {
                     "component_id": component_hash,
-                    "catalog_type": reader.catalog_type,
+                    "location_type": reader.catalog_type,
                     # "location": component_metadata['metadata'].get('location'),
                     "categories": registry_categories,
                     "component_definition": component_metadata_dict.get('definition'),
-                    "component_metadata": component_metadata_dict['metadata'],
-                    # "reader": reader
+                    "component_metadata": component_metadata_dict['metadata']
                 }
 
                 # Parse the component entry to get a fully qualified Component object

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -250,8 +250,8 @@ class ComponentRegistry(LoggingConfigurable):
                     .get(catalog.schema_name)\
                     .load()(self._parser.file_types, parent=self.parent)
             except Exception as e:
-                self.log.warning(f"Could not load appropriate ComponentCatalogConnector class: {e}")
-                raise RuntimeError(f"Could not load appropriate ComponentCatalogConnector class: {e}")
+                self.log.warning(f"Could not load appropriate ComponentCatalogConnector class: {e}. Skipping...")
+                continue
 
             # Get content of component definition file for each component in this catalog
             self.log.debug(f"Processing components in catalog '{catalog.display_name}'")

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -198,7 +198,7 @@ class ComponentRegistry(LoggingConfigurable):
 
         runtime_registries = self._get_registries_for_runtime()
         for registry in runtime_registries:
-            self.log.debug(f"Component registry: processing components in registry '{registry['display_name']}'")
+            self.log.debug(f"Processing components in catalog '{registry['display_name']}'")
 
             categories = registry['metadata'].get("categories", [])
             catalog_type = registry['schema_name']
@@ -208,18 +208,19 @@ class ComponentRegistry(LoggingConfigurable):
             reader = catalog_reader.load()(catalog_type, self._parser.file_types)
 
             # Get content of component definition file for each component in this registry
-            hash_to_metadata = reader.read_component_definitions(registry['metadata'])
-            for component_hash, component_metadata_dict in hash_to_metadata.items():
-                # Ignore this entry if no definition content is returned
-                if not component_metadata_dict.get('definition'):
-                    continue
+            component_data_dict = reader.read_component_definitions(registry['metadata'])
+            if not component_data_dict:
+                self.log.debug(f"Could not read catalog '{registry['display_name']}'. Skipping...")
+                continue
+
+            for component_id, component_data in component_data_dict.items():
 
                 component_entry = {
-                    "component_id": component_hash,
+                    "component_id": component_id,
                     "catalog_type": reader.catalog_type,
                     "categories": categories,
-                    "component_definition": component_metadata_dict.get('definition'),
-                    "component_metadata": component_metadata_dict['metadata']
+                    "component_definition": component_data.get('definition'),
+                    "component_identifier": component_data.get('identifier')
                 }
 
                 # Parse the component entry to get a fully qualified Component object

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -200,12 +200,12 @@ class ComponentRegistry(LoggingConfigurable):
         for registry in runtime_registries:
             self.log.debug(f"Component registry: processing components in registry '{registry['display_name']}'")
 
-            registry_categories = registry['metadata'].get("categories", [])
-            registry_location_type = registry['schema_name']
+            categories = registry['metadata'].get("categories", [])
+            catalog_type = registry['schema_name']
 
             # Assign reader based on the location type of the registry (file, directory, url)
-            catalog_reader = entrypoints.get_group_named('elyra.component.catalog_types').get(registry_location_type)
-            reader = catalog_reader.load()(registry_location_type, self._parser.file_types)
+            catalog_reader = entrypoints.get_group_named('elyra.component.catalog_types').get(catalog_type)
+            reader = catalog_reader.load()(catalog_type, self._parser.file_types)
 
             # Get content of component definition file for each component in this registry
             hash_to_metadata = reader.read_component_definitions(registry['metadata'])
@@ -214,7 +214,7 @@ class ComponentRegistry(LoggingConfigurable):
                 component_entry = {
                     "component_id": component_hash,
                     "catalog_type": reader.catalog_type,
-                    "categories": registry_categories,
+                    "categories": categories,
                     "component_definition": component_metadata_dict.get('definition'),
                     "component_metadata": component_metadata_dict['metadata']
                 }

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -29,10 +29,6 @@ from elyra.metadata.manager import MetadataManager
 from elyra.metadata.schemaspaces import ComponentRegistries
 from elyra.pipeline.component import Component
 from elyra.pipeline.component import ComponentParser
-from elyra.pipeline.component_reader import ComponentReader
-from elyra.pipeline.component_reader import DirectoryComponentReader
-from elyra.pipeline.component_reader import FilesystemComponentReader
-from elyra.pipeline.component_reader import UrlComponentReader
 
 
 class ComponentRegistry(LoggingConfigurable):
@@ -209,7 +205,7 @@ class ComponentRegistry(LoggingConfigurable):
 
             # Assign reader based on the location type of the registry (file, directory, url)
             catalog_reader = entrypoints.get_group_named('elyra.component.catalog_types').get(registry_location_type)
-            reader = catalog_reader.load()(self._parser.file_types)
+            reader = catalog_reader.load()(registry_location_type, self._parser.file_types)
 
             # Get content of component definition file for each component in this registry
             hash_to_metadata = reader.read_component_definitions(registry['metadata'])
@@ -218,7 +214,6 @@ class ComponentRegistry(LoggingConfigurable):
                 component_entry = {
                     "component_id": component_hash,
                     "location_type": reader.catalog_type,
-                    # "location": component_metadata['metadata'].get('location'),
                     "categories": registry_categories,
                     "component_definition": component_metadata_dict.get('definition'),
                     "component_metadata": component_metadata_dict['metadata']

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -213,16 +213,16 @@ class ComponentRegistry(LoggingConfigurable):
 
             # Get content of component definition file for each component in this registry
             hash_to_metadata = reader.read_component_definitions(registry['metadata'])
-            for component_id, component_metadata in hash_to_metadata.items():
+            for component_hash, component_metadata_dict in hash_to_metadata.items():
 
                 component_entry = {
-                    "location_type": reader.rendering_type,
+                    "component_id": component_hash,
+                    "catalog_type": reader.catalog_type,
                     # "location": component_metadata['metadata'].get('location'),
                     "categories": registry_categories,
-                    "component_id": component_id,
-                    "component_definition": component_metadata.get('definition'),
-                    "component_metadata": component_metadata['metadata'],
-                    "reader": reader
+                    "component_definition": component_metadata_dict.get('definition'),
+                    "component_metadata": component_metadata_dict['metadata'],
+                    # "reader": reader
                 }
 
                 # Parse the component entry to get a fully qualified Component object
@@ -249,19 +249,3 @@ class ComponentRegistry(LoggingConfigurable):
             self.log.error(f"Could not access registries for processor: {self._parser._component_platform}")
 
         return runtime_registries
-
-    def _get_reader(self, registry_location_type: str, file_types: List[str]) -> ComponentReader:
-        """
-        Find the proper reader based on the given registry location type
-        """
-        readers = {
-            FilesystemComponentReader.location_type: FilesystemComponentReader(file_types),
-            DirectoryComponentReader.location_type: DirectoryComponentReader(file_types),
-            UrlComponentReader.location_type: UrlComponentReader(file_types)
-        }
-
-        reader = readers.get(registry_location_type)
-        if not reader:
-            raise ValueError(f"Unsupported registry type: '{registry_location_type}'")
-
-        return reader

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -204,7 +204,7 @@ class ComponentRegistry(LoggingConfigurable):
             try:
                 catalog_reader = entrypoints.get_group_named('elyra.component.catalog_types')\
                     .get(catalog.schema_name)\
-                    .load()(self._parser.file_types)
+                    .load()(self._parser.file_types, parent=self.parent)
             except Exception as e:
                 self.log.warning(f"Could not load appropriate ComponentCatalogConnector class: {e}")
                 raise RuntimeError(f"Could not load appropriate ComponentCatalogConnector class: {e}")

--- a/elyra/pipeline/kfp/component_parser_kfp.py
+++ b/elyra/pipeline/kfp/component_parser_kfp.py
@@ -49,7 +49,7 @@ class KfpComponentParser(ComponentParser):
             name=component_yaml.get('name'),
             description=description,
             catalog_type=registry_entry.catalog_type,
-            location=registry_entry.component_identifier.get('location'),
+            location=registry_entry.component_identifier,
             definition=registry_entry.component_definition,
             runtime=self.component_platform,
             categories=registry_entry.categories,

--- a/elyra/pipeline/kfp/component_parser_kfp.py
+++ b/elyra/pipeline/kfp/component_parser_kfp.py
@@ -49,7 +49,7 @@ class KfpComponentParser(ComponentParser):
             name=component_yaml.get('name'),
             description=description,
             catalog_type=registry_entry.catalog_type,
-            location=registry_entry.component_identifier,
+            source_identifier=registry_entry.component_identifier,
             definition=registry_entry.component_definition,
             runtime=self.component_platform,
             categories=registry_entry.categories,

--- a/elyra/pipeline/kfp/component_parser_kfp.py
+++ b/elyra/pipeline/kfp/component_parser_kfp.py
@@ -37,7 +37,7 @@ class KfpComponentParser(ComponentParser):
             return None
 
         # Assign component_id and description
-        component_id = self.get_component_id(registry_entry.location, component_yaml.get('name', ''))
+        # component_id = self.get_component_id(registry_entry.location, component_yaml.get('name', ''))
         description = ""
         if component_yaml.get('description'):
             # Remove whitespace characters and replace with spaces
@@ -45,14 +45,16 @@ class KfpComponentParser(ComponentParser):
 
         component_properties = self._parse_properties(component_yaml)
 
-        component = Component(id=component_id,
+        component = Component(id=registry_entry.component_id,
                               name=component_yaml.get('name'),
                               description=description,
                               runtime=self.component_platform,
                               location_type=registry_entry.location_type,
-                              location=registry_entry.location,
+                              location=registry_entry.component_metadata.get('location'),
                               properties=component_properties,
-                              categories=registry_entry.categories)
+                              categories=registry_entry.categories,
+                              metadata=registry_entry.component_metadata,
+                              reader=registry_entry.reader)
 
         return [component]
 

--- a/elyra/pipeline/kfp/component_parser_kfp.py
+++ b/elyra/pipeline/kfp/component_parser_kfp.py
@@ -53,8 +53,7 @@ class KfpComponentParser(ComponentParser):
                               location=registry_entry.component_metadata.get('location'),
                               properties=component_properties,
                               categories=registry_entry.categories,
-                              metadata=registry_entry.component_metadata,
-                              reader=registry_entry.reader)
+                              metadata=registry_entry.component_metadata)
 
         return [component]
 

--- a/elyra/pipeline/kfp/component_parser_kfp.py
+++ b/elyra/pipeline/kfp/component_parser_kfp.py
@@ -146,7 +146,7 @@ class KfpComponentParser(ComponentParser):
         try:
             return yaml.safe_load(registry_entry.component_definition)
         except Exception as e:
-            self.log.warning(f"Could not read definition for component at "
+            self.log.warning(f"Could not load YAML definition for component at "
                              f"location: '{registry_entry.component_metadata.get('location')}' -> {str(e)}")
             return None
 

--- a/elyra/pipeline/kfp/component_parser_kfp.py
+++ b/elyra/pipeline/kfp/component_parser_kfp.py
@@ -48,7 +48,7 @@ class KfpComponentParser(ComponentParser):
                               name=component_yaml.get('name'),
                               description=description,
                               runtime=self.component_platform,
-                              location_type=registry_entry.location_type,
+                              catalog_type=registry_entry.catalog_type,
                               location=registry_entry.component_metadata.get('location'),
                               properties=component_properties,
                               categories=registry_entry.categories,

--- a/elyra/pipeline/kfp/component_parser_kfp.py
+++ b/elyra/pipeline/kfp/component_parser_kfp.py
@@ -44,15 +44,17 @@ class KfpComponentParser(ComponentParser):
 
         component_properties = self._parse_properties(component_yaml)
 
-        component = Component(id=registry_entry.component_id,
-                              name=component_yaml.get('name'),
-                              description=description,
-                              runtime=self.component_platform,
-                              catalog_type=registry_entry.catalog_type,
-                              location=registry_entry.component_metadata.get('location'),
-                              properties=component_properties,
-                              categories=registry_entry.categories,
-                              metadata=registry_entry.component_metadata)
+        component = Component(
+            id=registry_entry.component_id,
+            name=component_yaml.get('name'),
+            description=description,
+            catalog_type=registry_entry.catalog_type,
+            location=registry_entry.component_identifier.get('location'),
+            definition=registry_entry.component_definition,
+            runtime=self.component_platform,
+            categories=registry_entry.categories,
+            properties=component_properties
+        )
 
         return [component]
 
@@ -113,14 +115,18 @@ class KfpComponentParser(ComponentParser):
                     # Add sentence to description to clarify that paraeter is an output
                     description = f"This is an output of this component. {description}"
 
-                properties.append(ComponentParameter(id=ref_name,
-                                                     name=display_name,
-                                                     data_type=data_type_info.data_type,
-                                                     value=(value or data_type_info.default_value),
-                                                     description=description,
-                                                     control=data_type_info.control,
-                                                     control_id=data_type_info.control_id,
-                                                     required=required))
+                properties.append(
+                    ComponentParameter(
+                        id=ref_name,
+                        name=display_name,
+                        data_type=data_type_info.data_type,
+                        value=(value or data_type_info.default_value),
+                        description=description,
+                        control=data_type_info.control,
+                        control_id=data_type_info.control_id,
+                        required=required
+                    )
+                )
         return properties
 
     def get_runtime_specific_properties(self) -> List[ComponentParameter]:
@@ -146,8 +152,8 @@ class KfpComponentParser(ComponentParser):
         try:
             return yaml.safe_load(registry_entry.component_definition)
         except Exception as e:
-            self.log.warning(f"Could not load YAML definition for component at "
-                             f"location: '{registry_entry.component_metadata.get('location')}' -> {str(e)}")
+            self.log.warning(f"Could not load YAML definition for component with identifying information: "
+                             f"'{str(registry_entry.component_identifier)}' -> {str(e)}")
             return None
 
     def _is_path_based_parameter(self, parameter_name: str, component_body: Dict[str, Any]) -> bool:

--- a/elyra/pipeline/kfp/component_parser_kfp.py
+++ b/elyra/pipeline/kfp/component_parser_kfp.py
@@ -37,7 +37,6 @@ class KfpComponentParser(ComponentParser):
             return None
 
         # Assign component_id and description
-        # component_id = self.get_component_id(registry_entry.location, component_yaml.get('name', ''))
         description = ""
         if component_yaml.get('description'):
             # Remove whitespace characters and replace with spaces
@@ -148,7 +147,7 @@ class KfpComponentParser(ComponentParser):
             return yaml.safe_load(registry_entry.component_definition)
         except Exception as e:
             self.log.warning(f"Could not read definition for component at "
-                             f"location: '{registry_entry.location}' -> {str(e)}")
+                             f"location: '{registry_entry.component_metadata.get('location')}' -> {str(e)}")
             return None
 
     def _is_path_based_parameter(self, parameter_name: str, component_body: Dict[str, Any]) -> bool:

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -627,13 +627,12 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                         processed_value = self._process_list_value(property_value)
                         operation.component_params[component_property.ref] = processed_value
 
-                # TODO Figure out best way to handle getting component details again
-                # TODO Add comment
-                reader = entrypoints.get_single('elyra.component.catalog_types', component.catalog_type)
-                component_source = reader.get_component_source_kwargs(component)
-
                 # Build component task factory
                 try:
+                    # TODO Add comment
+                    reader = entrypoints.get_single('elyra.component.catalog_types', component.location_type)
+                    component_source = reader.get_component_source_kwargs(component)
+
                     factory_function = components.load_component(**component_source)
                 except Exception as e:
                     # TODO Fix error messaging and break exceptions down into categories

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -25,7 +25,6 @@ from urllib.parse import urlsplit
 import autopep8
 from jinja2 import Environment
 from jinja2 import PackageLoader
-from jupyter_core.paths import ENV_JUPYTER_PATH
 from kfp import Client as ArgoClient
 from kfp import compiler as kfp_argo_compiler
 from kfp import components as components
@@ -627,12 +626,13 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                         processed_value = self._process_list_value(property_value)
                         operation.component_params[component_property.ref] = processed_value
 
-                # Get absolute path to the location of the component definition
-                component_path = component.location
-                if component.location_type == "filename":
-                    component_path = os.path.join(ENV_JUPYTER_PATH[0], 'components', component_path)
-
-                component_source = {component.location_type: component_path}
+                # TODO Figure out best way to handle getting component details again
+                if component.location:
+                    component_source = {component.location_type: component.location}
+                else:
+                    reader = component.reader
+                    component_metadata = list(reader.read_component_definition((component.id, component.metadata), {}).values())[0]
+                    component_source = {'text': component_metadata['definition']}
 
                 # Build component task factory
                 try:

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -629,8 +629,9 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
 
                 # Build component task factory
                 try:
-                    # TODO Add comment
-                    reader = entrypoints.get_single('elyra.component.catalog_types', component.location_type)
+                    # Get the reader class associated with this component and construct the appropriate kwargs
+                    catalog_reader = entrypoints.get_single('elyra.component.catalog_types', component.location_type)
+                    reader = catalog_reader.load()(component.location_type, self.component_parser.file_types)
                     component_source = reader.get_component_source_kwargs(component)
 
                     factory_function = components.load_component(**component_source)

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -628,14 +628,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
 
                 # Build component task factory
                 try:
-                    # Get the reader class associated with this component and construct the appropriate kwargs
-                    # catalog_reader = entrypoints.get_single('elyra.component.catalog_types', component.catalog_type)
-                    # reader = catalog_reader.load()(component.catalog_type, self.component_parser.file_types)
-                    # component_source = reader.get_component_source_kwargs(component)
-
-                    component_source = {'text': component.definition}
-
-                    factory_function = components.load_component(**component_source)
+                    factory_function = components.load_component_from_text(component.definition)
                 except Exception as e:
                     # TODO Fix error messaging and break exceptions down into categories
                     self.log.error(f"Error loading component spec for {operation.name}: {str(e)}")

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -630,8 +630,8 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                 # Build component task factory
                 try:
                     # Get the reader class associated with this component and construct the appropriate kwargs
-                    catalog_reader = entrypoints.get_single('elyra.component.catalog_types', component.location_type)
-                    reader = catalog_reader.load()(component.location_type, self.component_parser.file_types)
+                    catalog_reader = entrypoints.get_single('elyra.component.catalog_types', component.catalog_type)
+                    reader = catalog_reader.load()(component.catalog_type, self.component_parser.file_types)
                     component_source = reader.get_component_source_kwargs(component)
 
                     factory_function = components.load_component(**component_source)

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -23,7 +23,6 @@ from typing import Dict
 from urllib.parse import urlsplit
 
 import autopep8
-import entrypoints
 from jinja2 import Environment
 from jinja2 import PackageLoader
 from kfp import Client as ArgoClient
@@ -630,9 +629,11 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                 # Build component task factory
                 try:
                     # Get the reader class associated with this component and construct the appropriate kwargs
-                    catalog_reader = entrypoints.get_single('elyra.component.catalog_types', component.catalog_type)
-                    reader = catalog_reader.load()(component.catalog_type, self.component_parser.file_types)
-                    component_source = reader.get_component_source_kwargs(component)
+                    # catalog_reader = entrypoints.get_single('elyra.component.catalog_types', component.catalog_type)
+                    # reader = catalog_reader.load()(component.catalog_type, self.component_parser.file_types)
+                    # component_source = reader.get_component_source_kwargs(component)
+
+                    component_source = {'text': component.definition}
 
                     factory_function = components.load_component(**component_source)
                 except Exception as e:

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -23,6 +23,7 @@ from typing import Dict
 from urllib.parse import urlsplit
 
 import autopep8
+import entrypoints
 from jinja2 import Environment
 from jinja2 import PackageLoader
 from kfp import Client as ArgoClient
@@ -627,12 +628,9 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                         operation.component_params[component_property.ref] = processed_value
 
                 # TODO Figure out best way to handle getting component details again
-                if component.location:
-                    component_source = {component.location_type: component.location}
-                else:
-                    reader = component.reader
-                    component_metadata = list(reader.read_component_definition((component.id, component.metadata), {}).values())[0]
-                    component_source = {'text': component_metadata['definition']}
+                # TODO Add comment
+                reader = entrypoints.get_single('elyra.component.catalog_types', component.catalog_type)
+                component_source = reader.get_component_source_kwargs(component)
 
                 # Build component task factory
                 try:

--- a/elyra/pipeline/pipeline_definition.py
+++ b/elyra/pipeline/pipeline_definition.py
@@ -21,7 +21,7 @@ from typing import List
 from typing import Optional
 
 
-class AppDataBase:  # ABC
+class AppDataBase(object):  # ABC
     """
     An abstraction for app_data based nodes
     """

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -312,7 +312,7 @@ class RuntimePipelineProcessor(PipelineProcessor):
         super().__init__(root_dir, **kwargs)
 
         self._component_parser = component_parser
-        self._component_registry = ComponentRegistry(component_parser)
+        self._component_registry = ComponentRegistry(component_parser, parent=self.parent)
 
     def _get_dependency_archive_name(self, operation):
         artifact_name = os.path.basename(operation.filename)

--- a/elyra/templates/airflow/airflow_template.jinja2
+++ b/elyra/templates/airflow/airflow_template.jinja2
@@ -44,7 +44,7 @@ from airflow.operators.{{operation.module_name}} import {{ operation.class_name 
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 {% endif %}
 
-# Operator source: {{ operation.operator_source }}{% if not operation.is_generic_operator %}
+{% if operation.operator_source %}# Operator source: {{ operation.operator_source }}{% if not operation.is_generic_operator %}{% endif %}
 op_{{ operation.id|regex_replace }} = {{ operation.class_name }}(
                                                            task_id='{{ operation.notebook|regex_replace }}',
         {% for param, value in operation.component_params.items() %}

--- a/elyra/templates/airflow/airflow_template.jinja2
+++ b/elyra/templates/airflow/airflow_template.jinja2
@@ -42,7 +42,7 @@ env_var_secret_key = Secret(deploy_type='env',
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 {% endif %}
 
-{% if operation.operator_source %}# Operator source: {{ operation.operator_source }}{% if not operation.is_generic_operator %}{% endif %}
+{% if operation.operator_source %}# Operator source: {{ operation.operator_source }}{% endif %}{% if not operation.is_generic_operator %}
 op_{{ operation.id|regex_replace }} = {{ operation.class_name }}(
                                                            task_id='{{ operation.notebook|regex_replace }}',
         {% for param, value in operation.component_params.items() %}

--- a/elyra/templates/airflow/airflow_template.jinja2
+++ b/elyra/templates/airflow/airflow_template.jinja2
@@ -35,11 +35,9 @@ env_var_secret_key = Secret(deploy_type='env',
 {% for key, operation in operations_list.items() %}
 
 {% if not operation.is_generic_operator %}
-{% if operation.is_contrib_operator %}
-from airflow.contrib.operators.{{operation.module_name}} import {{ operation.class_name }}
-{% else %}
-from airflow.operators.{{operation.module_name}} import {{ operation.class_name }}
-{% endif %}
+{% for import_statement in operation.imports %}
+{{import_statement}}
+{% endfor %}
 {% else %}
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 {% endif %}

--- a/elyra/templates/components/canvas_properties_template.jinja2
+++ b/elyra/templates/components/canvas_properties_template.jinja2
@@ -13,7 +13,7 @@
       "elyra_{{ property.ref }}": "{{ property.value }}"
     {% endif %},
 {% endfor %}
-      "component_source": "{{ component.source_identifier }}"
+      "component_source": "{{ component.component_source }}"
     },
     "parameters": [
       {% if component.description %}{
@@ -97,7 +97,7 @@
             "default": "Component Source"
           },
           "description": {
-            "default": "Unique information used to identify this component for catalog type '{{component.catalog_type}}'",
+            "default": "Unique information used to identify this component.",
             "placement": "on_panel"
           },
           "data": {}

--- a/elyra/templates/components/canvas_properties_template.jinja2
+++ b/elyra/templates/components/canvas_properties_template.jinja2
@@ -13,7 +13,7 @@
       "elyra_{{ property.ref }}": "{{ property.value }}"
     {% endif %},
 {% endfor %}
-      "component_source": "{{ component.location }}"
+      "component_source": "{{ component.source_identifier }}"
     },
     "parameters": [
       {% if component.description %}{
@@ -97,7 +97,7 @@
             "default": "Component Source"
           },
           "description": {
-            "default": "The path to the component specification file.",
+            "default": "Unique information used to identify this component for catalog type '{{component.catalog_type}}''",
             "placement": "on_panel"
           },
           "data": {}

--- a/elyra/templates/components/canvas_properties_template.jinja2
+++ b/elyra/templates/components/canvas_properties_template.jinja2
@@ -97,7 +97,7 @@
             "default": "Component Source"
           },
           "description": {
-            "default": "Unique information used to identify this component for catalog type '{{component.catalog_type}}''",
+            "default": "Unique information used to identify this component for catalog type '{{component.catalog_type}}'",
             "placement": "on_panel"
           },
           "data": {}

--- a/elyra/tests/cli/resources/kfp_3_node_custom.pipeline
+++ b/elyra/tests/cli/resources/kfp_3_node_custom.pipeline
@@ -11,7 +11,7 @@
         {
           "id": "151538a2-4279-49a4-8742-c3ed50c31b2d",
           "type": "execution_node",
-          "op": "component_Calculatedatahash",
+          "op": "url-catalog:4fc759382b1b",
           "app_data": {
             "component_parameters": {
               "hash_algorithm": "SHA256",
@@ -68,7 +68,7 @@
         {
           "id": "321b18d9-1585-4a08-9ca7-9128ee3df527",
           "type": "execution_node",
-          "op": "component_Downloaddata",
+          "op": "url-catalog:c6c0588048ae",
           "app_data": {
             "component_parameters": {
               "url": "https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/metadata/error.py",
@@ -115,7 +115,7 @@
         {
           "id": "b7d9fe00-2a2d-4bd8-8fc4-73a9d8917052",
           "type": "execution_node",
-          "op": "filter_text_using_shell_and_grep_Filtertext",
+          "op": "local-directory-catalog:737915b826e9",
           "app_data": {
             "component_parameters": {
               "component_description": "Filter input text according to the given regex pattern using shell and grep.",

--- a/elyra/tests/metadata/test_handlers.py
+++ b/elyra/tests/metadata/test_handlers.py
@@ -135,7 +135,7 @@ async def test_create_instance(jp_base_url, jp_fetch):
                                                       METADATA_TEST_SCHEMASPACE_ID, 'valid')
     metadata = json.loads(r.body.decode())
     # Add expected "extra" fields to 'valid' so whole-object comparison is satisfied.
-    # These are added during the pre_save(), post_save() and post_load() hooks on the
+    # These are added during the pre_save(), post_save() and on_load() hooks on the
     # MockMetadataTest class instance or when default values for missing properties are applied.
     valid['pre_property'] = valid['metadata']['required_test']
     valid['post_property'] = valid['display_name']

--- a/elyra/tests/metadata/test_utils.py
+++ b/elyra/tests/metadata/test_utils.py
@@ -330,8 +330,8 @@ class MockMetadataTest(Metadata):
             d['post_property'] = self.post_property
         return d
 
-    def post_load(self, **kwargs: Any) -> None:
-        super().post_load(**kwargs)
+    def on_load(self, **kwargs: Any) -> None:
+        super().on_load(**kwargs)
         self.post_property = self.display_name
 
     def pre_save(self, **kwargs: Any) -> None:

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -23,8 +23,8 @@ from elyra.metadata.manager import MetadataManager
 from elyra.metadata.metadata import Metadata
 from elyra.metadata.schemaspaces import ComponentRegistries
 from elyra.pipeline.airflow.component_parser_airflow import AirflowComponentParser
-from elyra.pipeline.component_reader import FilesystemComponentCatalogConnector
-from elyra.pipeline.component_reader import UrlComponentCatalogConnector
+from elyra.pipeline.catalog_connector import FilesystemComponentCatalogConnector
+from elyra.pipeline.catalog_connector import UrlComponentCatalogConnector
 from elyra.pipeline.component_registry import ComponentRegistry
 
 COMPONENT_CATALOG_DIRECTORY = os.path.join(jupyter_core.paths.ENV_JUPYTER_PATH[0], 'components')
@@ -63,17 +63,16 @@ def test_modify_component_registries():
     metadata_manager = MetadataManager(schemaspace=ComponentRegistries.COMPONENT_REGISTRIES_SCHEMASPACE_ID)
 
     # Create new registry instance with a single URL-based component
-    paths = ["https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/tests/pipeline/resources/components/"
-             "airflow_test_operator.py"]
+    urls = ["https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/tests/pipeline/resources/components/"
+            "airflow_test_operator.py"]
 
     instance_metadata = {
         "description": "A test registry",
         "runtime": "airflow",
         "categories": ["New Components"],
-        "catalog_type": "URL",
-        "paths": paths
+        "paths": urls
     }
-    registry_instance = Metadata(schema_name="component-registry",
+    registry_instance = Metadata(schema_name="url-catalog",
                                  name="new_registry",
                                  display_name="New Registry",
                                  metadata=instance_metadata)
@@ -96,8 +95,8 @@ def test_modify_component_registries():
     assert 'TestOperatorNoInputs' not in added_component_names
 
     # Modify the test registry to add an additional path to
-    paths.append("https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/tests/pipeline/resources/components"
-                 "/airflow_test_operator_no_inputs.py")
+    urls.append("https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/tests/pipeline/resources/components"
+                "/airflow_test_operator_no_inputs.py")
     metadata_manager.update("new_registry", registry_instance)
 
     # Get set of components from all active registries, including modified test registry
@@ -140,10 +139,9 @@ def test_directory_based_component_registry():
         "description": "A test registry",
         "runtime": "airflow",
         "categories": ["New Components"],
-        "catalog_type": "Directory",
         "paths": [registry_path]
     }
-    registry_instance = Metadata(schema_name="component-registry",
+    registry_instance = Metadata(schema_name="local-directory-catalog",
                                  name="new_registry",
                                  display_name="New Registry",
                                  metadata=instance_metadata)
@@ -178,14 +176,15 @@ def test_parse_airflow_component_file():
 
     # Read contents of given path -- read_component_definition() returns a
     # a dictionary of component definition content indexed by path
-    component_definition = reader.read_component_definition(path, {})[path]
+    component_definition = reader.read_catalog_entry({"path": path}, {})
 
     # Build entry for parsing
     entry = {
-        "catalog_type": reader.resource_type,
-        "location": path,
+        "component_id": reader.get_unique_component_hash('local-file-catalog', {"path": path}, ["path"]),
+        "catalog_type": "local-file-catalog",
         "categories": ["Test"],
-        "component_definition": component_definition
+        "component_definition": component_definition,
+        "component_identifier": {"path": path}
     }
     component_entry = SimpleNamespace(**entry)
 
@@ -196,7 +195,7 @@ def test_parse_airflow_component_file():
 
     # Ensure component parameters are prefixed (and system parameters are not), and hold correct values
     assert properties_json['current_parameters']['label'] == ''
-    assert properties_json['current_parameters']['component_source'] == component_entry.location
+    assert properties_json['current_parameters']['component_source'] == str(component_entry.component_identifier)
     assert properties_json['current_parameters']['elyra_test_string_no_default'] == ''
     assert properties_json['current_parameters']['elyra_test_string_default_value'] == 'default'
     assert properties_json['current_parameters']['elyra_test_string_default_empty'] == ''
@@ -242,18 +241,19 @@ def test_parse_airflow_component_url():
     airflow_supported_file_types = [".py"]
     reader = UrlComponentCatalogConnector(airflow_supported_file_types)
 
-    path = 'https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/bash_operator.py'  # noqa: E501
+    url = 'https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/bash_operator.py'  # noqa: E501
 
     # Read contents of given path -- read_component_definition() returns a
     # a dictionary of component definition content indexed by path
-    component_definition = reader.read_component_definition(path, {})[path]
+    component_definition = reader.read_catalog_entry({"url": url}, {})
 
     # Build entry for parsing
     entry = {
-        "catalog_type": reader.resource_type,
-        "location": path,
+        "component_id": reader.get_unique_component_hash('local-file-catalog', {"url": url}, ["url"]),
+        "catalog_type": "url-catalog",
         "categories": ["Test"],
-        "component_definition": component_definition
+        "component_definition": component_definition,
+        "component_identifier": {"url": url}
     }
     component_entry = SimpleNamespace(**entry)
 
@@ -264,7 +264,7 @@ def test_parse_airflow_component_url():
 
     # Ensure component parameters are prefixed, and system parameters are not, and hold correct values
     assert properties_json['current_parameters']['label'] == ''
-    assert properties_json['current_parameters']['component_source'] == component_entry.location
+    assert properties_json['current_parameters']['component_source'] == str(component_entry.component_identifier)
     assert properties_json['current_parameters']['elyra_bash_command'] == ''
     assert properties_json['current_parameters']['elyra_xcom_push'] is False
     assert properties_json['current_parameters']['elyra_env'] == ''  # {}
@@ -280,14 +280,15 @@ def test_parse_airflow_component_file_no_inputs():
 
     # Read contents of given path -- read_component_definition() returns a
     # a dictionary of component definition content indexed by path
-    component_definition = reader.read_component_definition(path, {})[path]
+    component_definition = reader.read_catalog_entry({"path": path}, {})
 
     # Build entry for parsing
     entry = {
-        "catalog_type": reader.resource_type,
-        "location": path,
+        "component_id": reader.get_unique_component_hash('local-file-catalog', {"path": path}, ["path"]),
+        "catalog_type": "local-file-catalog",
         "categories": ["Test"],
-        "component_definition": component_definition
+        "component_definition": component_definition,
+        "component_identifier": {"path": path}
     }
     component_entry = SimpleNamespace(**entry)
 
@@ -306,7 +307,7 @@ def test_parse_airflow_component_file_no_inputs():
 
     # Ensure that template still renders the two common parameters correctly
     assert properties_json['current_parameters']['label'] == ""
-    assert properties_json['current_parameters']['component_source'] == component_entry.location
+    assert properties_json['current_parameters']['component_source'] == str(component_entry.component_identifier)
 
 
 @pytest.mark.parametrize('invalid_url', [
@@ -320,19 +321,5 @@ async def test_parse_components_invalid_url(invalid_url):
     reader = UrlComponentCatalogConnector(airflow_supported_file_types)
 
     # Get path to an invalid component definition file and read contents
-    component_definition = reader.read_component_definition(invalid_url, {})
-    assert component_definition == {}
-
-    # Build entry for parsing
-    entry = {
-        "catalog_type": reader.resource_type,
-        "location": invalid_url,
-        "categories": ["Test"],
-        "component_definition": component_definition
-    }
-    component_entry = SimpleNamespace(**entry)
-
-    # Parse the component entry
-    parser = AirflowComponentParser()
-    component = parser.parse(component_entry)
-    assert component is None
+    component_definition = reader.read_catalog_entry({"url": invalid_url}, {})
+    assert component_definition is None

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -23,8 +23,8 @@ from elyra.metadata.manager import MetadataManager
 from elyra.metadata.metadata import Metadata
 from elyra.metadata.schemaspaces import ComponentRegistries
 from elyra.pipeline.airflow.component_parser_airflow import AirflowComponentParser
-from elyra.pipeline.component import FilesystemComponentReader
-from elyra.pipeline.component import UrlComponentReader
+from elyra.pipeline.component import FilesystemComponentCatalogConnector
+from elyra.pipeline.component import UrlComponentCatalogConnector
 from elyra.pipeline.component_registry import ComponentRegistry
 
 COMPONENT_CATALOG_DIRECTORY = os.path.join(jupyter_core.paths.ENV_JUPYTER_PATH[0], 'components')
@@ -172,7 +172,7 @@ def test_directory_based_component_registry():
 def test_parse_airflow_component_file():
     # Define the appropriate reader for a filesystem-type component definition
     airflow_supported_file_types = [".py"]
-    reader = FilesystemComponentReader(airflow_supported_file_types)
+    reader = FilesystemComponentCatalogConnector(airflow_supported_file_types)
 
     path = _get_resource_path('airflow_test_operator.py')
 
@@ -240,7 +240,7 @@ def test_parse_airflow_component_file():
 def test_parse_airflow_component_url():
     # Define the appropriate reader for a Url-type component definition
     airflow_supported_file_types = [".py"]
-    reader = UrlComponentReader(airflow_supported_file_types)
+    reader = UrlComponentCatalogConnector(airflow_supported_file_types)
 
     path = 'https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/bash_operator.py'  # noqa: E501
 
@@ -274,7 +274,7 @@ def test_parse_airflow_component_url():
 def test_parse_airflow_component_file_no_inputs():
     # Define the appropriate reader for a filesystem-type component definition
     airflow_supported_file_types = [".py"]
-    reader = FilesystemComponentReader(airflow_supported_file_types)
+    reader = FilesystemComponentCatalogConnector(airflow_supported_file_types)
 
     path = _get_resource_path('airflow_test_operator_no_inputs.py')
 
@@ -317,7 +317,7 @@ def test_parse_airflow_component_file_no_inputs():
 async def test_parse_components_invalid_url(invalid_url):
     # Define the appropriate reader for a Url-type component definition
     airflow_supported_file_types = [".py"]
-    reader = UrlComponentReader(airflow_supported_file_types)
+    reader = UrlComponentCatalogConnector(airflow_supported_file_types)
 
     # Get path to an invalid component definition file and read contents
     component_definition = reader.read_component_definition(invalid_url, {})

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -70,7 +70,7 @@ def test_modify_component_registries():
         "description": "A test registry",
         "runtime": "airflow",
         "categories": ["New Components"],
-        "location_type": "URL",
+        "catalog_type": "URL",
         "paths": paths
     }
     registry_instance = Metadata(schema_name="component-registry",
@@ -140,7 +140,7 @@ def test_directory_based_component_registry():
         "description": "A test registry",
         "runtime": "airflow",
         "categories": ["New Components"],
-        "location_type": "Directory",
+        "catalog_type": "Directory",
         "paths": [registry_path]
     }
     registry_instance = Metadata(schema_name="component-registry",
@@ -182,7 +182,7 @@ def test_parse_airflow_component_file():
 
     # Build entry for parsing
     entry = {
-        "location_type": reader.resource_type,
+        "catalog_type": reader.resource_type,
         "location": path,
         "categories": ["Test"],
         "component_definition": component_definition
@@ -250,7 +250,7 @@ def test_parse_airflow_component_url():
 
     # Build entry for parsing
     entry = {
-        "location_type": reader.resource_type,
+        "catalog_type": reader.resource_type,
         "location": path,
         "categories": ["Test"],
         "component_definition": component_definition
@@ -284,7 +284,7 @@ def test_parse_airflow_component_file_no_inputs():
 
     # Build entry for parsing
     entry = {
-        "location_type": reader.resource_type,
+        "catalog_type": reader.resource_type,
         "location": path,
         "categories": ["Test"],
         "component_definition": component_definition
@@ -325,7 +325,7 @@ async def test_parse_components_invalid_url(invalid_url):
 
     # Build entry for parsing
     entry = {
-        "location_type": reader.resource_type,
+        "catalog_type": reader.resource_type,
         "location": invalid_url,
         "categories": ["Test"],
         "component_definition": component_definition

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -179,9 +179,10 @@ def test_parse_airflow_component_file():
     component_definition = reader.read_catalog_entry({"path": path}, {})
 
     # Build entry for parsing
+    catalog_type = "local-file-catalog"
     entry = {
-        "component_id": reader.get_unique_component_hash('local-file-catalog', {"path": path}, ["path"]),
-        "catalog_type": "local-file-catalog",
+        "component_id": reader.get_unique_component_hash(catalog_type, {"path": path}, ["path"]),
+        "catalog_type": catalog_type,
         "categories": ["Test"],
         "component_definition": component_definition,
         "component_identifier": {"path": path}
@@ -195,7 +196,9 @@ def test_parse_airflow_component_file():
 
     # Ensure component parameters are prefixed (and system parameters are not), and hold correct values
     assert properties_json['current_parameters']['label'] == ''
-    assert properties_json['current_parameters']['component_source'] == str(component_entry.component_identifier)
+
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.component_identifier})
+    assert properties_json['current_parameters']['component_source'] == component_source
     assert properties_json['current_parameters']['elyra_test_string_no_default'] == ''
     assert properties_json['current_parameters']['elyra_test_string_default_value'] == 'default'
     assert properties_json['current_parameters']['elyra_test_string_default_empty'] == ''
@@ -248,9 +251,10 @@ def test_parse_airflow_component_url():
     component_definition = reader.read_catalog_entry({"url": url}, {})
 
     # Build entry for parsing
+    catalog_type = "url-catalog"
     entry = {
-        "component_id": reader.get_unique_component_hash('local-file-catalog', {"url": url}, ["url"]),
-        "catalog_type": "url-catalog",
+        "component_id": reader.get_unique_component_hash(catalog_type, {"url": url}, ["url"]),
+        "catalog_type": catalog_type,
         "categories": ["Test"],
         "component_definition": component_definition,
         "component_identifier": {"url": url}
@@ -264,7 +268,9 @@ def test_parse_airflow_component_url():
 
     # Ensure component parameters are prefixed, and system parameters are not, and hold correct values
     assert properties_json['current_parameters']['label'] == ''
-    assert properties_json['current_parameters']['component_source'] == str(component_entry.component_identifier)
+
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.component_identifier})
+    assert properties_json['current_parameters']['component_source'] == component_source
     assert properties_json['current_parameters']['elyra_bash_command'] == ''
     assert properties_json['current_parameters']['elyra_xcom_push'] is False
     assert properties_json['current_parameters']['elyra_env'] == ''  # {}
@@ -283,9 +289,10 @@ def test_parse_airflow_component_file_no_inputs():
     component_definition = reader.read_catalog_entry({"path": path}, {})
 
     # Build entry for parsing
+    catalog_type = "local-file-catalog"
     entry = {
-        "component_id": reader.get_unique_component_hash('local-file-catalog', {"path": path}, ["path"]),
-        "catalog_type": "local-file-catalog",
+        "component_id": reader.get_unique_component_hash(catalog_type, {"path": path}, ["path"]),
+        "catalog_type": catalog_type,
         "categories": ["Test"],
         "component_definition": component_definition,
         "component_identifier": {"path": path}
@@ -307,7 +314,9 @@ def test_parse_airflow_component_file_no_inputs():
 
     # Ensure that template still renders the two common parameters correctly
     assert properties_json['current_parameters']['label'] == ""
-    assert properties_json['current_parameters']['component_source'] == str(component_entry.component_identifier)
+
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.component_identifier})
+    assert properties_json['current_parameters']['component_source'] == component_source
 
 
 @pytest.mark.parametrize('invalid_url', [

--- a/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
@@ -170,9 +170,10 @@ def test_parse_kfp_component_file():
     component_definition = reader.read_catalog_entry({"path": path}, {})
 
     # Build entry for parsing
+    catalog_type = "local-file-catalog"
     entry = {
-        "component_id": reader.get_unique_component_hash('local-file-catalog', {"path": path}, ["path"]),
-        "catalog_type": "local-file-catalog",
+        "component_id": reader.get_unique_component_hash(catalog_type, {"path": path}, ["path"]),
+        "catalog_type": catalog_type,
         "categories": ["Test"],
         "component_definition": component_definition,
         "component_identifier": {"path": path}
@@ -186,7 +187,9 @@ def test_parse_kfp_component_file():
 
     # Ensure component parameters are prefixed (and system parameters are not) and all hold correct values
     assert properties_json['current_parameters']['label'] == ''
-    assert properties_json['current_parameters']['component_source'] == str(component_entry.component_identifier)
+
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.component_identifier})
+    assert properties_json['current_parameters']['component_source'] == component_source
     assert properties_json['current_parameters']['elyra_test_string_no_default'] == ''
     assert properties_json['current_parameters']['elyra_test_string_default_value'] == 'default'
     assert properties_json['current_parameters']['elyra_test_string_default_empty'] == ''
@@ -259,9 +262,10 @@ def test_parse_kfp_component_url():
     component_definition = reader.read_catalog_entry({"url": url}, {})
 
     # Build entry for parsing
+    catalog_type = "url-catalog"
     entry = {
-        "component_id": reader.get_unique_component_hash('local-file-catalog', {"url": url}, ["url"]),
-        "catalog_type": "url-catalog",
+        "component_id": reader.get_unique_component_hash(catalog_type, {"url": url}, ["url"]),
+        "catalog_type": catalog_type,
         "categories": ["Test"],
         "component_definition": component_definition,
         "component_identifier": {"url": url}
@@ -275,7 +279,9 @@ def test_parse_kfp_component_url():
 
     # Ensure component parameters are prefixed (and system parameters are not) and all hold correct values
     assert properties_json['current_parameters']['label'] == ''
-    assert properties_json['current_parameters']['component_source'] == str(component_entry.component_identifier)
+
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.component_identifier})
+    assert properties_json['current_parameters']['component_source'] == component_source
     assert properties_json['current_parameters']['elyra_notebook'] == 'None'   # Default value for type `inputpath`
     assert properties_json['current_parameters']['elyra_parameters'] == '{}'
     assert properties_json['current_parameters']['elyra_packages_to_install'] == ''  # {}
@@ -294,9 +300,10 @@ def test_parse_kfp_component_file_no_inputs():
     component_definition = reader.read_catalog_entry({"path": path}, {})
 
     # Build entry for parsing
+    catalog_type = "local-file-catalog"
     entry = {
-        "component_id": reader.get_unique_component_hash('local-file-catalog', {"path": path}, ["path"]),
-        "catalog_type": "local-file-catalog",
+        "component_id": reader.get_unique_component_hash(catalog_type, {"path": path}, ["path"]),
+        "catalog_type": catalog_type,
         "categories": ["Test"],
         "component_definition": component_definition,
         "component_identifier": {"path": path}
@@ -320,7 +327,9 @@ def test_parse_kfp_component_file_no_inputs():
 
     # Ensure that template still renders the two common parameters correctly
     assert properties_json['current_parameters']['label'] == ""
-    assert properties_json['current_parameters']['component_source'] == str(component_entry.component_identifier)
+
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.component_identifier})
+    assert properties_json['current_parameters']['component_source'] == component_source
 
 
 async def test_parse_components_invalid_file():

--- a/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
@@ -21,8 +21,8 @@ import jupyter_core.paths
 from elyra.metadata.manager import MetadataManager
 from elyra.metadata.metadata import Metadata
 from elyra.metadata.schemaspaces import ComponentRegistries
-from elyra.pipeline.component import FilesystemComponentReader
-from elyra.pipeline.component import UrlComponentReader
+from elyra.pipeline.component import FilesystemComponentCatalogConnector
+from elyra.pipeline.component import UrlComponentCatalogConnector
 from elyra.pipeline.component_registry import ComponentRegistry
 from elyra.pipeline.kfp.component_parser_kfp import KfpComponentParser
 
@@ -163,7 +163,7 @@ def test_directory_based_component_registry():
 def test_parse_kfp_component_file():
     # Define the appropriate reader for a filesystem-type component definition
     kfp_supported_file_types = [".yaml"]
-    reader = FilesystemComponentReader(kfp_supported_file_types)
+    reader = FilesystemComponentCatalogConnector(kfp_supported_file_types)
 
     path = _get_resource_path('kfp_test_operator.yaml')
 
@@ -251,7 +251,7 @@ def test_parse_kfp_component_file():
 def test_parse_kfp_component_url():
     # Define the appropriate reader for a URL-type component definition
     kfp_supported_file_types = [".yaml"]
-    reader = UrlComponentReader(kfp_supported_file_types)
+    reader = UrlComponentCatalogConnector(kfp_supported_file_types)
 
     path = 'https://raw.githubusercontent.com/kubeflow/pipelines/1.4.1/components/notebooks/Run_notebook_using_papermill/component.yaml'  # noqa: E501
 
@@ -285,7 +285,7 @@ def test_parse_kfp_component_url():
 def test_parse_kfp_component_file_no_inputs():
     # Define the appropriate reader for a filesystem-type component definition
     kfp_supported_file_types = [".yaml"]
-    reader = FilesystemComponentReader(kfp_supported_file_types)
+    reader = FilesystemComponentCatalogConnector(kfp_supported_file_types)
 
     path = _get_resource_path('kfp_test_operator_no_inputs.yaml')
 
@@ -325,7 +325,7 @@ def test_parse_kfp_component_file_no_inputs():
 async def test_parse_components_invalid_file():
     # Define the appropriate reader for a filesystem-type component definition
     kfp_supported_file_types = [".yaml"]
-    reader = FilesystemComponentReader(kfp_supported_file_types)
+    reader = FilesystemComponentCatalogConnector(kfp_supported_file_types)
 
     # Get path to an invalid component definition file and read contents
     path = _get_resource_path('kfp_test_operator_invalid.yaml')

--- a/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
@@ -63,7 +63,7 @@ def test_modify_component_registries():
         "description": "A test registry",
         "runtime": "kfp",
         "categories": ["New Components"],
-        "location_type": "Filename",
+        "catalog_type": "Filename",
         "paths": paths
     }
     registry_instance = Metadata(schema_name="component-registry",
@@ -130,7 +130,7 @@ def test_directory_based_component_registry():
         "description": "A test registry",
         "runtime": "kfp",
         "categories": ["New Components"],
-        "location_type": "Directory",
+        "catalog_type": "Directory",
         "paths": [registry_path]
     }
     registry_instance = Metadata(schema_name="component-registry",
@@ -173,7 +173,7 @@ def test_parse_kfp_component_file():
 
     # Build entry for parsing
     entry = {
-        "location_type": reader.resource_type,
+        "catalog_type": reader.resource_type,
         "location": path,
         "categories": ["Test"],
         "component_definition": component_definition
@@ -261,7 +261,7 @@ def test_parse_kfp_component_url():
 
     # Build entry for parsing
     entry = {
-        "location_type": reader.resource_type,
+        "catalog_type": reader.resource_type,
         "location": path,
         "categories": ["Test"],
         "component_definition": component_definition
@@ -295,7 +295,7 @@ def test_parse_kfp_component_file_no_inputs():
 
     # Build entry for parsing
     entry = {
-        "location_type": reader.resource_type,
+        "catalog_type": reader.resource_type,
         "location": path,
         "categories": ["Test"],
         "component_definition": component_definition
@@ -334,7 +334,7 @@ async def test_parse_components_invalid_file():
 
     # Build entry for parsing
     entry = {
-        "location_type": reader.resource_type,
+        "catalog_type": reader.resource_type,
         "location": path,
         "categories": ["Test"],
         "component_definition": component_definition

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -282,7 +282,7 @@ def test_processing_url_runtime_specific_component(monkeypatch, processor, sampl
                           name="Filter text",
                           description="",
                           op="filter-text",
-                          location_type="url",
+                          catalog_type="url",
                           location=url,
                           properties=[],
                           categories=[])
@@ -352,7 +352,7 @@ def test_processing_filename_runtime_specific_component(monkeypatch, processor, 
                           name="Filter text",
                           description="",
                           op="filter-text",
-                          location_type="filename",
+                          catalog_type="filename",
                           location=relative_path,
                           properties=[],
                           categories=[])

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -293,7 +293,7 @@ def test_processing_url_runtime_specific_component(monkeypatch, processor, sampl
                           description="",
                           op="filter-text",  # TODO remove this??
                           catalog_type="url-catalog",
-                          location={"url": url},
+                          source_identifier={"url": url},
                           definition=component_definition,
                           categories=[],
                           properties=[])
@@ -369,7 +369,7 @@ def test_processing_filename_runtime_specific_component(monkeypatch, processor, 
                           description="",
                           op="filter-text",
                           catalog_type="local-directory-catalog",
-                          location={"path": absolute_path},
+                          source_identifier={"path": absolute_path},
                           definition=component_definition,
                           properties=[],
                           categories=[])

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -18,6 +18,7 @@ import os
 import tarfile
 from unittest import mock
 
+from jupyter_core.paths import ENV_JUPYTER_PATH
 from kfp import compiler as kfp_argo_compiler
 import pytest
 import yaml
@@ -345,6 +346,7 @@ def test_processing_url_runtime_specific_component(monkeypatch, processor, sampl
 def test_processing_filename_runtime_specific_component(monkeypatch, processor, sample_metadata, tmpdir):
     # Assign test resource location
     relative_path = "kfp/filter_text_using_shell_and_grep.yaml"
+    absolute_path = os.path.join(ENV_JUPYTER_PATH[0], 'components', relative_path)
 
     # Instantiate a file-based component
     component_id = "filter-text"
@@ -353,7 +355,7 @@ def test_processing_filename_runtime_specific_component(monkeypatch, processor, 
                           description="",
                           op="filter-text",
                           catalog_type="filename",
-                          location=relative_path,
+                          location=absolute_path,
                           properties=[],
                           categories=[])
 
@@ -409,4 +411,4 @@ def test_processing_filename_runtime_specific_component(monkeypatch, processor, 
 
     component_ref = pipeline_template['metadata']['annotations']['pipelines.kubeflow.org/component_ref']
     component_ref = ast.literal_eval(component_ref)
-    assert relative_path in component_ref['url']
+    assert absolute_path in component_ref['url']

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import ast
 import os
 import tarfile
 from unittest import mock
@@ -24,6 +23,8 @@ import pytest
 import yaml
 
 from elyra.metadata.metadata import Metadata
+from elyra.pipeline.catalog_connector import FilesystemComponentCatalogConnector
+from elyra.pipeline.catalog_connector import UrlComponentCatalogConnector
 from elyra.pipeline.component import Component
 from elyra.pipeline.kfp.processor_kfp import KfpPipelineProcessor
 from elyra.pipeline.parser import PipelineParser
@@ -273,20 +274,29 @@ def test_process_dictionary_value_function(processor):
 
 
 def test_processing_url_runtime_specific_component(monkeypatch, processor, sample_metadata, tmpdir):
+    # Define the appropriate reader for a URL-type component definition
+    kfp_supported_file_types = [".yaml"]
+    reader = UrlComponentCatalogConnector(kfp_supported_file_types)
+
     # Assign test resource location
     url = 'https://raw.githubusercontent.com/elyra-ai/elyra/master/' \
           'elyra/tests/pipeline/resources/components/filter_text.yaml'
 
+    # Read contents of given path -- read_component_definition() returns a
+    # a dictionary of component definition content indexed by path
+    component_definition = reader.read_catalog_entry({"url": url}, {})
+
     # Instantiate a url-based component
-    component_id = 'filter-text'
+    component_id = 'url-catalog:7f0546b6135c'
     component = Component(id=component_id,
                           name="Filter text",
                           description="",
-                          op="filter-text",
-                          catalog_type="url",
-                          location=url,
-                          properties=[],
-                          categories=[])
+                          op="filter-text",  # TODO remove this??
+                          catalog_type="url-catalog",
+                          location={"url": url},
+                          definition=component_definition,
+                          categories=[],
+                          properties=[])
 
     # Replace cached component registry with single url-based component for testing
     processor._component_registry._cached_components = {component_id: component}
@@ -338,24 +348,29 @@ def test_processing_url_runtime_specific_component(monkeypatch, processor, sampl
     assert pipeline_template['metadata']['annotations']['pipelines.kubeflow.org/task_display_name'] == operation_name
     assert pipeline_template['inputs']['artifacts'][0]['raw']['data'] == operation_params['text']
 
-    component_ref = pipeline_template['metadata']['annotations']['pipelines.kubeflow.org/component_ref']
-    component_ref = ast.literal_eval(component_ref)
-    assert component_ref['url'] == url
-
 
 def test_processing_filename_runtime_specific_component(monkeypatch, processor, sample_metadata, tmpdir):
+    # Define the appropriate reader for a filesystem-type component definition
+    kfp_supported_file_types = [".yaml"]
+    reader = FilesystemComponentCatalogConnector(kfp_supported_file_types)
+
     # Assign test resource location
     relative_path = "kfp/filter_text_using_shell_and_grep.yaml"
     absolute_path = os.path.join(ENV_JUPYTER_PATH[0], 'components', relative_path)
 
+    # Read contents of given path -- read_component_definition() returns a
+    # a dictionary of component definition content indexed by path
+    component_definition = reader.read_catalog_entry({"path": absolute_path}, {})
+
     # Instantiate a file-based component
-    component_id = "filter-text"
+    component_id = "local-directory-catalog:7f0546b6135c"
     component = Component(id=component_id,
                           name="Filter text",
                           description="",
                           op="filter-text",
-                          catalog_type="filename",
-                          location=absolute_path,
+                          catalog_type="local-directory-catalog",
+                          location={"path": absolute_path},
+                          definition=component_definition,
                           properties=[],
                           categories=[])
 
@@ -408,7 +423,3 @@ def test_processing_filename_runtime_specific_component(monkeypatch, processor, 
     pipeline_template = pipeline_yaml['spec']['templates'][0]
     assert pipeline_template['metadata']['annotations']['pipelines.kubeflow.org/task_display_name'] == operation_name
     assert pipeline_template['inputs']['artifacts'][0]['raw']['data'] == operation_params['text']
-
-    component_ref = pipeline_template['metadata']['annotations']['pipelines.kubeflow.org/component_ref']
-    component_ref = ast.literal_eval(component_ref)
-    assert absolute_path in component_ref['url']

--- a/elyra/tests/pipeline/resources/sample_pipelines/pipeline_with_airflow_components.json
+++ b/elyra/tests/pipeline/resources/sample_pipelines/pipeline_with_airflow_components.json
@@ -11,7 +11,7 @@
         {
           "id": "bb9606ca-29ec-4133-a36a-67bd2a1f6dc3",
           "type": "execution_node",
-          "op": "bash_operator_BashOperator",
+          "op": "url-catalog:49f8e61b78c3",
           "app_data": {
             "label": "b",
             "component_parameters": {
@@ -61,7 +61,7 @@
         {
           "id": "4ef63a48-a27c-4d1e-a0ee-2fbbdbe3be74",
           "type": "execution_node",
-          "op": "email_operator_EmailOperator",
+          "op": "url-catalog:8bef428ea3cd",
           "app_data": {
             "label": "d",
             "component_parameters": {
@@ -115,7 +115,7 @@
         {
           "id": "f82c4699-b392-4a3e-92b0-45d9e11126fe",
           "type": "execution_node",
-          "op": "http_operator_SimpleHttpOperator",
+          "op": "url-catalog:e97030fb448a",
           "app_data": {
             "label": "f",
             "component_parameters": {
@@ -176,7 +176,7 @@
         {
           "id": "779c2630-64bf-47ca-8a98-9ac8a60e85f7",
           "type": "execution_node",
-          "op": "slack_operator_SlackAPIPostOperator",
+          "op": "local-file-catalog:81b4f925702e",
           "app_data": {
             "label": "x",
             "component_parameters": {
@@ -230,7 +230,7 @@
         {
           "id": "92a7a247-1131-489c-8c3e-1e2389d4c673",
           "type": "execution_node",
-          "op": "bash_operator_BashOperator",
+          "op": "url-catalog:49f8e61b78c3",
           "app_data": {
             "label": "h",
             "component_parameters": {

--- a/elyra/tests/pipeline/resources/validation_pipelines/kf_inputpath_parameter.pipeline
+++ b/elyra/tests/pipeline/resources/validation_pipelines/kf_inputpath_parameter.pipeline
@@ -59,7 +59,7 @@
         {
           "id": "089a12df-fe2f-4fcb-ae37-a1f8a6259ca1",
           "type": "execution_node",
-          "op": "local-directory-catalog:0c7bc4a10720",
+          "op": "local-directory-catalog:61e6f4141f65",
           "app_data": {
             "component_parameters": {
               "notebook": {

--- a/elyra/tests/pipeline/resources/validation_pipelines/kf_inputpath_parameter.pipeline
+++ b/elyra/tests/pipeline/resources/validation_pipelines/kf_inputpath_parameter.pipeline
@@ -11,7 +11,7 @@
         {
           "id": "5a244bf5-bc26-48a3-8680-b9c08a6746a0",
           "type": "execution_node",
-          "op": "component_Downloaddata",
+          "op": "url-catalog:c6c0588048ae",
           "app_data": {
             "component_parameters": {
               "url": "https://raw.githubusercontent.com/kubeflow/pipelines/93fc34474bf989998cf19445149aca2847eee763/components/notebooks/samples/test_notebook.ipynb",
@@ -59,7 +59,7 @@
         {
           "id": "089a12df-fe2f-4fcb-ae37-a1f8a6259ca1",
           "type": "execution_node",
-          "op": "run_notebook_using_papermill_Runnotebookusingpapermill",
+          "op": "local-directory-catalog:0c7bc4a10720",
           "app_data": {
             "component_parameters": {
               "notebook": {
@@ -121,7 +121,7 @@
         {
           "id": "e8820c55-dc79-46d1-b32e-924fa5d70d2a",
           "type": "execution_node",
-          "op": "component_Calculatedatahash",
+          "op": "url-catalog:4fc759382b1b",
           "app_data": {
             "component_parameters": {
               "data": {

--- a/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_inputpath_missing_connection.pipeline
+++ b/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_inputpath_missing_connection.pipeline
@@ -11,7 +11,7 @@
         {
           "id": "65ef3a01-569a-4ea4-bd3d-842ca6ce47ac",
           "type": "execution_node",
-          "op": "filter_text_using_shell_and_grep_Filtertext",
+          "op": "local-directory-catalog:737915b826e9",
           "app_data": {
             "component_parameters": {
               "component_description": "Filter input text according to the given regex pattern using shell and grep.",
@@ -71,7 +71,7 @@
         {
           "id": "4ca98ef2-2e1a-4266-a6e7-6a1a42ec471a",
           "type": "execution_node",
-          "op": "component_Downloaddata",
+          "op": "url-catalog:c6c0588048ae",
           "app_data": {
             "component_parameters": {
               "curl_options": "--location",
@@ -119,7 +119,7 @@
         {
           "id": "5b78ea0a-e5fc-4022-94d4-7b9dc170d794",
           "type": "execution_node",
-          "op": "component_Calculatedatahash",
+          "op": "url-catalog:4fc759382b1b",
           "app_data": {
             "component_parameters": {
               "hash_algorithm": "SHA256",

--- a/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_inputpath_parameter.pipeline
+++ b/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_inputpath_parameter.pipeline
@@ -59,7 +59,7 @@
         {
           "id": "089a12df-fe2f-4fcb-ae37-a1f8a6259ca1",
           "type": "execution_node",
-          "op": "local-directory-catalog:0c7bc4a10720",
+          "op": "local-directory-catalog:61e6f4141f65",
           "app_data": {
             "component_parameters": {
               "notebook": {

--- a/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_inputpath_parameter.pipeline
+++ b/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_inputpath_parameter.pipeline
@@ -11,7 +11,7 @@
         {
           "id": "5a244bf5-bc26-48a3-8680-b9c08a6746a0",
           "type": "execution_node",
-          "op": "component_Downloaddata",
+          "op": "url-catalog:c6c0588048ae",
           "app_data": {
             "component_parameters": {
               "url": "https://raw.githubusercontent.com/kubeflow/pipelines/93fc34474bf989998cf19445149aca2847eee763/components/notebooks/samples/test_notebook.ipynb",
@@ -59,7 +59,7 @@
         {
           "id": "089a12df-fe2f-4fcb-ae37-a1f8a6259ca1",
           "type": "execution_node",
-          "op": "run_notebook_using_papermill_Runnotebookusingpapermill",
+          "op": "local-directory-catalog:0c7bc4a10720",
           "app_data": {
             "component_parameters": {
               "notebook": {
@@ -121,7 +121,7 @@
         {
           "id": "e8820c55-dc79-46d1-b32e-924fa5d70d2a",
           "type": "execution_node",
-          "op": "component_Calculatedatahash",
+          "op": "url-catalog:4fc759382b1b",
           "app_data": {
             "component_parameters": {
               "data": {

--- a/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_node_op.pipeline
+++ b/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_node_op.pipeline
@@ -61,7 +61,7 @@
         {
           "id": "63804769-699b-444a-89c2-60ab2cbd39e9",
           "type": "execution_node",
-          "op": "filter_text_using_shell_and_grep_Filtertext",
+          "op": "local-directory-catalog:737915b826e9",
           "app_data": {
             "component_parameters": {
               "text": "Untitled.ipynb",

--- a/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_node_op_with_supernode.pipeline
+++ b/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_node_op_with_supernode.pipeline
@@ -11,7 +11,7 @@
         {
           "id": "fe08b42d-bd8c-4e97-8010-0503a3185427",
           "type": "execution_node",
-          "op": "local-directory-catalog:0c7bc4a10720",
+          "op": "local-directory-catalog:61e6f4141f65",
           "app_data": {
             "component_parameters": {
               "notebook": "../notebookA.ipynb",

--- a/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_node_op_with_supernode.pipeline
+++ b/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_node_op_with_supernode.pipeline
@@ -11,7 +11,7 @@
         {
           "id": "fe08b42d-bd8c-4e97-8010-0503a3185427",
           "type": "execution_node",
-          "op": "run_notebook_using_papermill_Runnotebookusingpapermill",
+          "op": "local-directory-catalog:0c7bc4a10720",
           "app_data": {
             "component_parameters": {
               "notebook": "../notebookA.ipynb",
@@ -71,7 +71,7 @@
         {
           "id": "bfa62a7e-4f55-4fb5-b358-a6f70278ae62",
           "type": "execution_node",
-          "op": "filter_text_using_shell_and_grep_Filtertext",
+          "op": "local-directory-catalog:737915b826e9",
           "app_data": {
             "component_parameters": {
               "text": "../B.txt",

--- a/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_node_property_in_component.pipeline
+++ b/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_node_property_in_component.pipeline
@@ -11,7 +11,7 @@
         {
           "id": "fe08b42d-bd8c-4e97-8010-0503a3185427",
           "type": "execution_node",
-          "op": "local-directory-catalog:0c7bc4a10720",
+          "op": "local-directory-catalog:61e6f4141f65",
           "app_data": {
             "label": "Run notebook using papermill",
             "component_parameters": {

--- a/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_node_property_in_component.pipeline
+++ b/elyra/tests/pipeline/resources/validation_pipelines/kf_invalid_node_property_in_component.pipeline
@@ -11,7 +11,7 @@
         {
           "id": "fe08b42d-bd8c-4e97-8010-0503a3185427",
           "type": "execution_node",
-          "op": "run_notebook_using_papermill_Runnotebookusingpapermill",
+          "op": "local-directory-catalog:0c7bc4a10720",
           "app_data": {
             "label": "Run notebook using papermill",
             "component_parameters": {
@@ -76,7 +76,7 @@
         {
           "id": "bfa62a7e-4f55-4fb5-b358-a6f70278ae62",
           "type": "execution_node",
-          "op": "filter_text_using_shell_and_grep_Filtertext",
+          "op": "local-directory-catalog:737915b826e9",
           "app_data": {
             "label": "Filter text",
             "component_parameters": {

--- a/elyra/tests/pipeline/resources/validation_pipelines/kf_supernode_invalid_single_cycle.pipeline
+++ b/elyra/tests/pipeline/resources/validation_pipelines/kf_supernode_invalid_single_cycle.pipeline
@@ -11,7 +11,7 @@
         {
           "id": "2ccb6e75-3a57-4cc1-8a96-8e19ce15c7a5",
           "type": "execution_node",
-          "op": "component_Downloaddata",
+          "op": "url-catalog:c6c0588048ae",
           "app_data": {
             "component_parameters": {
               "url": "test",
@@ -120,7 +120,7 @@
         {
           "id": "9023de3e-b4cb-4549-b630-ae842e926ee2",
           "type": "execution_node",
-          "op": "run_notebook_using_papermill_Runnotebookusingpapermill",
+          "op": "local-directory-catalog:0c7bc4a10720",
           "app_data": {
             "component_parameters": {
               "parameters": "{}",
@@ -206,7 +206,7 @@
         {
           "id": "5bd9bfbb-5db8-4ee5-b49e-ebcac2e7c185",
           "type": "execution_node",
-          "op": "filter_text_using_shell_and_grep_Filtertext",
+          "op": "local-directory-catalog:737915b826e9",
           "app_data": {
             "component_parameters": {
               "pattern": ".*",
@@ -265,7 +265,7 @@
         {
           "id": "51036094-4cc5-440a-a652-a84b0871786a",
           "type": "execution_node",
-          "op": "component_Calculatedatahash",
+          "op": "url-catalog:4fc759382b1b",
           "app_data": {
             "component_parameters": {
               "hash_algorithm": "SHA256",

--- a/elyra/tests/pipeline/resources/validation_pipelines/kf_supernode_valid.pipeline
+++ b/elyra/tests/pipeline/resources/validation_pipelines/kf_supernode_valid.pipeline
@@ -11,7 +11,7 @@
         {
           "id": "2ccb6e75-3a57-4cc1-8a96-8e19ce15c7a5",
           "type": "execution_node",
-          "op": "component_Downloaddata",
+          "op": "url-catalog:c6c0588048ae",
           "app_data": {
             "component_parameters": {
               "url": "test",
@@ -115,7 +115,7 @@
         {
           "id": "9023de3e-b4cb-4549-b630-ae842e926ee2",
           "type": "execution_node",
-          "op": "run_notebook_using_papermill_Runnotebookusingpapermill",
+          "op": "local-directory-catalog:0c7bc4a10720",
           "app_data": {
             "component_parameters": {
               "notebook": "None",
@@ -192,7 +192,7 @@
         {
           "id": "5bd9bfbb-5db8-4ee5-b49e-ebcac2e7c185",
           "type": "execution_node",
-          "op": "filter_text_using_shell_and_grep_Filtertext",
+          "op": "local-directory-catalog:737915b826e9",
           "app_data": {
             "component_parameters": {
               "pattern": ".*",
@@ -251,7 +251,7 @@
         {
           "id": "51036094-4cc5-440a-a652-a84b0871786a",
           "type": "execution_node",
-          "op": "component_Calculatedatahash",
+          "op": "url-catalog:4fc759382b1b",
           "app_data": {
             "component_parameters": {
               "hash_algorithm": "SHA256",

--- a/elyra/tests/pipeline/test_validation.py
+++ b/elyra/tests/pipeline/test_validation.py
@@ -128,7 +128,6 @@ async def test_invalid_runtime_node_kubeflow_with_supernode(validation_manager, 
                                                      pipeline_type='kfp',
                                                      pipeline_runtime='kfp')
     issues = response.to_json().get('issues')
-    print(issues)
     assert len(issues) == 1
     assert issues[0]['severity'] == 1
     assert issues[0]['type'] == 'invalidNodeType'

--- a/elyra/tests/pipeline/test_validation.py
+++ b/elyra/tests/pipeline/test_validation.py
@@ -128,6 +128,7 @@ async def test_invalid_runtime_node_kubeflow_with_supernode(validation_manager, 
                                                      pipeline_type='kfp',
                                                      pipeline_runtime='kfp')
     issues = response.to_json().get('issues')
+    print(issues)
     assert len(issues) == 1
     assert issues[0]['severity'] == 1
     assert issues[0]['type'] == 'invalidNodeType'

--- a/etc/config/metadata/component-registries/elyra-airflow-filename-preconfig.json
+++ b/etc/config/metadata/component-registries/elyra-airflow-filename-preconfig.json
@@ -6,5 +6,6 @@
     "categories": ["Preloaded Airflow"],
     "paths": ["airflow/slack_operator.py"]
   },
-  "schema_name": "local-file-catalog"
+  "schema_name": "local-file-catalog",
+  "version": 1
 }

--- a/etc/config/metadata/component-registries/elyra-airflow-filesystem-preconfig.json
+++ b/etc/config/metadata/component-registries/elyra-airflow-filesystem-preconfig.json
@@ -1,7 +1,7 @@
 {
-  "display_name": "Airflow Preloaded Components - Filename",
+  "display_name": "Airflow Preloaded Components - Filesystem",
   "metadata": {
-    "description": "Preloaded filename-based components that are supported by Apache Airflow",
+    "description": "Preloaded filesystem-based components that are supported by Apache Airflow",
     "runtime": "airflow",
     "categories": ["Preloaded Airflow"],
     "paths": ["airflow/slack_operator.py"]

--- a/etc/config/metadata/component-registries/elyra-airflow-url-preconfig.json
+++ b/etc/config/metadata/component-registries/elyra-airflow-url-preconfig.json
@@ -4,7 +4,7 @@
     "description": "Preloaded URL-based components that are supported by Apache Airflow",
     "runtime": "airflow",
     "categories": ["Preloaded Airflow"],
-    "urls": [
+    "paths": [
       "https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/bash_operator.py",
       "https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/email_operator.py",
       "https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/http_operator.py",

--- a/etc/config/metadata/component-registries/elyra-airflow-url-preconfig.json
+++ b/etc/config/metadata/component-registries/elyra-airflow-url-preconfig.json
@@ -12,5 +12,6 @@
       "https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/contrib/operators/spark_submit_operator.py"
     ]
   },
-  "schema_name": "url-catalog"
+  "schema_name": "url-catalog",
+  "version": 1
 }

--- a/etc/config/metadata/component-registries/elyra-kfp-directory-preconfig.json
+++ b/etc/config/metadata/component-registries/elyra-kfp-directory-preconfig.json
@@ -6,5 +6,6 @@
     "categories": ["Preloaded KFP"],
     "paths": ["kfp"]
   },
-  "schema_name": "local-directory-catalog"
+  "schema_name": "local-directory-catalog",
+  "version": 1
 }

--- a/etc/config/metadata/component-registries/elyra-kfp-directory-preconfig.json
+++ b/etc/config/metadata/component-registries/elyra-kfp-directory-preconfig.json
@@ -4,7 +4,7 @@
     "description": "Preloaded directory-based components that are supported by Kubeflow Pipelines",
     "runtime": "kfp",
     "categories": ["Preloaded KFP"],
-    "path": "kfp"
+    "paths": ["kfp"]
   },
   "schema_name": "local-directory-catalog"
 }

--- a/etc/config/metadata/component-registries/elyra-kfp-url-preconfig.json
+++ b/etc/config/metadata/component-registries/elyra-kfp-url-preconfig.json
@@ -9,5 +9,6 @@
       "https://raw.githubusercontent.com/kubeflow/pipelines/1.6.0/components/basics/Calculate_hash/component.yaml"
     ]
   },
-  "schema_name": "url-catalog"
+  "schema_name": "url-catalog",
+  "version": 1
 }

--- a/etc/config/metadata/component-registries/elyra-kfp-url-preconfig.json
+++ b/etc/config/metadata/component-registries/elyra-kfp-url-preconfig.json
@@ -4,7 +4,7 @@
     "description": "Preloaded URL-based components that are supported by Kubeflow Pipelines",
     "runtime": "kfp",
     "categories": ["Preloaded KFP"],
-    "urls": [
+    "paths": [
       "https://raw.githubusercontent.com/kubeflow/pipelines/1.6.0/components/web/Download/component.yaml",
       "https://raw.githubusercontent.com/kubeflow/pipelines/1.6.0/components/basics/Calculate_hash/component.yaml"
     ]

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -36,7 +36,7 @@ import {
   kubeflowIcon,
   airflowIcon,
   argoIcon,
-  pipelineComponentsIcon
+  componentCatalogIcon
 } from '@elyra/ui-components';
 import { ILabShell } from '@jupyterlab/application';
 import { Dialog, ReactWidget, showDialog } from '@jupyterlab/apputils';
@@ -836,7 +836,7 @@ const PipelineWrapper: React.FC<IProps> = ({
         case 'openRuntimeImages':
           shell.activateById(`elyra-metadata:${RUNTIME_IMAGES_SCHEMASPACE}`);
           break;
-        case 'openPipelineComponents':
+        case 'openComponentCatalogs':
           shell.activateById(
             `elyra-metadata:${PIPELINE_COMPONENTS_SCHEMASPACE}`
           );
@@ -906,11 +906,11 @@ const PipelineWrapper: React.FC<IProps> = ({
         iconDisabled: IconUtil.encode(containerIcon)
       },
       {
-        action: 'openPipelineComponents',
-        label: 'Open Pipeline Components',
+        action: 'openComponentCatalogs',
+        label: 'Open Component Catalogs',
         enable: true,
-        iconEnabled: IconUtil.encode(pipelineComponentsIcon),
-        iconDisabled: IconUtil.encode(pipelineComponentsIcon)
+        iconEnabled: IconUtil.encode(componentCatalogIcon),
+        iconDisabled: IconUtil.encode(componentCatalogIcon)
       },
       { action: 'undo', label: 'Undo' },
       { action: 'redo', label: 'Redo' },

--- a/packages/pipeline-editor/src/index.ts
+++ b/packages/pipeline-editor/src/index.ts
@@ -21,7 +21,7 @@ import {
   pipelineIcon,
   RequestErrors,
   runtimesIcon,
-  pipelineComponentsIcon
+  componentCatalogIcon
 } from '@elyra/ui-components';
 
 import {
@@ -327,14 +327,14 @@ const extension: JupyterFrontEndPlugin<void> = {
     const componentRegistryWidget = new MetadataWidget({
       app,
       themeManager,
-      display_name: 'Pipeline Components',
+      display_name: 'Component Catalogs',
       schemaspace: COMPONENT_REGISTRY_SCHEMASPACE,
-      icon: pipelineComponentsIcon
+      icon: componentCatalogIcon
     });
     const componentRegistryWidgetID = `elyra-metadata:${COMPONENT_REGISTRY_SCHEMASPACE}`;
     componentRegistryWidget.id = componentRegistryWidgetID;
-    componentRegistryWidget.title.icon = pipelineComponentsIcon;
-    componentRegistryWidget.title.caption = 'Pipeline Components';
+    componentRegistryWidget.title.icon = componentCatalogIcon;
+    componentRegistryWidget.title.caption = 'Component Catalogs';
 
     restorer.add(runtimeImagesWidget, runtimeImagesWidgetID);
     app.shell.add(runtimeImagesWidget, 'left', { rank: 951 });

--- a/packages/services/src/test/application.spec.ts
+++ b/packages/services/src/test/application.spec.ts
@@ -29,7 +29,8 @@ const codeSnippetMetadata = {
   metadata: {
     language: 'Python',
     code: ['hello_world']
-  }
+  },
+  version: 0
 };
 
 beforeAll(async () => {

--- a/packages/ui-components/src/icons.tsx
+++ b/packages/ui-components/src/icons.tsx
@@ -66,7 +66,7 @@ export const pipelineIcon = new LabIcon({
   name: 'elyra:pipeline',
   svgstr: pipelineSvg
 });
-export const pipelineComponentsIcon = new LabIcon({
+export const componentCatalogIcon = new LabIcon({
   name: 'elyra:pipeline-components',
   svgstr: pipelineComponentSvg
 });

--- a/packages/ui-components/style/icons/pipeline-components.svg
+++ b/packages/ui-components/style/icons/pipeline-components.svg
@@ -2,7 +2,7 @@
     <defs>
         <style>.cls-1{fill:none;}</style>
     </defs>
-    <title>Pipeline Components</title>
+    <title>Component Catalogs</title>
     <path d="M26,14a2,2,0,0,0,2-2V6a2,2,0,0,0-2-2H20a2,2,0,0,0-2,2v6a2,2,0,0,0,2,2h2v4.1A5,5,0,0,0,18.1,22H14V20a2,2,0,0,0-2-2H10V13.9a5,5,0,1,0-2,0V18H6a2,2,0,0,0-2,2v6a2,2,0,0,0,2,2h6a2,2,0,0,0,2-2V24h4.1A5,5,0,1,0,24,18.1V14ZM6,9a3,3,0,1,1,3,3A3,3,0,0,1,6,9Zm6,17H6V20h6Zm14-3a3,3,0,1,1-3-3A3,3,0,0,1,26,23ZM20,6h6v6H20Z" transform="translate(0 0)"/>
     <rect id="_Transparent_Rectangle_" data-name="&lt;Transparent Rectangle&gt;" class="cls-1" width="32" height="32"/>
 </svg>

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ setup_args = dict(
         'elyra.component.catalog_types': [
             'url-catalog = elyra.pipeline.catalog_connector:UrlComponentCatalogConnector',
             'local-file-catalog = elyra.pipeline.catalog_connector:FilesystemComponentCatalogConnector',
-            'local-directory-catalog = elyra.pipeline.catalog_connector:DirectoryComponentCatalogConnector'
+            'local-directory-catalog = elyra.pipeline.catalog_connector:DirectoryComponentCkhkatalogConnector'
         ],
         'papermill.engine': [
             'ElyraEngine = elyra.pipeline.elyra_engine:ElyraEngine',

--- a/setup.py
+++ b/setup.py
@@ -143,9 +143,9 @@ setup_args = dict(
             'kfp = elyra.pipeline.kfp.processor_kfp:KfpPipelineProcessor'
         ],
         'elyra.component.catalog_types': [
-            'url = elyra.pipeline.component:UrlComponentReader',
-            'local-file = elyra.pipeline.component:FilenameComponentReader',
-            'local-directory = elyra.pipeline.component:DirectoryComponentReader'
+            'url-catalog = elyra.pipeline.component_reader:UrlComponentReader',
+            'local-file-catalog = elyra.pipeline.component_reader:FilesystemComponentReader',
+            'local-directory-catalog = elyra.pipeline.component_reader:DirectoryComponentReader'
         ],
         'papermill.engine': [
             'ElyraEngine = elyra.pipeline.elyra_engine:ElyraEngine',

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ setup_args = dict(
         'elyra.component.catalog_types': [
             'url-catalog = elyra.pipeline.catalog_connector:UrlComponentCatalogConnector',
             'local-file-catalog = elyra.pipeline.catalog_connector:FilesystemComponentCatalogConnector',
-            'local-directory-catalog = elyra.pipeline.catalog_connector:DirectoryComponentCkhkatalogConnector'
+            'local-directory-catalog = elyra.pipeline.catalog_connector:DirectoryComponentCatalogConnector'
         ],
         'papermill.engine': [
             'ElyraEngine = elyra.pipeline.elyra_engine:ElyraEngine',

--- a/setup.py
+++ b/setup.py
@@ -143,9 +143,9 @@ setup_args = dict(
             'kfp = elyra.pipeline.kfp.processor_kfp:KfpPipelineProcessor'
         ],
         'elyra.component.catalog_types': [
-            'url-catalog = elyra.pipeline.component_reader:UrlComponentReader',
-            'local-file-catalog = elyra.pipeline.component_reader:FilesystemComponentReader',
-            'local-directory-catalog = elyra.pipeline.component_reader:DirectoryComponentReader'
+            'url-catalog = elyra.pipeline.component_reader:UrlComponentCatalogConnector',
+            'local-file-catalog = elyra.pipeline.component_reader:FilesystemComponentCatalogConnector',
+            'local-directory-catalog = elyra.pipeline.component_reader:DirectoryComponentCatalogConnector'
         ],
         'papermill.engine': [
             'ElyraEngine = elyra.pipeline.elyra_engine:ElyraEngine',

--- a/setup.py
+++ b/setup.py
@@ -143,9 +143,9 @@ setup_args = dict(
             'kfp = elyra.pipeline.kfp.processor_kfp:KfpPipelineProcessor'
         ],
         'elyra.component.catalog_types': [
-            'url-catalog = elyra.pipeline.component_reader:UrlComponentCatalogConnector',
-            'local-file-catalog = elyra.pipeline.component_reader:FilesystemComponentCatalogConnector',
-            'local-directory-catalog = elyra.pipeline.component_reader:DirectoryComponentCatalogConnector'
+            'url-catalog = elyra.pipeline.catalog_connector:UrlComponentCatalogConnector',
+            'local-file-catalog = elyra.pipeline.catalog_connector:FilesystemComponentCatalogConnector',
+            'local-directory-catalog = elyra.pipeline.catalog_connector:DirectoryComponentCatalogConnector'
         ],
         'papermill.engine': [
             'ElyraEngine = elyra.pipeline.elyra_engine:ElyraEngine',

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -534,8 +534,8 @@ describe('Pipeline Editor tests', () => {
     cy.expandPaletteCategory({ type: 'kfp' });
 
     const kfpCustomComponents = [
-      'local-directory-catalog:737915b826e9', // filter text
-      'local-directory-catalog:61e6f4141f65' // run notebook using papermill
+      'local-directory-catalog\\:737915b826e9', // filter text
+      'local-directory-catalog\\:61e6f4141f65' // run notebook using papermill
     ];
 
     kfpCustomComponents.forEach(component => {
@@ -563,11 +563,11 @@ describe('Pipeline Editor tests', () => {
     cy.expandPaletteCategory({ type: 'airflow' });
 
     const airflowCustomComponents = [
-      'url-catalog:49f8e61b78c3', // bash operator
-      'url-catalog:8bef428ea3cd', // email operator
-      'url-catalog:e97030fb448a', // http operator
-      'url-catalog:ff0d51b70719', // spark sql operator
-      'url-catalog:2756314f3ff5' // spark submit operator
+      'url-catalog\\:49f8e61b78c3', // bash operator
+      'url-catalog\\:8bef428ea3cd', // email operator
+      'url-catalog\\:e97030fb448a', // http operator
+      'url-catalog\\:ff0d51b70719', // spark sql operator
+      'url-catalog\\:2756314f3ff5' // spark submit operator
     ];
 
     airflowCustomComponents.forEach(component => {

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -108,7 +108,7 @@ describe('Pipeline Editor tests', () => {
       /clear/i,
       /open runtimes/i,
       /open runtime images/i,
-      /open pipeline components/i,
+      /open component catalogs/i,
       /undo/i,
       /add comment/i,
       /arrange horizontally/i,

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -534,8 +534,8 @@ describe('Pipeline Editor tests', () => {
     cy.expandPaletteCategory({ type: 'kfp' });
 
     const kfpCustomComponents = [
-      'filter_text_using_shell_and_grep_Filtertext',
-      'run_notebook_using_papermill_Runnotebookusingpapermill'
+      'local-directory-catalog:737915b826e9', // filter text
+      'local-directory-catalog:61e6f4141f65' // run notebook using papermill
     ];
 
     kfpCustomComponents.forEach(component => {
@@ -563,11 +563,11 @@ describe('Pipeline Editor tests', () => {
     cy.expandPaletteCategory({ type: 'airflow' });
 
     const airflowCustomComponents = [
-      'bash_operator_BashOperator',
-      'email_operator_EmailOperator',
-      'http_operator_SimpleHttpOperator',
-      'spark_sql_operator_SparkSqlOperator',
-      'spark_submit_operator_SparkSubmitOperator'
+      'url-catalog:49f8e61b78c3', // bash operator
+      'url-catalog:8bef428ea3cd', // email operator
+      'url-catalog:e97030fb448a', // http operator
+      'url-catalog:ff0d51b70719', // spark sql operator
+      'url-catalog:2756314f3ff5' // spark submit operator
     ];
 
     airflowCustomComponents.forEach(component => {


### PR DESCRIPTION
Closes #2220. This PR generalizes the `ComponentReader` class in order to better support additional catalog types for which we may not know the structure.

Related: 

- #2224 
- #2228 
- #2189

### What changes were proposed in this pull request?
This PR touches the following elements:
- Entrypoints in `setup.py`
  - A new entrypoint group is declared (`elyra.component.catalog_types`) and contains one name for each type of catalog (see schemas section below)
- Component catalog schemas and corresponding `ComponentRegistrySchemas` class
  - The former `component-registry` schema name has been removed in favor of creating one schema per component catalog type
  - The `schema_name` must match the entrypoint name in order to be found during the call to `get_schemas()`
  - All keys except one in the schema for the built-in catalog types (file, directory, or url) have been preserved from when it existed as a single `component-registry` schema in order to avoid some larger migration issues
    - This doesn't completely remove the need for some sort of migration, however, as the `schema_name` field still must change to reflect the new schemas -- more discussion needed
  -  Added an optional field to the `local-file-catalog` ~~and `local-directory-catalog`~~ schema called `base_path`, which allows a user to enter an optional base directory from which the rest of the `paths` values may be resolved (otherwise, absolute directories are assumed)
  - Added an optional field to the `local-directory-catalog` type called `include_subdirs`, which allows a user to indicate whether they want to search subdirectories for additional component specs
    - **Discussion point:** I'm not sure if there's a boolean control (like a checkbox or something) already available for this purpose on the frontend in the metadata editor or if one will have to be created
  - Some frontend considerations rise from these changes:
    - Changed the naming on the frontend from 'Pipeline Components' to 'Component Catalogs'; someone from frontend should probably take a look to make sure I haven't missed anything or screwed something up
    - **Discussion point:** The addition of certain fields in the schema sometimes may look less-than ideal; see the UI when adding/modifying a `local-file-catalog` instance (note that `Base Path` doesn't line up with `Paths` since the paths array type required some different formatting options)
    - We'd like to remove the duplicate title/display_name information in the schema (`title`, `display_name`, and `uihints.title`)
- `ComponentRegistry`
  - The `schema_name` field now determines the appropriate reader class by comparing with entrypoint keys
  - The `component_entry` `SimpleNamespace` object includes a few changes:
    - A `component_identifier` field is added, which is passed on to the `Component` object after parsing and saved for later access
    - `location` is removed from the top-level of the `component_entry` object, as it now optionally resides in the `component_metadata` value
    - The `component_id` value is added, the value of which now is determined in and returned from the reader (see below)
- `ComponentReader` classes
  - The logic has been moved out of `component.py` and into it's own file `component_reader.py` since it got pretty bulky
  - The `max_readers` configurable Integer has been converted to one of potentially/eventually several override-able settings (stored in a configurable dictionary)
  - `read_component_definitions()` still drives the below functionality using threads
    - `get_catalog_entries()` (formerly `get_absolute_locations()`) takes the registry/catalog instance metadata and, for each component in that registry, builds a dictionary containing all the relevant data that will be required in order to read a component in the call to `read_component_definition()`; these dictionaries are returned in a list
    - on return to the `read_component_definitions()` function, the catalog entry dictionaries are added to the thread queue
      - The id-ing method used currently takes the following form
        - `<catalog-type-name>:hash(<hashing_key1>:<hashing_key2>:<...>)`
        - The hash portion of the above id only includes the first 12 characters for brevity
        - Each catalog-type class can set the hashing_keys as above for their component instances by implementing `get_hash_keys()` to return a list of keys available in the `component_entry_data` object returned from `get_catalog_entries()` for each component
    - when an entry is pulled from the queue, `read_component_definition()` is passed the catalog entry data and registry metadata used to return the catalog entry's definition in string form
  - ~~Adds some logging functions so that classes can implement custom messages -- this might be overkill and will likely change when we finalize what we are doing with the `component_source` property~~
- `ComponentParser` classes
  - Determination of the `component_id` is removed from the parser classes and takes place in the reader
  - Minor changes to include the component `identifier` field and other field changes in the constructors
  - The `AirflowComponentParser` is refactored to only include the portion of the operator definition for a component of a single class
- `Component` object class
  - Now includes a `definition` attribute that can be used during processing to access the component definition without re-reading/parsing
  - Some simple name changes:
    - To start, the `location_type` attribute has been changed to `catalog_type`
    - **Discussion point:** We may want to consider changing the name of `location` to something like `location_identifier` or something that better conveys where/how a particular component can be defined (consider the MLX example where the "location" is something like the component access id instead)
      - `component_identifier` is another naming option for this attribute
      - FYI, the value of this attribute is what is displayed under the `Component Source` property in the node properties panel
- `RuntimePipelineProcessor` classes
  - These differ a lot from each other, so I'll explain separately
  - KFP
    - When a component needs to be loaded, KFP's `load_component_from_text()` is now used for every type of component, where the `definition` attribute of the `Component` object is given as the argument
  - Airflow
    - This is a bit of a sticky situation, even outside of the scope of this PR; the issue is that the Airflow DAG template requires us to have the module name in order to insert the appropriate `import` statement, so we need a way for all catalog types to be able to import the correct modules
      - We will use configuration to handle this; more details to be added later
- **Migration**
With these changes, the existing `component-registry` schema is replaced by three schemas reflecting the previous `location_type` property.  Any user-maintained instances will need to be adjusted in the following ways (note, _factory_ instances will immediately reflect the new forms):
    - Based on the old `location_type` value, the appropriate schema name is applied
    - The `location_type` property is then removed
    - A new `version` property is added with a value of `1`
    - If we choose to rename `paths` to `urls` and `directories` for `url-catalog` and `local-directory-catalog` instances, respectively, then those properties will be "renamed".
    - The user-maintained instances are migrated via the metadata-class hook relative to the _old_ `component-registry` schema.  Since the `ComponentRegistry` initialization accesses all instances of the `ComponentRegistries` schemaspace, each instance is essentially "touched".
        - It is anticipated that each migration relative to a given schema will be different.  In the case of `component-registry` instances, they are transitioning to a new schema entirely, dropping and adding a property (as noted previously).  In this case, the migration will hook the `post_load()` method and perform an update of the updated instance prior to its return.  As a result, what is returned is an instance corresponding to the new schema that has also been persisted in the metadata storage (filesystem).
        - Since the `component-registry` schema is still required to be present, support for _schema deprecation_ has been added and a `deprecated = true` property has been added to the `component-registry` schema.  The behavior is that deprecated schemas can be accessed by name only and their instances retrieved, but deprecated schemas are NOT present when retrieving the set of schemas of a given schemaspace.  This way, they will not show up in metadata-driven applications (such as Elyra's frontend) but internal code can still reference them.
        - With these changes, a `version` property has been added to all `component-registries` schemaspace schemas.  We may want a _meta-version_ property at some point that reflects the version of the schema itself, but, for now, `version` is meant to reflect the version of instances that must adhere to the schema.
        - We will need to decide when we can safely remove the `component-registry` schema.  If we deliver these changes in 3.3, then perhaps 3.4 could be a removal point.  This way, anyone jumping from 3.2 to 3.4 will be asked to go through 3.3 first.

### Still Left To Do

- [x] Update tests
- [x] Update the schema `$id` fields to be the appropriate path closer to merge time
- [x] Support metadata migration
- [x] Remove test fields from directory schema
- [ ] Finalize naming and docstrings, etc. (including abstract methods, "catalog" vs "registry" usage, etc.)


Frontend concerns (not must haves):
  - #2262
  - #2256 
  - #2254 
  - #2255 
  - ~~Formatting for schema fields that appear side-by-side~~ this will be coming in JL 4.0

Docs will be updated in a separate PR; see #2249 

### How to implement a new catalog type

- Add a new schema for your type to the `elyra/metadata/schemas` directory
  - The name of the schema file must match the value of the `schema_name` field in the JSON file, e.g. url-catalog.json and `'schema_name': 'url-catalog'`
  - Follow the format of the existing catalog schemas, including the noted required keys
    - "schema_name", "display_name", "metadata" must be present in the schema, as should "runtime", "categories", and "description"
    - add other fields as needed to the "metadata" properties that will make it possible to access the components associated with this catalog type
    - Ensure that the `schemaspace_name` is `component-registries` and the `schemaspace_id` is `ae79159a-489d-4656-83a6-1adfbc567c70`
    - [Implement and register a SchemasProvider](https://elyra.readthedocs.io/en/latest/developer_guide/metadata.html#schemasprovider) associated with the [`ComponentRegistries` schemaspace](https://github.com/elyra-ai/elyra/blob/b0a8e52bc4065c2bc434fbccf3a82d2c032ee217/elyra/metadata/schemaspaces.py#L55) that makes the schema available via its `get_schemas()` method.
- Implement a custom `ComponentReader` subclass, including the following functions for...
  - `get_catalog_entries()` -- gets a dictionary of relevant data from each component in the catalog that will be used to access component definitions
  - `read_catalog_entry()` -- reads and returns a component definition (in string form) given the data for that catalog entry/component
  - `get_hash_keys()` -- provides a list of keys available in the 'catalog_entry_data' dictionary the values of which will be used in constructing a unique hash id for each entry with the given catalog type
  - (More details for all of these functions can be found in their docstrings)
- Add the new `schema_name` to the entrypoint for `elyra.component.catalog_types` in `setup.py`
  - The entrypoint name **must** match the `schema_name` defined in the schema
  - e.g., `'my-type-catalog = elyra.pipeline.component_reader:MyTypeComponentReader'`

### How was this pull request tested?
This PR will definitely require updates to the tests, but I am holding off on making those until we've finalized the design elements.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
