### PR TITLE
Add catalog type information to DAG for custom components

### DIFF
--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -349,7 +349,7 @@ be fully qualified (i.e., prefixed with their package names).
                              'class_name': component.name,
                              'parent_operation_ids': operation.parent_operation_ids,
                              'component_params': operation.component_params_as_dict,
-                             'operator_source': component.source_identifier,
+                             'operator_source': component.component_source,
                              'is_generic_operator': False
                              }
 


### PR DESCRIPTION
Fixes #2323 

### What changes were proposed in this pull request?
This PR adds the full `component_source` field for a component to the informational comment above each custom component in the DAG.

<img width="1020" alt="Screen Shot 2021-12-02 at 10 18 04 AM" src="https://user-images.githubusercontent.com/31816267/144460716-52aaf945-a5b9-4940-8d26-b471331a85c9.png">

Beforehand, only the `component_ref` portion of the data structure showed up, i.e.:

```
...
# Operator source: {'component-id': 'http_operator.py'}
op_98d6968d_aa93_45fc_a368_b2db45c841fa = SimpleHttpOperator(
...
```

### How was this pull request tested?
This comment portion of the DAG isn't explicitly tested and it is probably unnecessary to do so
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
