### PR TITLE
Improve error messaging for comparisons involving entrypoints

### DIFF
--- a/elyra/metadata/schemasproviders.py
+++ b/elyra/metadata/schemasproviders.py
@@ -83,7 +83,7 @@ class RuntimesSchemas(ElyraSchemasProvider):
                     kfp_needed = True
             else:
                 self.log.error(f"No entrypoint with name '{schema['name']}' was found in group "
-                               f"'elyra.pipeline.processor'. Skipping...")
+                               f"'elyra.pipeline.processor' to match the schema with the same name. Skipping...")
 
         if kfp_needed:  # Update the kfp engine enum to reflect current packages...
             # If TektonClient package is missing, navigate to the engine property

--- a/elyra/metadata/schemasproviders.py
+++ b/elyra/metadata/schemasproviders.py
@@ -114,4 +114,5 @@ class CodeSnippetsSchemas(ElyraSchemasProvider):
 class ComponentRegistriesSchemas(ElyraSchemasProvider):
     """Returns schemas relative to Component Registries schemaspace."""
     def get_schemas(self) -> List[Dict]:
-        return self.get_local_schemas_by_schemaspace(ComponentRegistries.COMPONENT_REGISTRIES_SCHEMASPACE_ID)
+        schemas = self.get_local_schemas_by_schemaspace(ComponentRegistries.COMPONENT_REGISTRIES_SCHEMASPACE_ID)
+        return schemas

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -235,7 +235,7 @@ class ComponentCatalogConnector(LoggingConfigurable):
 
         except NotImplementedError as e:
             err_msg = f"{self.__class__.__name__} does not meet the requirements of a catalog connector class: {e}"
-            self.log.warning(err_msg)
+            self.log.error(err_msg)
         except Exception as e:
             err_msg = f"Could not get catalog entry information for catalog '{catalog_instance.display_name}': {e}"
             # Dump stack trace with error message
@@ -279,7 +279,7 @@ class ComponentCatalogConnector(LoggingConfigurable):
 
                 except NotImplementedError as e:
                     msg = f"{self.__class__.__name__} does not meet the requirements of a catalog connector class: {e}."
-                    self.log.warning(msg)
+                    self.log.error(msg)
                 except Exception as e:
                     # Dump stack trace with error message and continue
                     self.log.exception(f"Could not read definition for catalog entry with identifying information: "

--- a/elyra/pipeline/component_registry.py
+++ b/elyra/pipeline/component_registry.py
@@ -240,11 +240,15 @@ class ComponentRegistry(LoggingConfigurable):
         for catalog in catalogs:
             # Assign reader based on the type of the catalog (the 'schema_name')
             try:
-                catalog_reader = entrypoints.get_group_named('elyra.component.catalog_types')\
-                    .get(catalog.schema_name)\
-                    .load()(self._parser.file_types, parent=self.parent)
+                catalog_reader = entrypoints.get_group_named('elyra.component.catalog_types').get(catalog.schema_name)
+                if not catalog_reader:
+                    self.log.error(f"No entrypoint with name '{catalog.schema_name}' was found in group "
+                                   f"'elyra.component.catalog_types' to match the 'schema_name' given in catalog "
+                                   f"'{catalog.display_name}'. Skipping...")
+                    continue
+                catalog_reader = catalog_reader.load()(self._parser.file_types, parent=self.parent)
             except Exception as e:
-                self.log.warning(f"Could not load appropriate ComponentCatalogConnector class: {e}. Skipping...")
+                self.log.error(f"Could not load appropriate ComponentCatalogConnector class: {e}. Skipping...")
                 continue
 
             # Get content of component definition file for each component in this catalog


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR makes the error messaging more specific for cases where entrypoint names must match other names (e.g., catalog types `schema_name`s and runtime schema file names). 

This necessitates adding a logger to the `ElyraSchemasProvider`.

### How was this pull request tested?
This was manually tested to ensure that the correct errors are logged when no matching entrypoint name is encountered.

```
[E 2021-11-04 16:34:02.062 ElyraApp] No entrypoint with name 'local-directory-catalog' was found in group 'elyra.component.catalog_types' to match the 'schema_name' given in catalog 'Other Airflow Components'. Skipping...
```

```
[E 2021-11-04 16:34:01.571 ServerApp] No entrypoint with name 'kfp' was found in group 'elyra.pipeline.processor' to match the schema with the same name. Skipping...
```

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
