### PR TITLE
Sort palette nodes by component label

### DIFF
--- a/packages/pipeline-editor/src/pipeline-hooks.spec.ts
+++ b/packages/pipeline-editor/src/pipeline-hooks.spec.ts
@@ -45,7 +45,8 @@ const createMockCategory = (
 
 const createMockComponent = (name: string): Component => {
   return {
-    op: name,
+    op: 'string',
+    label: name,
     id: 'string',
     type: 'execution_node',
     inputs: [],

--- a/packages/pipeline-editor/src/pipeline-hooks.ts
+++ b/packages/pipeline-editor/src/pipeline-hooks.ts
@@ -85,6 +85,7 @@ export interface IRuntimeComponent {
   node_types: {
     op: string;
     id: string;
+    label: string;
     type: 'execution_node';
     inputs: { app_data: any }[];
     outputs: { app_data: any }[];
@@ -138,13 +139,9 @@ export const sortPalette = (palette: {
 
   for (const components of palette.categories) {
     components.node_types.sort((a, b) =>
-      a.app_data.ui_data.label.localeCompare(
-        b.app_data.ui_data.label,
-        undefined,
-        {
-          numeric: true
-        }
-      )
+      a.label.localeCompare(b.label, undefined, {
+        numeric: true
+      })
     );
   }
 };

--- a/packages/pipeline-editor/src/pipeline-hooks.ts
+++ b/packages/pipeline-editor/src/pipeline-hooks.ts
@@ -138,7 +138,13 @@ export const sortPalette = (palette: {
 
   for (const components of palette.categories) {
     components.node_types.sort((a, b) =>
-      a.op.localeCompare(b.op, undefined, { numeric: true })
+      a.app_data.ui_data.label.localeCompare(
+        b.app_data.ui_data.label,
+        undefined,
+        {
+          numeric: true
+        }
+      )
     );
   }
 };


### PR DESCRIPTION
Resolves #2171 (again)

After the merge of #2241, the component `op`s are no longer in alphabetical order according to the label (name) of the component. 

Note that `localeCompare` is already case insensitive.

### What changes were proposed in this pull request?
This PR gets the label from the palette nodes from the `app_data.ui_data.label` field. The top-level `label` field (not within `app_data.ui_data`) appears to be available on each node object, but when trying to directly access it directly, build fails with the following error: 

```
@elyra/pipeline-editor-extension: src/pipeline-hooks.ts(142,9): error TS2339: Property 'label' does not exist on type '{ op: string; id: string; type: "execution_node"; inputs: { app_data: any; }[]; outputs: { app_data: any; }[]; app_data: any; }'.
```

I **think** this might have something to do with Canvas and how they enforce attributes on a node? I'm guessing this is what @bourdakos1 was alluding to with his comment [here](https://github.com/elyra-ai/elyra/blob/5eceb1753e45801bfc356a91582d045cb551daf1/packages/pipeline-editor/src/pipeline-hooks.ts#L124).

All this to say, this PR seems to work, but I don't know if it's the best way to get it done. Will definitely need some input from the frontend experts.

### How was this pull request tested?
Tested manually to ensure that components are sorted by label.
 
<img width="260" alt="Screen Shot 2021-11-04 at 5 37 47 PM" src="https://user-images.githubusercontent.com/31816267/140429929-db1d23f3-e105-460e-a3d3-3739def21fde.png">

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
