### PR TITLE
Re-add integration test for runtime specific components in the palette

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,7 @@ jobs:
         run: |
           make yarn-install
           make only-install-server
+          make install-examples
       - name: Build
         run: make build-ui
       - name: Setup JupyterLab

--- a/Makefile
+++ b/Makefile
@@ -177,10 +177,10 @@ test-ui: lint-ui test-ui-unit test-integration # Run frontend tests
 test-ui-unit: # Run frontend jest unit tests
 	yarn test:unit
 
-test-integration: # Run frontend cypress integration tests
+test-integration: install-examples # Run frontend cypress integration tests
 	yarn test:integration
 
-test-integration-debug: # Open cypress integration test debugger
+test-integration-debug: install-examples # Open cypress integration test debugger
 	yarn test:integration:debug
 
 test: test-server test-ui ## Run all tests (backend, frontend and cypress integration tests)

--- a/Makefile
+++ b/Makefile
@@ -177,10 +177,10 @@ test-ui: lint-ui test-ui-unit test-integration # Run frontend tests
 test-ui-unit: # Run frontend jest unit tests
 	yarn test:unit
 
-test-integration: install-examples # Run frontend cypress integration tests
+test-integration: # Run frontend cypress integration tests
 	yarn test:integration
 
-test-integration-debug: install-examples # Open cypress integration test debugger
+test-integration-debug: # Open cypress integration test debugger
 	yarn test:integration:debug
 
 test: test-server test-ui ## Run all tests (backend, frontend and cypress integration tests)

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -544,27 +544,22 @@ describe('Pipeline Editor tests', () => {
     });
   });
 
-  /**
-   * Runtime-specific components are no longer included by default
-   * as of PR2286: https://github.com/elyra-ai/elyra/pull/2286.
-   *
-   * These tests will be revisited at a later time. See issue for
-   * more: https://github.com/elyra-ai/elyra/issues/2298
-   *
   it('kfp pipeline should display custom components', () => {
+    cy.createExampleComponentCatalog({ type: 'kfp' });
     cy.createPipeline({ type: 'kfp' });
-    cy.expandPaletteCategory({ type: 'kfp' });
+    cy.expandPaletteCategory();
 
     const kfpCustomComponents = [
-      'local-directory-catalog\\:737915b826e9', // filter text
-      'local-directory-catalog\\:61e6f4141f65' // run notebook using papermill
+      'elyra-kfp-examples-catalog\\:61e6f4141f65', // run notebook using papermill
+      'elyra-kfp-examples-catalog\\:737915b826e9', // filter text
+      'elyra-kfp-examples-catalog\\:a08014f9252f', // download data
+      'elyra-kfp-examples-catalog\\:d68ec7fcdf46' // calculate data hash
     ];
 
     kfpCustomComponents.forEach(component => {
       cy.get(`#${component}`).should('exist');
     });
   });
-  **/
 
   it('kfp pipeline should display expected export options', () => {
     cy.createPipeline({ type: 'kfp' });
@@ -581,30 +576,24 @@ describe('Pipeline Editor tests', () => {
     cy.findByRole('button', { name: /cancel/i }).click();
   });
 
-  /**
-   * Runtime-specific components are no longer included by default
-   * as of PR2286: https://github.com/elyra-ai/elyra/pull/2286.
-   *
-   * These tests will be revisited at a later time. See issue for
-   * more: https://github.com/elyra-ai/elyra/issues/2298
-   *
   it('airflow pipeline should display custom components', () => {
+    cy.createExampleComponentCatalog({ type: 'airflow' });
     cy.createPipeline({ type: 'airflow' });
-    cy.expandPaletteCategory({ type: 'airflow' });
+    cy.expandPaletteCategory();
 
     const airflowCustomComponents = [
-      'url-catalog\\:49f8e61b78c3', // bash operator
-      'url-catalog\\:8bef428ea3cd', // email operator
-      'url-catalog\\:e97030fb448a', // http operator
-      'url-catalog\\:ff0d51b70719', // spark sql operator
-      'url-catalog\\:2756314f3ff5' // spark submit operator
+      'elyra-airflow-examples-catalog\\:3a55d015ea96', // bash operator
+      'elyra-airflow-examples-catalog\\:a043648d3897', // email operator
+      'elyra-airflow-examples-catalog\\:b94cd49692e2', // http operator
+      'elyra-airflow-examples-catalog\\:3b639742748f', // spark sql operator
+      'elyra-airflow-examples-catalog\\:b29c25ec8bd6', // spark submit operator
+      'elyra-airflow-examples-catalog\\:16a204f716a2' // slack post operator
     ];
 
     airflowCustomComponents.forEach(component => {
       cy.get(`#${component}`).should('exist');
     });
   });
-  **/
 
   it('airflow pipeline should display expected export options', () => {
     cy.createPipeline({ type: 'airflow' });

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -49,13 +49,7 @@ describe('Pipeline Editor tests', () => {
 
     // delete example catalogs used for testing
     cy.exec(
-      'elyra-metadata remove component-catalogs --name=example_components_-_kfp',
-      {
-        failOnNonZeroExit: false
-      }
-    );
-    cy.exec(
-      'elyra-metadata remove component-catalogs --name=example_components_-_airflow',
+      'elyra-metadata remove component-catalogs --name=example_components',
       {
         failOnNonZeroExit: false
       }
@@ -561,7 +555,7 @@ describe('Pipeline Editor tests', () => {
   it('kfp pipeline should display custom components', () => {
     cy.createExampleComponentCatalog({ type: 'kfp' });
     cy.createPipeline({ type: 'kfp' });
-    cy.expandPaletteCategory();
+    cy.get('.palette-flyout-category[value="examples"]').click();
 
     const kfpCustomComponents = [
       'elyra-kfp-examples-catalog\\:61e6f4141f65', // run notebook using papermill
@@ -593,7 +587,7 @@ describe('Pipeline Editor tests', () => {
   it('airflow pipeline should display custom components', () => {
     cy.createExampleComponentCatalog({ type: 'airflow' });
     cy.createPipeline({ type: 'airflow' });
-    cy.expandPaletteCategory();
+    cy.get('.palette-flyout-category[value="examples"]').click();
 
     const airflowCustomComponents = [
       'elyra-airflow-examples-catalog\\:3a55d015ea96', // bash operator

--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -46,6 +46,20 @@ describe('Pipeline Editor tests', () => {
     cy.exec('elyra-metadata remove runtimes --name=test_runtime', {
       failOnNonZeroExit: false
     });
+
+    // delete example catalogs used for testing
+    cy.exec(
+      'elyra-metadata remove component-catalogs --name=example_components_-_kfp',
+      {
+        failOnNonZeroExit: false
+      }
+    );
+    cy.exec(
+      'elyra-metadata remove component-catalogs --name=example_components_-_airflow',
+      {
+        failOnNonZeroExit: false
+      }
+    );
   });
 
   // TODO: Fix Test is actually failing

--- a/tests/support/commands.ts
+++ b/tests/support/commands.ts
@@ -60,8 +60,19 @@ Cypress.Commands.add('createRuntimeConfig', ({ type } = {}): void => {
 });
 
 Cypress.Commands.add('createExampleComponentCatalog', ({ type } = {}): void => {
+  cy.on('fail', e => {
+    console.error(
+      `Example catalog connectors do not appear to be installed.\n${e}`
+    );
+    throw new Error(
+      `Example catalog connectors do not appear to be installed.\n${e}`
+    );
+  });
+
   cy.findByRole('tab', { name: /component catalogs/i }).click();
-  cy.findByRole('button', { name: /create new component catalog/i }).click();
+  cy.findByRole('button', { name: /create new component catalog/i })
+    .click()
+    .PinCustomMessage();
 
   if (type === 'kfp') {
     cy.findByRole('menuitem', { name: /kubeflow pipelines/i }).click();

--- a/tests/support/commands.ts
+++ b/tests/support/commands.ts
@@ -59,6 +59,22 @@ Cypress.Commands.add('createRuntimeConfig', ({ type } = {}): void => {
   cy.findByRole('button', { name: /save/i }).click();
 });
 
+Cypress.Commands.add('createExampleComponentCatalog', ({ type } = {}): void => {
+  cy.findByRole('tab', { name: /component catalogs/i }).click();
+  cy.findByRole('button', { name: /create new component catalog/i }).click();
+
+  if (type === 'kfp') {
+    cy.findByRole('menuitem', { name: /kubeflow pipelines/i }).click();
+  } else {
+    cy.findByRole('menuitem', { name: /apache airflow/i }).click();
+  }
+
+  cy.findByLabelText(/^name/i).type(`Example Components - ${type}`);
+
+  // save it
+  cy.findByRole('button', { name: /save/i }).click();
+});
+
 Cypress.Commands.add('deleteFile', (name: string): void => {
   cy.exec(`find build/cypress-tests/ -name "${name}" -delete`, {
     failOnNonZeroExit: false
@@ -157,18 +173,8 @@ Cypress.Commands.add('checkTabMenuOptions', (fileType: string): void => {
   cy.get('[aria-label="Canvas"]').click({ force: true });
 });
 
-Cypress.Commands.add('expandPaletteCategory', ({ type } = {}): void => {
-  switch (type) {
-    case 'kfp':
-      cy.get('.palette-flyout-category[value="Preloaded KFP"]').click();
-      break;
-    case 'airflow':
-      cy.get('.palette-flyout-category[value="Preloaded Airflow"]').click();
-      break;
-    default:
-      cy.get('.palette-flyout-category[value="Elyra"]').click();
-      break;
-  }
+Cypress.Commands.add('expandPaletteCategory', (): void => {
+  cy.get('.palette-flyout-category[value="examples"]').click();
 });
 
 Cypress.Commands.add('closeTab', (index: number): void => {

--- a/tests/support/commands.ts
+++ b/tests/support/commands.ts
@@ -70,9 +70,7 @@ Cypress.Commands.add('createExampleComponentCatalog', ({ type } = {}): void => {
   });
 
   cy.findByRole('tab', { name: /component catalogs/i }).click();
-  cy.findByRole('button', { name: /create new component catalog/i })
-    .click()
-    .PinCustomMessage();
+  cy.findByRole('button', { name: /create new component catalog/i }).click();
 
   if (type === 'kfp') {
     cy.findByRole('menuitem', { name: /kubeflow pipelines/i }).click();

--- a/tests/support/commands.ts
+++ b/tests/support/commands.ts
@@ -69,7 +69,7 @@ Cypress.Commands.add('createExampleComponentCatalog', ({ type } = {}): void => {
     cy.findByRole('menuitem', { name: /apache airflow/i }).click();
   }
 
-  cy.findByLabelText(/^name/i).type(`Example Components - ${type}`);
+  cy.findByLabelText(/^name/i).type('Example Components');
 
   // save it
   cy.findByRole('button', { name: /save/i }).click();
@@ -171,10 +171,6 @@ Cypress.Commands.add('checkTabMenuOptions', (fileType: string): void => {
   );
   //dismiss menu
   cy.get('[aria-label="Canvas"]').click({ force: true });
-});
-
-Cypress.Commands.add('expandPaletteCategory', (): void => {
-  cy.get('.palette-flyout-category[value="examples"]').click();
 });
 
 Cypress.Commands.add('closeTab', (index: number): void => {

--- a/tests/support/index.d.ts
+++ b/tests/support/index.d.ts
@@ -33,9 +33,6 @@ declare namespace Cypress {
     bootstrapFile(fileName: string): Chainable<void>;
     resetJupyterLab(): Chainable<void>;
     checkTabMenuOptions(fileType: string): Chainable<void>;
-    expandPaletteCategory(options?: {
-      type?: 'kfp' | 'airflow' | 'generic';
-    }): Chainable<void>;
     closeTab(index: number): Chainable<void>;
   }
 }

--- a/tests/support/index.d.ts
+++ b/tests/support/index.d.ts
@@ -17,6 +17,9 @@ declare namespace Cypress {
   // eslint-disable-next-line @typescript-eslint/interface-name-prefix
   interface Chainable {
     createRuntimeConfig(options?: { type?: 'kfp' }): Chainable<void>;
+    createExampleComponentCatalog(options?: {
+      type?: 'kfp' | 'airflow';
+    }): Chainable<void>;
     deleteFile(fileName: string): Chainable<void>;
     openDirectory(fileName: string): Chainable<void>;
     addFileToPipeline(fileName: string): Chainable<void>;


### PR DESCRIPTION
Fixes #2298 

### What changes were proposed in this pull request?
PR #2286 removed built-in components being included by default in the palette, and the corresponding integration tests (`kfp pipeline should display custom components` and `airflow pipeline should display custom components`) were commented out. This PR creates a function to add an example component catalog for each runtime type, which allows the custom components to be displayed in the palette again.

This update also necessitates the examples packages be installed, so the `install-examples` Makefile target has been added to the existing integration test targets (`test-integration` and `test-integration-debug`).

The component id's also have been updated to reflect the latest values.

### How was this pull request tested?
Uncommented tests are now passing (locally and CI)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
