### PR TITLE
Reintroduce error handling for pipeline export

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -587,15 +587,17 @@ const PipelineWrapper: React.FC<IProps> = ({
         allowLocal: actionType === 'run'
       });
 
-      let title = `${actionType} pipeline`;
-      if (type !== undefined) {
-        title = `${actionType} pipeline for ${runtimeDisplayName}`;
+      let title =
+        type !== undefined
+          ? `${actionType} pipeline for ${runtimeDisplayName}`
+          : `${actionType} pipeline`;
 
+      if (actionType === 'export' || type !== undefined) {
         if (!isRuntimeTypeAvailable(runtimeData, type)) {
           const res = await RequestErrors.noMetadataError(
             'runtime',
             `${actionType} pipeline.`,
-            runtimeDisplayName
+            type !== undefined ? runtimeDisplayName : undefined
           );
 
           if (res.button.label.includes(RUNTIMES_SCHEMASPACE)) {


### PR DESCRIPTION
The error handling for the case of no runtimes when exporting a
pipeline was removed in #2320 this reintroduces it without reverting
the solution in that PR

Fixes #2332

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
