### PR TITLE
Update components section with migration instructions

### DIFF
--- a/docs/source/user_guide/pipeline-components.md
+++ b/docs/source/user_guide/pipeline-components.md
@@ -166,10 +166,10 @@ $ elyra-metadata remove component-registries \
 
 Refer to section [Configuration properties](#configuration-properties) for parameter descriptions.
 
-#### Migrating user-defined component registries to 3.3
+### Migrating user-defined component registries to 3.3
 The Elyra 3.3 release renames _Component Registries_ to _Component Catalogs_ and splits the `component-registry` schema into three separate "component catalog" schemas based on the old schema's `location-type`.  As a result, any  user-defined component registry instances created prior to Elyra 3.3 will not be available until migrated.  This migration is performed using the `elyra-metadata` CLI tool.
 
-##### Determining instances to migrate
+#### Determining instances to migrate
 To determine the instances available to migrate, issue the following command:
 ```bash
 $ elyra-metadata list component-registries
@@ -193,7 +193,7 @@ Metadata instance 'aa_custom' removed from schemaspace 'component-registries'.
 
 Note: Because the `component-registries` schemaspace has been deprecated, instances can be listed, removed, or migrated, but not created.
 
-##### Migrating instances
+#### Migrating instances
 Once the set of component registry instances to migrate have been determined, issue the following command to migrate the remaining instances:
 ```bash
 $ elyra-metadata migrate component-registries
@@ -204,7 +204,17 @@ Upon completion, which should be on the order of seconds, output similar to the 
 [I 2021-11-15 11:05:48,042.042] Migrating 'component-registries' instance 'airflow_components' to schema 'url-catalog' of schemaspace 'component-catalogs'...
 The following component-registries instances were migrated: ['myoperators', 'airflow_components']
 ```
-Once migrated, these entries should appear in the set of component catalogs.
+Once migrated, these entries should appear in the set of component catalogs.  This can be confirmed by listing the component-catalogs instances:
+```bash
+$ elyra-metadata list component-catalogs
+Available metadata instances for component-catalogs (includes invalid):
+
+Schema                    Instance                            Resource                                                                                                         
+------                    --------                            --------                                                                                                             
+local-file-catalog        aa_custom                           /Users/jovyan/Library/Jupyter/metadata/component-catalogs/aa_custom.json                                         
+local-file-catalog        myoperators                         /Users/jovyan/Library/Jupyter/metadata/component-catalogs/myoperators.json                                       
+url-catalog               airflow_components                  /Users/jovyan/Library/Jupyter/metadata/component-catalogs/airflow_components.json                                             
+```
 
 ### Configuration properties
 

--- a/docs/source/user_guide/pipeline-components.md
+++ b/docs/source/user_guide/pipeline-components.md
@@ -166,6 +166,46 @@ $ elyra-metadata remove component-registries \
 
 Refer to section [Configuration properties](#configuration-properties) for parameter descriptions.
 
+#### Migrating user-defined component registries to 3.3
+The Elyra 3.3 release renames _Component Registries_ to _Component Catalogs_ and splits the `component-registry` schema into three separate "component catalog" schemas based on the old schema's `location-type`.  As a result, any  user-defined component registry instances created prior to Elyra 3.3 will not be available until migrated.  This migration is performed using the `elyra-metadata` CLI tool.
+
+##### Determining instances to migrate
+To determine the instances available to migrate, issue the following command:
+```bash
+$ elyra-metadata list component-registries
+```
+In this example, there are three user-defined instances.
+```bash
+Available metadata instances for component-registries (includes invalid):
+
+Schema               Instance            Resource
+------               --------            --------
+component-registry   airflow_components  /Users/jovyan/Library/Jupyter/metadata/component-registries/airflow_components.json
+component-registry   aa_custom           /Users/jovyan/Library/Jupyter/metadata/component-registries/aa_custom.json
+component-registry   myoperators         /Users/jovyan/Library/Jupyter/metadata/component-registries/myoperators.json
+```
+You may find that some of these instances no longer apply.  If there are any that do not apply to 3.3, they can be removed individually:
+```bash
+$ elyra-metadata remove component-registries --name=aa_custom
+
+Metadata instance 'aa_custom' removed from schemaspace 'component-registries'.
+````
+
+Note: Because the `component-registries` schemaspace has been deprecated, instances can be listed, removed, or migrated, but not created.
+
+##### Migrating instances
+Once the set of component registry instances to migrate have been determined, issue the following command to migrate the remaining instances:
+```bash
+$ elyra-metadata migrate component-registries
+```
+Upon completion, which should be on the order of seconds, output similar to the following should be produced:
+```
+[I 2021-11-15 11:05:48,012.012] Migrating 'component-registries' instance 'myoperators' to schema 'local-file-catalog' of schemaspace 'component-catalogs'...
+[I 2021-11-15 11:05:48,042.042] Migrating 'component-registries' instance 'airflow_components' to schema 'url-catalog' of schemaspace 'component-catalogs'...
+The following component-registries instances were migrated: ['myoperators', 'airflow_components']
+```
+Once migrated, these entries should appear in the set of component catalogs.
+
 ### Configuration properties
 
 The component registry entry properties are defined as follows. The string in the headings below, which is enclosed in parentheses, denotes the CLI option name.


### PR DESCRIPTION
This pull request updates the user guide's Pipeline Components section with instructions on how to migrate user-defined component-registry instances for the Elyra 3.3 release.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
