### PR TITLE
Add hidden uihint for fields not to be displayed in editor

### DIFF
--- a/elyra/metadata/schemas/airflow.json
+++ b/elyra/metadata/schemas/airflow.json
@@ -34,7 +34,10 @@
           "title": "Runtime Type",
           "description": "The runtime associated with this instance",
           "type": "string",
-          "const": "APACHE_AIRFLOW"
+          "const": "APACHE_AIRFLOW",
+          "uihints": {
+            "hidden": true
+          }
         },
         "description": {
           "title": "Description",

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -34,7 +34,10 @@
           "title": "Runtime Type",
           "description": "The runtime associated with this instance",
           "type": "string",
-          "const": "KUBEFLOW_PIPELINES"
+          "const": "KUBEFLOW_PIPELINES",
+          "uihints": {
+            "hidden": true
+          }
         },
         "description": {
           "title": "Description",

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -486,6 +486,9 @@ export class MetadataEditor extends ReactWidget {
       uihints = {};
       this.schema[fieldName].uihints = uihints;
     }
+    if (uihints.hidden) {
+      return <div />;
+    }
     if (
       uihints.field_type === 'textinput' ||
       uihints.field_type === undefined


### PR DESCRIPTION
Addresses #2269 for now (shouldn't close the issue though). Allows for a `uihint` to be set in the schema for fields that shouldn't be displayed in the metadata editor. Changes the airflow and kfp schema to use the hidden flag for runtime type. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
