### PR TITLE
Fix code snippet language check

### DIFF
--- a/tests/integration/codesnippet.ts
+++ b/tests/integration/codesnippet.ts
@@ -193,7 +193,7 @@ describe('Code Snippet tests', () => {
     // Open blank python file
     cy.createNewScriptFile('Python');
 
-    cy.wait(500);
+    cy.wait(1500);
 
     // Insert snippet into python editor
     insert(snippetName);

--- a/tests/integration/codesnippet.ts
+++ b/tests/integration/codesnippet.ts
@@ -187,6 +187,47 @@ describe('Code Snippet tests', () => {
     cy.wait(100);
   });
 
+  it('should insert a python code snippet into python file', () => {
+    createValidCodeSnippet(snippetName);
+
+    // Open blank python file
+    cy.get(
+      '.jp-LauncherCard[data-category="Elyra"][title="Create a new Python file"]:visible'
+    ).click();
+
+    cy.wait(500);
+
+    // Insert snippet into python editor
+    insert(snippetName);
+
+    // Check if editor has the new code
+    cy.get('.CodeMirror:visible');
+    cy.get('span.cm-string').contains(/test/i);
+  });
+
+  it('should fail to insert a java code snippet into python file', () => {
+    createValidCodeSnippet(snippetName, 'Java');
+
+    // Open blank python file
+    cy.get(
+      '.jp-LauncherCard[data-category="Elyra"][title="Create a new Python file"]:visible'
+    ).click();
+
+    cy.wait(500);
+
+    // Insert snippet into python editor
+    insert(snippetName);
+
+    // Check for language mismatch warning
+    cy.get('.jp-Dialog-header').contains(/warning/i);
+    // Dismiss the dialog
+    cy.findByRole('button', { name: /cancel/i }).click();
+
+    // Check it did not insert the code
+    cy.get('.CodeMirror:visible');
+    cy.get('span.cm-string').should('not.exist');
+  });
+
   // DEV NOTE: Uncomment the tests below to run them locally
   // TODO: Investigate tests below only failing on CI
   // Steps: checkCodeMirror, closeTabWithoutSaving
@@ -319,14 +360,17 @@ const createInvalidCodeSnippet = (snippetName: string): any => {
   saveAndCloseMetadataEditor();
 };
 
-const populateCodeSnippetFields = (snippetName: string): any => {
+const populateCodeSnippetFields = (
+  snippetName: string,
+  language?: string
+): any => {
   clickCreateNewSnippetButton();
 
   // Name code snippet
   cy.get('.elyra-metadataEditor-form-display_name').type(snippetName);
 
   // Select python language from dropdown list
-  editSnippetLanguage(snippetName, 'Python');
+  editSnippetLanguage(snippetName, language ?? 'Python');
 
   // Add snippet code
   cy.get('.CodeMirror .CodeMirror-scroll:visible').type(
@@ -334,7 +378,10 @@ const populateCodeSnippetFields = (snippetName: string): any => {
   );
 };
 
-const createValidCodeSnippet = (snippetName: string): any => {
+const createValidCodeSnippet = (
+  snippetName: string,
+  language?: string
+): any => {
   populateCodeSnippetFields(snippetName);
 
   saveAndCloseMetadataEditor();

--- a/tests/integration/codesnippet.ts
+++ b/tests/integration/codesnippet.ts
@@ -191,9 +191,7 @@ describe('Code Snippet tests', () => {
     createValidCodeSnippet(snippetName);
 
     // Open blank python file
-    cy.get(
-      '.jp-LauncherCard[data-category="Elyra"][title="Create a new Python file"]:visible'
-    ).click();
+    cy.createNewScriptFile('Python');
 
     cy.wait(500);
 
@@ -209,9 +207,7 @@ describe('Code Snippet tests', () => {
     createValidCodeSnippet(snippetName, 'Java');
 
     // Open blank python file
-    cy.get(
-      '.jp-LauncherCard[data-category="Elyra"][title="Create a new Python file"]:visible'
-    ).click();
+    cy.createNewScriptFile('Python');
 
     cy.wait(500);
 
@@ -260,50 +256,6 @@ describe('Code Snippet tests', () => {
   //   closeTabWithoutSaving();
   //   // NOTE: Save dialog isn't visible when this test runs on CI
   // });
-
-  //   it('Test inserting a code snippet into a python editor', () => {
-  //     openCodeSnippetExtension();
-  //     clickCreateNewSnippetButton();
-
-  //     const snippetName = 'test-code-snippet';
-  //     fillMetadaEditorForm(snippetName);
-
-  //     cy.wait(500);
-
-  //     // Open blank python file
-  //     cy.get(
-  //       '.jp-LauncherCard[title="Create a new python file"]:visible'
-  //     ).click();
-
-  //     cy.wait(500);
-
-  //     // Check widget is loaded
-  //     cy.get('.CodeMirror:visible');
-
-  //     insert(snippetName);
-
-  //     // Check if python editor has the new code
-  //     checkCodeMirror();
-
-  //     // Edit snippet language
-  //     getActionButtonsElement(snippetName).within(() => {
-  //       cy.get('button[title="Edit"]').click();
-  //     });
-  //     cy.wait(100);
-  //     editSnippetLanguage(snippetName, 'Java');
-  //     saveAndCloseMetadataEditor();
-
-  //     cy.wait(500);
-
-  //     insert(snippetName);
-
-  //     // Check for language mismatch warning
-  //     cy.get('.jp-Dialog-header').contains('Warning');
-  //     cy.get('button.jp-mod-accept').click();
-  //     cy.wait(100);
-
-  //     closeTabWithoutSaving();
-  //   });
 
   //   it('Test inserting a code snippet into a markdown file', () => {
   //     openCodeSnippetExtension();
@@ -382,7 +334,7 @@ const createValidCodeSnippet = (
   snippetName: string,
   language?: string
 ): any => {
-  populateCodeSnippetFields(snippetName);
+  populateCodeSnippetFields(snippetName, language);
 
   saveAndCloseMetadataEditor();
 

--- a/tests/integration/scripteditor.ts
+++ b/tests/integration/scripteditor.ts
@@ -35,9 +35,7 @@ describe('Script Editor tests', () => {
 
   // Python Tests
   it('opens blank Python file from launcher', () => {
-    cy.get(
-      '.jp-LauncherCard[data-category="Elyra"][title="Create a new Python file"]'
-    ).click();
+    cy.createNewScriptFile('Python');
     cy.get('.lm-TabBar-tab[data-type="document-title"]');
   });
 
@@ -95,9 +93,7 @@ describe('Script Editor tests', () => {
 
   // R Tests
   it('opens blank R file from launcher', () => {
-    cy.get(
-      '.jp-LauncherCard[data-category="Elyra"][title="Create a new R file"]'
-    ).click();
+    cy.createNewScriptFile('R');
     cy.get('.lm-TabBar-tab[data-type="document-title"]');
   });
 

--- a/tests/support/commands.ts
+++ b/tests/support/commands.ts
@@ -176,3 +176,9 @@ Cypress.Commands.add('closeTab', (index: number): void => {
     .eq(index)
     .click();
 });
+
+Cypress.Commands.add('createNewScriptFile', (language: string): void => {
+  cy.get(
+    `.jp-LauncherCard[data-category="Elyra"][title="Create a new ${language} file"]:visible`
+  ).click();
+});

--- a/tests/support/index.d.ts
+++ b/tests/support/index.d.ts
@@ -34,5 +34,6 @@ declare namespace Cypress {
       type?: 'kfp' | 'airflow' | 'generic';
     }): Chainable<void>;
     closeTab(index: number): Chainable<void>;
+    createNewScriptFile(language: string): Chainable<void>;
   }
 }


### PR DESCRIPTION
Fix code snippet language check when inserting into script editors using the `insert` button.
Fixes #2018 

### What changes were proposed in this pull request?
When the package is published - eg. not installed from source - widget names are mapped to some kind of id. 
This is (probably) why when installing elyra/code-snippets extension from `pip` or `conda` the condition 
`if (widget.constructor.name === 'ScriptEditor')` fails, and language check is never triggered.Although it works as expected when installing from source code.

This PR removes the reference to ScriptEditor widget, which means the code-snippet extension will verify language match against any file editor which has kernel language support (such as Elyra Python/R editors).

**NOTE**: It won't change the behavior from source installation, proper fix would only be verified on a new publishing including these changes (or is there a way to mock that environment?)

### How was this pull request tested?
New integration tests added.
Includes small refactor/cleanup of existing relevant tests.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
