### PR TITLE
Fix export dialog title for generic pipelines

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -540,7 +540,7 @@ const PipelineWrapper: React.FC<IProps> = ({
       });
 
       let title = `${actionType} pipeline`;
-      if (actionType === 'export' || type !== undefined) {
+      if (type !== undefined) {
         title = `${actionType} pipeline for ${runtimeDisplayName}`;
 
         if (!isRuntimeTypeAvailable(runtimeData, type)) {

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -445,6 +445,11 @@ describe('Pipeline Editor tests', () => {
     // try to export valid pipeline
     cy.findByRole('button', { name: /export pipeline/i }).click();
 
+    // check label for generic pipeline
+    cy.get('.jp-Dialog-header').contains('Export pipeline');
+
+    cy.findByLabelText(/runtime platform/i).select('KUBEFLOW_PIPELINES');
+
     cy.findByLabelText(/runtime configuration/i)
       .select('test_runtime') // there might be other runtimes present when testing locally, so manually select.
       .should('have.value', 'test_runtime');
@@ -476,6 +481,11 @@ describe('Pipeline Editor tests', () => {
 
     // try to export valid pipeline
     cy.findByRole('button', { name: /export pipeline/i }).click();
+
+    // check label for generic pipeline
+    cy.get('.jp-Dialog-header').contains('Export pipeline');
+
+    cy.findByLabelText(/runtime platform/i).select('KUBEFLOW_PIPELINES');
 
     cy.findByLabelText(/runtime configuration/i)
       .select('test_runtime') // there might be other runtimes present when testing locally, so manually select.
@@ -611,22 +621,20 @@ describe('Pipeline Editor tests', () => {
     cy.findByRole('button', { name: /cancel/i }).click();
   });
 
-  // TODO: Uncomment tests below once final values are in place
+  it('generic pipeline toolbar should display expected runtime', () => {
+    cy.createPipeline();
+    cy.get('.toolbar-icon-label').contains(/runtime: generic/i);
+  });
 
-  // it('generic pipeline should display expected runtime', () => {
-  //   cy.createPipeline();
-  //   cy.get('.toolbar-icon-label').contains('Runtime: Generic');
-  // });
+  it('kfp pipeline toolbar should display expected runtime', () => {
+    cy.createPipeline({ type: 'kfp' });
+    cy.get('.toolbar-icon-label').contains(/runtime: kubeflow pipelines/i);
+  });
 
-  // it('kfp pipeline should display expected runtime', () => {
-  //   cy.createPipeline({ type: 'kfp' });
-  //   cy.get('.toolbar-icon-label').contains('Runtime: Kubeflow Pipelines');
-  // });
-
-  // it('airflow pipeline should display expected runtime', () => {
-  //   cy.createPipeline({ type: 'airflow' });
-  //   cy.get('.toolbar-icon-label').contains('Runtime: Apache Airflow');
-  // });
+  it('airflow pipeline toolbar should display expected runtime', () => {
+    cy.createPipeline({ type: 'airflow' });
+    cy.get('.toolbar-icon-label').contains(/runtime: apache airflow/i);
+  });
 });
 
 // ------------------------------


### PR DESCRIPTION
Fixes #2319 
Update the dialog title used to export generic pipelines, which currently reads `Export pipeline for Generic`.

### What changes were proposed in this pull request?
Dropped the additional export title for generic pipelines
![image](https://user-images.githubusercontent.com/25207344/143086459-8b8cfa82-32ef-47ca-9182-73cd0b0e2ee8.png)

For runtime specific pipelines, the additional context is still used
![image](https://user-images.githubusercontent.com/25207344/143086596-c118d229-2748-43f1-9afe-b4e712dae605.png)

### How was this pull request tested?
Added integration test for export dialog title.
(unrelated to this PR) Uncommented integration tests for runtime info displayed in the VPE toolbar.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
