### PR TITLE
Add environment variable for `max_readers` in CatalogConnector

### DIFF
--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -301,8 +301,6 @@ class ComponentCatalogConnector(LoggingConfigurable):
 
         # Start 'max_reader' reader threads if catalog includes more than 'max_reader'
         # number of catalog entries, else start one thread per entry
-        print("MAX READERS: " + str(self.max_readers))
-
         num_threads = min(catalog_entry_q.qsize(), self.max_readers)
         for i in range(num_threads):
             Thread(target=read_with_thread).start()

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -29,6 +29,7 @@ from typing import Optional
 from jupyter_core.paths import ENV_JUPYTER_PATH
 import requests
 from traitlets.config import LoggingConfigurable
+from traitlets.traitlets import default
 from traitlets.traitlets import Integer
 
 from elyra.metadata.metadata import Metadata
@@ -38,10 +39,20 @@ class ComponentCatalogConnector(LoggingConfigurable):
     """
     Abstract class to model component_entry readers that can read components from different locations
     """
-
-    max_readers = Integer(3, config=True, allow_none=True,
+    max_threads_default = 3
+    max_readers_env = 'ELYRA_CATALOG_CONNECTOR_MAX_READERS'
+    max_readers = Integer(max_threads_default,
                           help="""Sets the maximum number of reader threads to be used to read
-                          catalog entries in parallel""")
+                          catalog entries in parallel""").tag(config=True)
+
+    @default('max_readers')
+    def max_readers_default(self):
+        max_reader_threads = ComponentCatalogConnector.max_threads_default
+        try:
+            max_reader_threads = int(os.getenv(self.max_readers_env, max_reader_threads))
+        except ValueError:
+            pass
+        return max_reader_threads
 
     def __init__(self, file_types: List[str], **kwargs):
         super().__init__(**kwargs)
@@ -290,6 +301,8 @@ class ComponentCatalogConnector(LoggingConfigurable):
 
         # Start 'max_reader' reader threads if catalog includes more than 'max_reader'
         # number of catalog entries, else start one thread per entry
+        print("MAX READERS: " + str(self.max_readers))
+
         num_threads = min(catalog_entry_q.qsize(), self.max_readers)
         for i in range(num_threads):
             Thread(target=read_with_thread).start()


### PR DESCRIPTION
Resolves #2266 

### What changes were proposed in this pull request?
Adds a corresponding environment variable, `ELYRA_CATALOG_CONNECTOR_MAX_READERS`, for the `max_readers` variable in the `ComponentCatalogConnector`.

### How was this pull request tested?
Existing tests are passing.

Also tested manually 1. by setting the Configurable from the command line, and 2. by setting the `max_readers` env var. Test manually as follows:

- Add a print statement to `read_component_definitions()`, e.g. `print(f"MAX READERS: {self.max_readers}"`), or, if you have debugging set up, set a breakpoint in the same function
- Test setting the configurable:
  - start Elyra with the following command: `jupyter elyra --ComponentCatalogConnector.max_readers=5`
  - check that `MAX READERS: 5` is shown in the log (or self.max_readers is set to 5 during debugging)
- Test setting the env var:
  - run `export ELYRA_CATALOG_CONNECTOR_MAX_READERS=4` on the command line
  - start Elyra and check that `MAX READERS: 4` is shown in the log (or self.max_readers is set to 4 during debugging)
  - run `unset ELYRA_CATALOG_CONNECTOR_MAX_READERS` if desired


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
