### PR TITLE
Enable building Elyra docker image from current source code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,12 @@ elyra-image: # Build Elyra stand-alone container image
 	@mkdir -p build/docker
 	cp etc/docker/elyra/Dockerfile build/docker/Dockerfile
 	cp etc/docker/elyra/start-elyra.sh build/docker/start-elyra.sh
-	DOCKER_BUILDKIT=1 docker build -t docker.io/$(ELYRA_IMAGE) -t quay.io/$(ELYRA_IMAGE) build/docker/ --progress plain --build-arg TAG=$(TAG)
+	@mkdir -p build/docker/elyra
+	if [ "$(TAG)" == "dev" ]; then \
+		cp etc/docker/elyra/Dockerfile.dev build/docker/Dockerfile && \
+	    rsync -av --delete --progress . build/docker/elyra --exclude dist --exclude build --exclude node_modules --exclude .git --exclude .github --exclude egg_info; \
+	fi
+	DOCKER_BUILDKIT=1 docker build -t docker.io/$(ELYRA_IMAGE) -t quay.io/$(ELYRA_IMAGE) build/docker/ --progress plain --build-arg TAG=$(TAG);
 
 publish-elyra-image: elyra-image # Publish Elyra stand-alone container image
     # this is a privileged operation; a `docker login` might be required

--- a/etc/docker/elyra/Dockerfile
+++ b/etc/docker/elyra/Dockerfile
@@ -23,7 +23,7 @@ ARG TAG="dev"
 
 USER root
 
-ADD  start-elyra.sh /usr/local/bin/start-elyra.sh
+ADD start-elyra.sh /usr/local/bin/start-elyra.sh
 
 RUN chmod ugo+x /usr/local/bin/start-elyra.sh
 

--- a/etc/docker/elyra/Dockerfile.dev
+++ b/etc/docker/elyra/Dockerfile.dev
@@ -16,7 +16,9 @@
 #
 
 # Ubuntu 18.04 LTS - Bionic
-FROM jupyterhub/k8s-singleuser-sample:1.1.0
+# Repository: https://hub.docker.com/r/jupyterhub/k8s-singleuser-sample/tags
+FROM jupyterhub/k8s-singleuser-sample:1.2.0
+
 
 ARG TAG="dev"
 

--- a/etc/docker/elyra/Dockerfile.dev
+++ b/etc/docker/elyra/Dockerfile.dev
@@ -16,21 +16,28 @@
 #
 
 # Ubuntu 18.04 LTS - Bionic
-# Repository: https://hub.docker.com/r/jupyterhub/k8s-singleuser-sample/tags
-FROM jupyterhub/k8s-singleuser-sample:1.2.0
+FROM jupyterhub/k8s-singleuser-sample:1.1.0
 
 ARG TAG="dev"
 
 USER root
 
 ADD  start-elyra.sh /usr/local/bin/start-elyra.sh
+COPY elyra /tmp/elyra
 
-RUN chmod ugo+x /usr/local/bin/start-elyra.sh
+RUN chmod ugo+x /usr/local/bin/start-elyra.sh && \
+    fix-permissions /tmp/elyra && \
+    apt-get update && apt-get install -y build-essential && \
+    rm -rf /var/lib/apt/lists/*
 
 USER $NB_USER
 
+#RUN python -m pip install --upgrade pandas numpy
+#RUN npm install -g yarn
+#RUN cd /tmp/elyra && make clean install
+
 RUN python -m pip install --upgrade pandas numpy && \
-    python3 -m pip install --quiet --no-cache-dir --use-deprecated=legacy-resolver elyra[all]=="$TAG" && \
-    jupyter lab build
+    npm install -g yarn && \
+    cd /tmp/elyra && make clean install
 
 CMD ["/usr/local/bin/start-elyra.sh"]

--- a/etc/docker/elyra/Dockerfile.dev
+++ b/etc/docker/elyra/Dockerfile.dev
@@ -34,12 +34,9 @@ RUN chmod ugo+x /usr/local/bin/start-elyra.sh && \
 
 USER $NB_USER
 
-#RUN python -m pip install --upgrade pandas numpy
-#RUN npm install -g yarn
-#RUN cd /tmp/elyra && make clean install
-
 RUN python -m pip install --upgrade pandas numpy && \
     npm install -g yarn && \
+    npm install -g npm && \
     cd /tmp/elyra && make clean install
 
 CMD ["/usr/local/bin/start-elyra.sh"]


### PR DESCRIPTION
Enable building the Elyra docker image (dev tag) from the current checked-out source code.

Fixes #2116
Closes #2166 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
