### PR TITLE
Fix contents handler path handling

### DIFF
--- a/elyra/elyra_app.py
+++ b/elyra/elyra_app.py
@@ -73,7 +73,7 @@ class ElyraApp(ExtensionAppJinjaMixin, ExtensionApp):
     def initialize_handlers(self):
         schemaspace_regex = r"(?P<schemaspace>[\w\.\-]+)"
         resource_regex = r"(?P<resource>[\w\.\-]+)"
-        path_regex = r"(?P<path>[\w\.\/\-\%]+)"
+        path_regex = r"(?P<path>(?:(?:/[^/]+)+|/?))"  # same as jupyter server and will include a leading slash
         processor_regex = r"(?P<processor>[\w]+)"
         component_regex = r"(?P<component_id>[\w\.\-:]+)"
 
@@ -90,7 +90,7 @@ class ElyraApp(ExtensionAppJinjaMixin, ExtensionApp):
             (f'/{self.name}/pipeline/components/{processor_regex}', PipelineComponentHandler),
             (f'/{self.name}/pipeline/components/{processor_regex}/{component_regex}/properties',
              PipelineComponentPropertiesHandler),
-            (f'/{self.name}/contents/properties/{path_regex}', ContentHandler),
+            (f'/{self.name}/contents/properties{path_regex}', ContentHandler),
             (f'/{self.name}/elyra/pipeline/validate', PipelineValidationHandler),
         ])
 

--- a/elyra/tests/contents/conftest.py
+++ b/elyra/tests/contents/conftest.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import json
+import os
 
 import pytest
 
@@ -61,24 +62,28 @@ def create_text_file(jp_root_dir, text_filename):
     create_file(jp_root_dir, text_filename, text_content)
 
 
-@pytest.fixture
-def create_notebook_file(jp_root_dir, notebook_filename):
-    create_file(jp_root_dir, notebook_filename, json.dumps(notebook_content))
+@pytest.fixture(params=['', '@subdir'])  # Create in a "difficult" subdir https://github.com/elyra-ai/elyra/issues/2270
+def create_notebook_file(jp_root_dir, notebook_filename, request):
+    create_file(jp_root_dir, notebook_filename, json.dumps(notebook_content), subdir=request.param)
+    yield os.path.join(request.param, notebook_filename)
 
 
-@pytest.fixture
-def create_python_file(jp_root_dir, python_filename):
-    create_file(jp_root_dir, python_filename, python_content)
+@pytest.fixture(params=['', '@subdir'])  # Create in a "difficult" subdir https://github.com/elyra-ai/elyra/issues/2270
+def create_python_file(jp_root_dir, python_filename, request):
+    create_file(jp_root_dir, python_filename, python_content, subdir=request.param)
+    yield os.path.join(request.param, python_filename)
 
 
-@pytest.fixture
-def create_r_file(jp_root_dir, r_filename):
-    create_file(jp_root_dir, r_filename, r_content)
+@pytest.fixture(params=['', '@subdir'])  # Create in a "difficult" subdir https://github.com/elyra-ai/elyra/issues/2270
+def create_r_file(jp_root_dir, r_filename, request):
+    create_file(jp_root_dir, r_filename, r_content, subdir=request.param)
+    yield os.path.join(request.param, r_filename)
 
 
-@pytest.fixture
-def create_empty_notebook_file(jp_root_dir, notebook_filename):
-    create_file(jp_root_dir, notebook_filename, json.dumps(empty_notebook_content))
+@pytest.fixture(params=['', '@subdir'])  # Create in a "difficult" subdir https://github.com/elyra-ai/elyra/issues/2270
+def create_empty_notebook_file(jp_root_dir, notebook_filename, request):
+    create_file(jp_root_dir, notebook_filename, json.dumps(empty_notebook_content), subdir=request.param)
+    yield os.path.join(request.param, notebook_filename)
 
 
 # Set Elyra server extension as enabled (overriding server_config fixture from jupyter_server)

--- a/elyra/tests/contents/test_handlers.py
+++ b/elyra/tests/contents/test_handlers.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import json
+# import os
 
 from jupyter_server.tests.utils import expected_http_error
 import pytest
@@ -51,29 +52,29 @@ async def test_invalid_file_type(jp_fetch, create_text_file, text_filename):
     assert json.loads(response.body) == expected_response_empty
 
 
-async def test_valid_notebook(jp_fetch, create_notebook_file, notebook_filename):
-    response = await jp_fetch('elyra', 'contents/properties', notebook_filename)
+async def test_valid_notebook(jp_fetch, create_notebook_file):
+    response = await jp_fetch('elyra', 'contents/properties', create_notebook_file)
 
     assert response.code == 200
     assert json.loads(response.body) == expected_response
 
 
-async def test_valid_python_file(jp_fetch, create_python_file, python_filename):
-    response = await jp_fetch('elyra', 'contents/properties', python_filename)
+async def test_valid_python_file(jp_fetch, create_python_file):
+    response = await jp_fetch('elyra', 'contents/properties', create_python_file)
 
     assert response.code == 200
     assert json.loads(response.body) == expected_response
 
 
-async def test_valid_r_file(jp_fetch, create_r_file, r_filename):
-    response = await jp_fetch('elyra', 'contents/properties', r_filename)
+async def test_valid_r_file(jp_fetch, create_r_file):
+    response = await jp_fetch('elyra', 'contents/properties', create_r_file)
 
     assert response.code == 200
     assert json.loads(response.body) == expected_response
 
 
-async def test_empty_notebook(jp_fetch, create_empty_notebook_file, notebook_filename):
-    response = await jp_fetch('elyra', 'contents/properties', notebook_filename)
+async def test_empty_notebook(jp_fetch, create_empty_notebook_file):
+    response = await jp_fetch('elyra', 'contents/properties', create_empty_notebook_file)
 
     assert response.code == 200
     assert json.loads(response.body) == expected_response_empty

--- a/elyra/tests/contents/test_utils.py
+++ b/elyra/tests/contents/test_utils.py
@@ -26,14 +26,15 @@ def create_dir(location, dir_name):
             raise
 
 
-def create_file(location, file_name, content):
+def create_file(location, file_name, content, subdir=''):
+    directory = os.path.join(location, subdir)
     try:
-        os.makedirs(location)
+        os.makedirs(directory)
     except OSError as e:
         if e.errno != errno.EEXIST:
             raise
 
-    resource = os.path.join(location, file_name)
+    resource = os.path.join(directory, file_name)
     with open(resource, 'w', encoding='utf-8') as f:
         f.write(content)
 


### PR DESCRIPTION
This pull request adjusts the regular expression used to configure the Elyra contents handler to the same expression used in Jupyter Server (where the described issue does not occur).  The issue at hand was due to an `@` being included in the parent directory of the notebook file.  When present, the regular expression that allows the webserver to direct requests to the handler was not able to map the request to the contents handler - thereby producing a 404.

The change was tested in two ways.  First, the automated tests were updated to execute twice, once without a sub-directory, the second with a sub-directory containing an `@` character.  However, it should be noted that these tests did NOT reproduce the problem and I suspect it has something to do with the `fp_fetch` pytest fixture "mocking" the webserver.  That said, manual testing does indicate the issue is fixed.  Since this anomaly was found following the code changes, the test updates were retained since they are a good exercise anyway.
 
Fixes #2270 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
