### PR TITLE
Rework docker image build

### DIFF
--- a/etc/docker/elyra/Dockerfile
+++ b/etc/docker/elyra/Dockerfile
@@ -15,26 +15,32 @@
 # limitations under the License.
 #
 
-# Ubuntu 18.04 LTS - Bionic
+# Ubuntu 20.04.2 LTS (Focal Fossa)
 # Repository: https://hub.docker.com/r/jupyterhub/k8s-singleuser-sample/tags
 FROM jupyterhub/k8s-singleuser-sample:1.2.0
 
 ARG TAG="dev"
 
-USER root
+# Install Elyra
+RUN python3 -m pip install --quiet --no-cache-dir --use-deprecated=legacy-resolver \
+    elyra[all]=="$TAG" \
+ && jupyter lab build \
+ && rm -rf $HOME/.cache/yarn
 
-ADD start-elyra.sh /usr/local/bin/start-elyra.sh
+# Install component examples catalogs
+#  - this wail fail if the 'kfp-examples' and 'airflow-examples' pip extras are not installed
+RUN elyra-metadata install component-catalogs \
+    --schema_name=elyra-airflow-examples-catalog \
+    --display_name="Apache Airflow examples" \
+    --runtime_type=APACHE_AIRFLOW \
+    --categories="['examples']" \
+ && elyra-metadata install component-catalogs \
+    --schema_name=elyra-kfp-examples-catalog  \
+    --display_name="Kubeflow Pipelines examples" \
+    --runtime_type=KUBEFLOW_PIPELINES \
+    --categories="['examples']"
 
-RUN chmod ugo+x /usr/local/bin/start-elyra.sh
-
-USER $NB_USER
-
-RUN python -m pip install --upgrade pandas numpy && \
-    python3 -m pip install --quiet --no-cache-dir --use-deprecated=legacy-resolver elyra[all]=="$TAG" && \
-    jupyter lab build
-
-# Comment out to hide the component examples for Kubeflow Pipelines and Apache Airflow
-RUN elyra-metadata install component-catalogs --schema_name=elyra-airflow-examples-catalog --display_name="Apache Airflow examples" --runtime_type=APACHE_AIRFLOW --categories="['examples']" && \
-    elyra-metadata install component-catalogs --schema_name=elyra-kfp-examples-catalog --display_name="Kubeflow Pipelines examples" --runtime_type=KUBEFLOW_PIPELINES --categories="['examples']"
+# Copy Elyra entrypoint
+COPY --chmod=0755 --chown=root:root start-elyra.sh /usr/local/bin/start-elyra.sh
 
 CMD ["/usr/local/bin/start-elyra.sh"]

--- a/etc/docker/elyra/Dockerfile
+++ b/etc/docker/elyra/Dockerfile
@@ -25,7 +25,8 @@ ARG TAG="dev"
 RUN python3 -m pip install --quiet --no-cache-dir --use-deprecated=legacy-resolver \
     elyra[all]=="$TAG" \
  && jupyter lab build \
- && rm -rf $HOME/.cache/yarn
+ && rm -rf $HOME/.cache/yarn \
+ && rm -rf /opt/conda/share/jupyter/lab/staging/node_modules
 
 # Install component examples catalogs
 #  - this wail fail if the 'kfp-examples' and 'airflow-examples' pip extras are not installed

--- a/etc/docker/elyra/Dockerfile.dev
+++ b/etc/docker/elyra/Dockerfile.dev
@@ -59,7 +59,9 @@ COPY --chown=${NB_USER} --chmod=0755 elyra /tmp/elyra/
 RUN cd /tmp/elyra \
  && make install \
  && rm -rf $HOME/.cache/yarn \
- && rm -rf /tmp/elyra/node_modules
+ && rm -rf $HOME/.cache/Cypress \
+ && rm -rf /tmp/elyra/node_modules \
+ && rm -rf /opt/conda/share/jupyter/lab/staging/node_modules
 
 # Install example component catalogs
 RUN pip install --quiet --no-cache-dir --use-deprecated=legacy-resolver \

--- a/etc/docker/elyra/Dockerfile.dev
+++ b/etc/docker/elyra/Dockerfile.dev
@@ -57,17 +57,15 @@ COPY --chown=${NB_USER} --chmod=0755 elyra /tmp/elyra/
 
 # Install Elyra from source
 RUN cd /tmp/elyra \
- && make install \
+ && make install-all \
  && rm -rf $HOME/.cache/yarn \
  && rm -rf $HOME/.cache/Cypress \
  && rm -rf /tmp/elyra/node_modules \
  && rm -rf /opt/conda/share/jupyter/lab/staging/node_modules
 
 # Install example component catalogs
-RUN pip install --quiet --no-cache-dir --use-deprecated=legacy-resolver \
-    elyra-examples-airflow-catalog \
-    elyra-examples-kfp-catalog \
- && elyra-metadata install component-catalogs \
+#  - this wail fail if the 'kfp-examples' and 'airflow-examples' pip extras are not installed
+RUN elyra-metadata install component-catalogs \
     --schema_name=elyra-airflow-examples-catalog \
     --display_name="Apache Airflow examples" \
     --runtime_type=APACHE_AIRFLOW \

--- a/etc/docker/elyra/Dockerfile.dev
+++ b/etc/docker/elyra/Dockerfile.dev
@@ -19,8 +19,6 @@
 # Repository: https://hub.docker.com/r/jupyterhub/k8s-singleuser-sample/tags
 FROM jupyterhub/k8s-singleuser-sample:1.2.0
 
-ARG TAG="dev"
-
 USER root
 
 # Install build dependencies

--- a/etc/docker/elyra/README.md
+++ b/etc/docker/elyra/README.md
@@ -16,5 +16,17 @@ limitations under the License.
 {% endcomment %}
 -->
 
-### elyra
-Builds the Elyra image for use as standalone or with JupyterHub. See [Deploying Elyra and JupyterHub in a Kubernetes environment](https://elyra.readthedocs.io/en/latest/recipes/deploying-elyra-in-a-jupyterhub-environment.html#deploying-elyra-jupyterhub-in-a-kubernetes-environment)
+### Elyra Docker Image
+
+Builds the Elyra image for use as standalone or with JupyterHub.
+
+See [Deploying Elyra and JupyterHub in a Kubernetes environment](https://elyra.readthedocs.io/en/latest/recipes/deploying-elyra-in-a-jupyterhub-environment.html#deploying-elyra-jupyterhub-in-a-kubernetes-environment)
+
+#### Building a custom container image
+
+To build a custom version of this container image:
+1. Clone this repository
+2. Build the image using the `Dockerfile` in the `kubeflow/notebooks` directory:
+  - (Option 1) Run `make elyra-image TAG=3.X.X` to build with Elyra version `3.X.X`
+  - (Option 2) Run `make elyra-image TAG=dev` to build with Elyra from your local source
+3. The container image is automatically tagged with `elyra/elyra:$TAG` and `quay.io/elyra/elyra:$TAG`

--- a/etc/docker/elyra/README.md
+++ b/etc/docker/elyra/README.md
@@ -26,7 +26,7 @@ See [Deploying Elyra and JupyterHub in a Kubernetes environment](https://elyra.r
 
 To build a custom version of this container image:
 1. Clone this repository
-2. Build the image using the `Dockerfile` in the `kubeflow/notebooks` directory:
+2. Build the image using the `Dockerfile` or `Dockerfile.dev` in the `etc/docker/elyra` directory:
   - (Option 1) Run `make elyra-image TAG=3.X.X` to build with Elyra version `3.X.X`
   - (Option 2) Run `make elyra-image TAG=dev` to build with Elyra from your local source
 3. The container image is automatically tagged with `elyra/elyra:$TAG` and `quay.io/elyra/elyra:$TAG`

--- a/etc/docker/kubeflow/Dockerfile
+++ b/etc/docker/kubeflow/Dockerfile
@@ -19,19 +19,20 @@
 # Repository: https://gallery.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter
 FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:v1.4
 
-# Install Elyra with Tekton support ('kfp-tekton') and component examples ('kfp-examples')
-# Customize the extras list as desired
-RUN python3 -m pip install --quiet --no-cache-dir --use-deprecated legacy-resolver \
-    elyra[kfp-tekton,kfp-examples]==3.3.0
+ARG TAG="dev"
 
-# build jupyter plugins
-RUN jupyter lab build
+# Install Elyra
+# - with KFP Tekton support ('kfp-tekton')
+# - with component examples ('kfp-examples')
+RUN python -m pip install --quiet --no-cache-dir --use-deprecated=legacy-resolver \
+    elyra[kfp-tekton,kfp-examples]=="$TAG" \
+ && jupyter lab build \
+ && rm -rf $HOME/.cache/yarn
 
-# Enable Kubeflow Pipelines examples catalog; this wail fail if 'kfp-examples' extra is not installed
-# Comment out the line below to hide the examples by default
-RUN elyra-metadata install component-catalogs --schema_name=elyra-kfp-examples-catalog --display_name="KFP examples" --runtime_type=KUBEFLOW_PIPELINES --categories="['examples']"
-
-# install - requirements.txt
-COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt
-RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir --use-deprecated=legacy-resolver \
- && rm -f /tmp/requirements.txt
+# Install component examples catalog
+#  - this wail fail if the 'kfp-examples' pip extra is not installed
+RUN elyra-metadata install component-catalogs \
+    --schema_name=elyra-kfp-examples-catalog \
+    --display_name="Kubeflow Pipelines examples" \
+    --runtime_type=KUBEFLOW_PIPELINES \
+    --categories="['examples']"

--- a/etc/docker/kubeflow/Dockerfile
+++ b/etc/docker/kubeflow/Dockerfile
@@ -27,7 +27,8 @@ ARG TAG="dev"
 RUN python -m pip install --quiet --no-cache-dir --use-deprecated=legacy-resolver \
     elyra[kfp-tekton,kfp-examples]=="$TAG" \
  && jupyter lab build \
- && rm -rf $HOME/.cache/yarn
+ && rm -rf $HOME/.cache/yarn \
+ && rm -rf /opt/conda/share/jupyter/lab/staging/node_modules
 
 # Install component examples catalog
 #  - this wail fail if the 'kfp-examples' pip extra is not installed

--- a/etc/docker/kubeflow/Dockerfile.dev
+++ b/etc/docker/kubeflow/Dockerfile.dev
@@ -19,8 +19,6 @@
 # Repository: https://gallery.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter
 FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:v1.4
 
-ARG TAG="dev"
-
 USER root
 
 # Install build dependencies

--- a/etc/docker/kubeflow/Dockerfile.dev
+++ b/etc/docker/kubeflow/Dockerfile.dev
@@ -59,7 +59,9 @@ COPY --chown=${NB_USER} --chmod=0755 elyra /tmp/elyra/
 RUN cd /tmp/elyra \
  && make install \
  && rm -rf $HOME/.cache/yarn \
- && rm -rf /tmp/elyra/node_modules
+ && rm -rf $HOME/.cache/Cypress \
+ && rm -rf /tmp/elyra/node_modules \
+ && rm -rf /opt/conda/share/jupyter/lab/staging/node_modules
 
 # Install component examples catalog
 RUN pip install --quiet --no-cache-dir --use-deprecated=legacy-resolver \

--- a/etc/docker/kubeflow/Dockerfile.dev
+++ b/etc/docker/kubeflow/Dockerfile.dev
@@ -16,8 +16,8 @@
 #
 
 # Ubuntu 20.04.2 LTS (Focal Fossa)
-# Repository: https://hub.docker.com/r/jupyterhub/k8s-singleuser-sample/tags
-FROM jupyterhub/k8s-singleuser-sample:1.2.0
+# Repository: https://gallery.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:v1.4
 
 ARG TAG="dev"
 
@@ -61,22 +61,11 @@ RUN cd /tmp/elyra \
  && rm -rf $HOME/.cache/yarn \
  && rm -rf /tmp/elyra/node_modules
 
-# Install example component catalogs
+# Install component examples catalog
 RUN pip install --quiet --no-cache-dir --use-deprecated=legacy-resolver \
-    elyra-examples-airflow-catalog \
     elyra-examples-kfp-catalog \
  && elyra-metadata install component-catalogs \
-    --schema_name=elyra-airflow-examples-catalog \
-    --display_name="Apache Airflow examples" \
-    --runtime_type=APACHE_AIRFLOW \
-    --categories="['examples']" \
- && elyra-metadata install component-catalogs \
-    --schema_name=elyra-kfp-examples-catalog  \
+    --schema_name=elyra-kfp-examples-catalog \
     --display_name="Kubeflow Pipelines examples" \
     --runtime_type=KUBEFLOW_PIPELINES \
     --categories="['examples']"
-
-# Copy Elyra entrypoint
-COPY --chmod=0755 --chown=root:root start-elyra.sh /usr/local/bin/start-elyra.sh
-
-CMD ["/usr/local/bin/start-elyra.sh"]

--- a/etc/docker/kubeflow/Dockerfile.dev
+++ b/etc/docker/kubeflow/Dockerfile.dev
@@ -57,16 +57,15 @@ COPY --chown=${NB_USER} --chmod=0755 elyra /tmp/elyra/
 
 # Install Elyra from source
 RUN cd /tmp/elyra \
- && make install \
+ && make install-all \
  && rm -rf $HOME/.cache/yarn \
  && rm -rf $HOME/.cache/Cypress \
  && rm -rf /tmp/elyra/node_modules \
  && rm -rf /opt/conda/share/jupyter/lab/staging/node_modules
 
 # Install component examples catalog
-RUN pip install --quiet --no-cache-dir --use-deprecated=legacy-resolver \
-    elyra-examples-kfp-catalog \
- && elyra-metadata install component-catalogs \
+#  - this wail fail if the 'kfp-examples' pip extra is not installed
+RUN elyra-metadata install component-catalogs \
     --schema_name=elyra-kfp-examples-catalog \
     --display_name="Kubeflow Pipelines examples" \
     --runtime_type=KUBEFLOW_PIPELINES \

--- a/etc/docker/kubeflow/README.md
+++ b/etc/docker/kubeflow/README.md
@@ -27,7 +27,7 @@ Refer to [the documentation](https://elyra.readthedocs.io/en/latest/recipes/usin
 
 To build a custom version of this container image:
 1. Clone this repository
-2. Build the image using the `Dockerfile` in the `kubeflow/notebooks` directory:
+2. Build the image using the `Dockerfile` or `Dockerfile.dev` in the `etc/docker/kubeflow` directory:
    - (Option 1) Run `make kf-notebook-image TAG=3.X.X` to build with Elyra version `3.X.X`
    - (Option 2) Run `make kf-notebook-image TAG=dev` to build with Elyra from your local source
 3. The container image is automatically tagged with `elyra/kf-notebook:$TAG` and `quay.io/elyra/kf-notebook:$TAG`

--- a/etc/docker/kubeflow/README.md
+++ b/etc/docker/kubeflow/README.md
@@ -16,15 +16,18 @@ limitations under the License.
 {% endcomment %}
 -->
 
-### Elyra notebook container image for use with Kubeflow's Notebook Server
+### Elyra Docker Image - Kubeflow Notebooks
 
-This `Dockerfile` is used to build an Elyra notebook image that can be launched by [Kubeflow's Notebook Server](https://www.kubeflow.org/docs/components/notebooks/). Ready-to-use  container images are published on [Docker Hub](https://hub.docker.com/r/elyra/kf-notebook) and [quay.io](https://quay.io/repository/elyra/kf-notebook). Refer to [the documentation](https://elyra.readthedocs.io/en/latest/recipes/using-elyra-with-kubeflow-notebook-server.html) for details.
+This `Dockerfile` is used to build an Elyra notebook image that can be launched by [Kubeflow's Notebook Server](https://www.kubeflow.org/docs/components/notebooks/).
+
+Ready-to-use container images are published on [Docker Hub](https://hub.docker.com/r/elyra/kf-notebook) and [quay.io](https://quay.io/repository/elyra/kf-notebook). 
+Refer to [the documentation](https://elyra.readthedocs.io/en/latest/recipes/using-elyra-with-kubeflow-notebook-server.html) for details.
 
 #### Building a custom container image
 
 To build a custom version of this container image:
-- Clone this repository.
-- Update the requirements in `etc/docker/kubeflow/requirements.txt`.
-- Run `make kf-notebook-image` in the root directory of this repository.
-
-> The container image is automatically tagged with `elyra/kf-notebook:dev` and `quay.io/elyra/kf-notebook:dev`.
+1. Clone this repository
+2. Build the image using the `Dockerfile` in the `kubeflow/notebooks` directory:
+   - (Option 1) Run `make kf-notebook-image TAG=3.X.X` to build with Elyra version `3.X.X`
+   - (Option 2) Run `make kf-notebook-image TAG=dev` to build with Elyra from your local source
+3. The container image is automatically tagged with `elyra/kf-notebook:$TAG` and `quay.io/elyra/kf-notebook:$TAG`

--- a/etc/docker/kubeflow/requirements.txt
+++ b/etc/docker/kubeflow/requirements.txt
@@ -1,3 +1,0 @@
-pandas
-pip
-setuptools


### PR DESCRIPTION
further resolves: https://github.com/elyra-ai/elyra/issues/2116

### What changes were proposed in this pull request?

- Allow building Kubeflow images from your local source (rather than just released versions of Elyra):
   -  `make kf-notebook-image TAG=dev`
- Improve the `rsync` command used to copy the sources (we now use the `.gitignore` file to determine rsync exclusions)
- Use the new `docker buildx build ...` command (rather than `DOCKER_BUILDKIT=1`)
- Reduce the size of images by running `rm -rf $HOME/.cache/yarn` after `jupter lab build`
- Reduce the size of images by running `rm -rf /tmp/elyra/node_modules` after `make install` 
- Stopped installing `pandas` and `numpy` in every docker image (lets users pick what packages they need when extending FROM our images)
- Removed `requirements.txt` from Kubeflow image (users should extend FROM our images, and run `pip install XXXX` for packages they need)
- General cleanup of how Dockerfiles are formatted

### How was this pull request tested?

- Building images locally with the following commands:
    - `make elyra-image TAG=3.3.0`
    - `make elyra-image TAG=dev`
    - `make kf-notebook-image TAG=3.3.0`
    - `make kf-notebook-image TAG=dev`
- Running the built images locally (with `docker run`) and in Kubeflow. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
