### PR TITLE
Update to JupyterHub Single User image version 1.1.4

### DIFF
--- a/etc/docker/elyra/Dockerfile
+++ b/etc/docker/elyra/Dockerfile
@@ -16,7 +16,8 @@
 #
 
 # Ubuntu 18.04 LTS - Bionic
-FROM jupyterhub/k8s-singleuser-sample:0.10.6
+# Repository: https://hub.docker.com/r/jupyterhub/k8s-singleuser-sample/tags
+FROM jupyterhub/k8s-singleuser-sample:1.2.0
 
 ARG TAG="dev"
 

--- a/etc/docker/kubeflow/Dockerfile
+++ b/etc/docker/kubeflow/Dockerfile
@@ -16,7 +16,8 @@
 #
 
 # Ubuntu 20.04.2 LTS (Focal Fossa)
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:v1.3.0
+# Repository: https://gallery.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:v1.4
 
 # install - elyra
 RUN python3 -m pip install --quiet --no-cache-dir --use-deprecated legacy-resolver \


### PR DESCRIPTION
Elyra is using an old version of JupyterHub single user image which seems to 
cause issues with more recent hub releases.

This PR updates the Hub base image used by Elyra images to solve this problem. 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
