### PR TITLE
Reduce airflow component parser output

### DIFF
--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -125,7 +125,7 @@ class AirflowComponentParser(ComponentParser):
             data_type_info = self.determine_type_information(data_type)
             if data_type_info.undetermined:
                 self.log.debug(f"Data type from parsed data ('{data_type}') could not be determined. "
-                                 f"Proceeding as if 'string' was detected.")
+                               f"Proceeding as if 'string' was detected.")
 
             properties.append(
                 ComponentParameter(

--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -124,7 +124,7 @@ class AirflowComponentParser(ComponentParser):
 
             data_type_info = self.determine_type_information(data_type)
             if data_type_info.undetermined:
-                self.log.warning(f"Data type from parsed data ('{data_type}') could not be determined. "
+                self.log.debug(f"Data type from parsed data ('{data_type}') could not be determined. "
                                  f"Proceeding as if 'string' was detected.")
 
             properties.append(


### PR DESCRIPTION
This PR changes the log level of an Airflow component parser message from warning to debug. The change removes messages like this one from the non-debug log:

```
[W 2021-11-09 11:58:03,038.038] Data type from parsed data ('A lambda or defined function.') could not be determined. Proceeding as if 'string' was detected.
```

The change aligns the behavior with the behavior of the [KFP component parser](https://github.com/elyra-ai/elyra/blob/master/elyra/pipeline/kfp/component_parser_kfp.py#L94-L95).

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
