### PR TITLE
Fix frontend metadata title

### DIFF
--- a/packages/metadata-common/src/AddMetadataButton.tsx
+++ b/packages/metadata-common/src/AddMetadataButton.tsx
@@ -36,6 +36,7 @@ export interface IAddMetadataButtonProps {
   schemas?: IDictionary<any>[];
   addMetadata: (schema: string) => void;
   titleContext?: string;
+  appendToTitle?: boolean;
 }
 
 const StyledButton = styled(Button)({
@@ -107,11 +108,7 @@ export const AddMetadataButton = (
                 <MenuItem
                   key={schema.title}
                   title={`New ${schema.title} ${
-                    schema.title
-                      .toLowerCase()
-                      .includes(props.titleContext?.toLocaleLowerCase())
-                      ? ''
-                      : props.titleContext
+                    props.appendToTitle ? props.titleContext : ''
                   }`}
                   onClick={(event: any): void => {
                     props.addMetadata(schema.name);
@@ -119,11 +116,7 @@ export const AddMetadataButton = (
                   }}
                 >
                   {`New ${schema.title} ${
-                    schema.title
-                      .toLowerCase()
-                      .includes(props.titleContext?.toLocaleLowerCase())
-                      ? ''
-                      : props.titleContext
+                    props.appendToTitle ? props.titleContext : ''
                   }`}
                 </MenuItem>
               ))}

--- a/packages/metadata-common/src/AddMetadataButton.tsx
+++ b/packages/metadata-common/src/AddMetadataButton.tsx
@@ -34,7 +34,7 @@ export const METADATA_HEADER_POPPER_CLASS = 'elyra-metadataHeader-popper';
 
 export interface IAddMetadataButtonProps {
   schemas?: IDictionary<any>[];
-  addMetadata: (schema: string) => void;
+  addMetadata: (schema: string, titleContext?: string) => void;
   titleContext?: string;
   appendToTitle?: boolean;
 }
@@ -111,7 +111,7 @@ export const AddMetadataButton = (
                     props.appendToTitle ? props.titleContext : ''
                   }`}
                   onClick={(event: any): void => {
-                    props.addMetadata(schema.name);
+                    props.addMetadata(schema.name, props.titleContext);
                     handleClose(event);
                   }}
                 >

--- a/packages/metadata-common/src/MetadataEditor.tsx
+++ b/packages/metadata-common/src/MetadataEditor.tsx
@@ -177,6 +177,7 @@ export class MetadataEditor extends ReactWidget {
   displayName?: string;
   editor?: CodeEditor.IEditor;
   schemaDisplayName?: string;
+  titleContext?: string;
   dirty?: boolean;
   requiredFields?: string[];
   referenceURL?: string;
@@ -630,7 +631,8 @@ export class MetadataEditor extends ReactWidget {
     }
     let headerText = `Edit "${this.displayName}"`;
     if (!this.name) {
-      headerText = `Add new ${this.schemaDisplayName}`;
+      headerText = `Add new ${this.schemaDisplayName} ${this.titleContext ??
+        ''}`;
     }
     const error = this.displayName === '' && this.invalidForm;
     const onKeyPress: React.KeyboardEventHandler = (

--- a/packages/metadata-common/src/MetadataWidget.tsx
+++ b/packages/metadata-common/src/MetadataWidget.tsx
@@ -326,6 +326,7 @@ export interface IMetadataWidgetProps {
   schemaspace: string;
   icon: LabIcon;
   titleContext?: string;
+  appendToTitle?: boolean;
 }
 
 /**
@@ -449,6 +450,7 @@ export class MetadataWidget extends ReactWidget {
               schemas={this.schemas}
               addMetadata={this.addMetadata}
               titleContext={this.titleContext}
+              appendToTitle={this.props.appendToTitle}
             />
           </header>
           <UseSignal signal={this.renderSignal} initialArgs={[]}>

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -60,6 +60,7 @@ const extension: JupyterFrontEndPlugin<void> = {
       schemaspace: string;
       name?: string;
       onSave: () => void;
+      titleContext?: string;
     }): void => {
       let widgetLabel: string;
       if (args.name) {
@@ -92,6 +93,7 @@ const extension: JupyterFrontEndPlugin<void> = {
       metadataEditorWidget.title.closable = true;
       metadataEditorWidget.title.icon = textEditorIcon;
       metadataEditorWidget.addClass(METADATA_EDITOR_ID);
+      metadataEditorWidget.titleContext = args.titleContext;
       app.shell.add(metadataEditorWidget, 'main');
     };
 

--- a/packages/pipeline-editor/src/RuntimesWidget.tsx
+++ b/packages/pipeline-editor/src/RuntimesWidget.tsx
@@ -144,6 +144,15 @@ export class RuntimesWidget extends MetadataWidget {
     return 'runtime configuration';
   };
 
+  addMetadata(schema: string, titleContext?: string): void {
+    this.openMetadataEditor({
+      onSave: this.updateMetadata,
+      schemaspace: this.props.schemaspace,
+      schema: schema,
+      titleContext: titleContext
+    });
+  }
+
   renderDisplay(metadata: IMetadata[]): React.ReactElement {
     if (Array.isArray(metadata) && !metadata.length) {
       // Empty metadata

--- a/packages/pipeline-editor/src/RuntimesWidget.tsx
+++ b/packages/pipeline-editor/src/RuntimesWidget.tsx
@@ -52,6 +52,7 @@ export interface IRuntimesDisplayProps extends IMetadataDisplayProps {
   className: string;
   schemas?: IDictionary<any>[];
   titleContext?: string;
+  appendToTitle?: boolean;
 }
 
 /**
@@ -167,6 +168,7 @@ export class RuntimesWidget extends MetadataWidget {
         className={RUNTIMES_METADATA_CLASS}
         labelName={this.getSchemaTitle}
         titleContext={this.props.titleContext}
+        appendToTitle={this.props.appendToTitle}
       />
     );
   }

--- a/packages/pipeline-editor/src/index.ts
+++ b/packages/pipeline-editor/src/index.ts
@@ -309,7 +309,8 @@ const extension: JupyterFrontEndPlugin<void> = {
       display_name: 'Runtimes',
       schemaspace: RUNTIMES_SCHEMASPACE,
       icon: runtimesIcon,
-      titleContext: 'runtime configuration'
+      titleContext: 'runtime configuration',
+      appendToTitle: true
     });
     const runtimesWidgetID = `elyra-metadata:${RUNTIMES_SCHEMASPACE}`;
     runtimesWidget.id = runtimesWidgetID;


### PR DESCRIPTION
When clicking the `+` button to add a new metadata and the corresponding schemaspace contains multiple schemas (runtimes or component registries), a list of metadata options is displayed.
The title of each option is defined by each schema title property, with an optional context title appended by the widget for better clarification.

Currently the additional text is only necessary to better describe runtime configurations, not necessary for component catalogs, as below:
![image](https://user-images.githubusercontent.com/25207344/141508893-3bf34840-dc8f-47bb-857d-a6e3ef32e4b6.png)
![image](https://user-images.githubusercontent.com/25207344/141508903-2b73085e-d584-47bf-821c-d0709bdcf7ca.png)
This PR fixes the logic of how the additional context is added.

### What changes were proposed in this pull request?
Introduce `appendToTitle` property to Metadata Widgets, which defines when `titleContext` info is appended to the list of metadata options after clicking the Add new metadata `+` button. This value is only used by runtimes widget.
As more metadata widgets are added, this property can still be used or not, depending on the need.

### How was this pull request tested?
Manual testing: Open Runtimes and Component Catalog widgets, click the Add new metadada button `+` and check the option labels are displayed as expected.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
