### PR TITLE
Remove redundant entry from pipeline validation endpoint

### DIFF
--- a/elyra/elyra_app.py
+++ b/elyra/elyra_app.py
@@ -91,7 +91,7 @@ class ElyraApp(ExtensionAppJinjaMixin, ExtensionApp):
             (f'/{self.name}/pipeline/components/{processor_regex}/{component_regex}/properties',
              PipelineComponentPropertiesHandler),
             (f'/{self.name}/contents/properties{path_regex}', ContentHandler),
-            (f'/{self.name}/elyra/pipeline/validate', PipelineValidationHandler),
+            (f'/{self.name}/pipeline/validate', PipelineValidationHandler),
         ])
 
     def initialize_settings(self):


### PR DESCRIPTION
While doing other work, I noticed the validation endpoint definition was including a redundant `elyra/` entry.  This PR removes that entry.  Since nothing is calling this endpoint, this change is safe to make at this time.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
