### PR TITLE
Compare major package version only in KFP bootstrapper test

### DIFF
--- a/elyra/tests/kfp/test_bootstrapper.py
+++ b/elyra/tests/kfp/test_bootstrapper.py
@@ -599,7 +599,7 @@ def test_package_installation_with_target_path(monkeypatch, virtualenv, tmpdir):
         virtual_env_dict[package_name] = package_version
 
     for package, version in correct_dict.items():
-        assert virtual_env_dict[package] == version
+        assert virtual_env_dict[package].split('.')[0] == version.split('.')[0]
 
 
 def test_convert_notebook_to_html(tmpdir):


### PR DESCRIPTION
This PR solves the recent test failures in `test_package_installation_with_target_path` where the virtual env `packaging` version was 21.2 but we were checking specifically for v21.0 by relaxing the check to only compare the major version.

I'm not sure if this is the best fix for this problem, however, so feedback is welcome!

### What changes were proposed in this pull request?
Only checks for the major version in `test_package_installation_with_target_path`

### How was this pull request tested?
Tests pass with this change

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
