### PR TITLE
Enable async component cache updates using SingletonConfigurable

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -44,9 +44,8 @@ AIRFLOW_COMPONENT_CACHE_INSTANCE = {
 def component_cache_instance(request):
     """Creates an instance of a component cache and removes after test."""
 
-    # Clear existing catalog if applicable and create new catalog, specifying test environment
-    ComponentCatalog.clear_instance()
-    ComponentCatalog.instance(for_test=True)
+    # Create a ComponentCatalog instance to handle the cache update on metadata instance creation
+    ComponentCatalog.instance()
 
     instance_name = "component_cache"
     md_mgr = MetadataManager(schemaspace=ComponentCatalogs.COMPONENT_CATALOGS_SCHEMASPACE_ID)

--- a/conftest.py
+++ b/conftest.py
@@ -18,7 +18,7 @@ import pytest
 from elyra.metadata.metadata import Metadata
 from elyra.metadata.schemaspaces import ComponentCatalogs
 from elyra.metadata.manager import MetadataManager
-from elyra.pipeline.component_catalog import ComponentCatalog
+from elyra.pipeline.component_catalog import ComponentCache
 
 pytest_plugins = ["jupyter_server.pytest_plugin"]
 
@@ -44,8 +44,8 @@ AIRFLOW_COMPONENT_CACHE_INSTANCE = {
 def component_cache_instance(request):
     """Creates an instance of a component cache and removes after test."""
 
-    # Create a ComponentCatalog instance to handle the cache update on metadata instance creation
-    ComponentCatalog.instance()
+    # Create a ComponentCache instance to handle the cache update on metadata instance creation
+    ComponentCache.instance()
 
     instance_name = "component_cache"
     md_mgr = MetadataManager(schemaspace=ComponentCatalogs.COMPONENT_CATALOGS_SCHEMASPACE_ID)

--- a/conftest.py
+++ b/conftest.py
@@ -18,6 +18,7 @@ import pytest
 from elyra.metadata.metadata import Metadata
 from elyra.metadata.schemaspaces import ComponentCatalogs
 from elyra.metadata.manager import MetadataManager
+from elyra.pipeline.component_catalog import ComponentCatalog
 
 pytest_plugins = ["jupyter_server.pytest_plugin"]
 
@@ -42,6 +43,11 @@ AIRFLOW_COMPONENT_CACHE_INSTANCE = {
 @pytest.fixture
 def component_cache_instance(request):
     """Creates an instance of a component cache and removes after test."""
+
+    # Clear existing catalog if applicable and create new catalog, specifying test environment
+    ComponentCatalog.clear_instance()
+    ComponentCatalog.instance(for_test=True)
+
     instance_name = "component_cache"
     md_mgr = MetadataManager(schemaspace=ComponentCatalogs.COMPONENT_CATALOGS_SCHEMASPACE_ID)
     # clean possible orphaned instance...

--- a/conftest.py
+++ b/conftest.py
@@ -45,7 +45,7 @@ def component_cache_instance(request):
     """Creates an instance of a component cache and removes after test."""
 
     # Create a ComponentCache instance to handle the cache update on metadata instance creation
-    ComponentCache.instance()
+    component_catalog = ComponentCache.instance()
 
     instance_name = "component_cache"
     md_mgr = MetadataManager(schemaspace=ComponentCatalogs.COMPONENT_CATALOGS_SCHEMASPACE_ID)
@@ -58,6 +58,10 @@ def component_cache_instance(request):
     # Attempt to create the instance
     try:
         component_cache_instance = md_mgr.create(instance_name, Metadata(**request.param))
+
+        # Wait for the cache update to complete
+        component_catalog.wait_for_all_cache_updates()
+
         yield component_cache_instance.name
         md_mgr.remove(component_cache_instance.name)
 

--- a/elyra/elyra_app.py
+++ b/elyra/elyra_app.py
@@ -31,7 +31,7 @@ from elyra.metadata.manager import MetadataManager
 from elyra.metadata.schema import SchemaManager
 from elyra.metadata.storage import FileMetadataCache
 from elyra.pipeline.catalog_connector import ComponentCatalogConnector
-from elyra.pipeline.component_catalog import ComponentCatalog
+from elyra.pipeline.component_catalog import ComponentCache
 from elyra.pipeline.handlers import PipelineComponentHandler
 from elyra.pipeline.handlers import PipelineComponentPropertiesHandler
 from elyra.pipeline.handlers import PipelineExportHandler
@@ -57,7 +57,7 @@ class ElyraApp(ExtensionAppJinjaMixin, ExtensionApp):
     extension_url = '/lab'
     load_other_extensions = True
 
-    classes = [FileMetadataCache, MetadataManager, PipelineProcessor, ComponentCatalogConnector, ComponentCatalog]
+    classes = [FileMetadataCache, MetadataManager, PipelineProcessor, ComponentCatalogConnector, ComponentCache]
 
     # Local path to static files directory.
     static_paths = [
@@ -112,7 +112,7 @@ class ElyraApp(ExtensionAppJinjaMixin, ExtensionApp):
         PipelineProcessorManager.instance(root_dir=self.settings['server_root_dir'], parent=self)
         PipelineValidationManager.instance(root_dir=self.settings['server_root_dir'], parent=self)
         FileMetadataCache.instance(parent=self)
-        ComponentCatalog.instance(parent=self)
+        ComponentCache.instance(parent=self)
         SchemaManager.instance(parent=self)
 
     def initialize_templates(self):

--- a/elyra/elyra_app.py
+++ b/elyra/elyra_app.py
@@ -112,6 +112,7 @@ class ElyraApp(ExtensionAppJinjaMixin, ExtensionApp):
         PipelineProcessorManager.instance(root_dir=self.settings['server_root_dir'], parent=self)
         PipelineValidationManager.instance(root_dir=self.settings['server_root_dir'], parent=self)
         FileMetadataCache.instance(parent=self)
+        ComponentCatalog.instance(parent=self)
         SchemaManager.instance(parent=self)
 
     def initialize_templates(self):

--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -41,8 +41,9 @@ class TypeHintRemover(ast.NodeTransformer):
 
 
 class AirflowComponentParser(ComponentParser):
-    _component_platform: RuntimeProcessorType = RuntimeProcessorType.APACHE_AIRFLOW
     _file_types: List[str] = [".py"]
+
+    component_platform: RuntimeProcessorType = RuntimeProcessorType.APACHE_AIRFLOW
 
     def parse(self, registry_entry: SimpleNamespace) -> Optional[List[Component]]:
         components: List[Component] = list()

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -269,7 +269,7 @@ be fully qualified (i.e., prefixed with their package names).
 
             else:
                 # Retrieve component from cache
-                component = ComponentCatalog.instance().get_component(self._type.name, operation.classifier)
+                component = ComponentCatalog.instance().get_component(self._type, operation.classifier)
 
                 # Convert the user-entered value of certain properties according to their type
                 for component_property in component.properties:

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -34,6 +34,7 @@ from elyra._version import __version__
 from elyra.airflow.operator import BootscriptBuilder
 from elyra.metadata.schemaspaces import RuntimeImages
 from elyra.metadata.schemaspaces import Runtimes
+from elyra.pipeline.component_catalog import ComponentCatalog
 from elyra.pipeline.pipeline import GenericOperation
 from elyra.pipeline.processor import PipelineProcessor
 from elyra.pipeline.processor import PipelineProcessorResponse
@@ -268,7 +269,7 @@ be fully qualified (i.e., prefixed with their package names).
 
             else:
                 # Retrieve component from cache
-                component = self._component_catalog.get_component(operation.classifier)
+                component = ComponentCatalog.instance().get_component(self._type.name, operation.classifier)
 
                 # Convert the user-entered value of certain properties according to their type
                 for component_property in component.properties:

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -34,7 +34,6 @@ from elyra._version import __version__
 from elyra.airflow.operator import BootscriptBuilder
 from elyra.metadata.schemaspaces import RuntimeImages
 from elyra.metadata.schemaspaces import Runtimes
-from elyra.pipeline.airflow.component_parser_airflow import AirflowComponentParser
 from elyra.pipeline.pipeline import GenericOperation
 from elyra.pipeline.processor import PipelineProcessor
 from elyra.pipeline.processor import PipelineProcessorResponse
@@ -76,7 +75,7 @@ be fully qualified (i.e., prefixed with their package names).
     class_import_map = {}
 
     def __init__(self, root_dir, **kwargs):
-        super().__init__(root_dir, component_parser=AirflowComponentParser(), **kwargs)
+        super().__init__(root_dir, **kwargs)
         if not self.class_import_map:  # Only need to load once
             for package in self.available_airflow_operators:
                 parts = package.rsplit(".", 1)

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -34,7 +34,7 @@ from elyra._version import __version__
 from elyra.airflow.operator import BootscriptBuilder
 from elyra.metadata.schemaspaces import RuntimeImages
 from elyra.metadata.schemaspaces import Runtimes
-from elyra.pipeline.component_catalog import ComponentCatalog
+from elyra.pipeline.component_catalog import ComponentCache
 from elyra.pipeline.pipeline import GenericOperation
 from elyra.pipeline.processor import PipelineProcessor
 from elyra.pipeline.processor import PipelineProcessorResponse
@@ -269,7 +269,7 @@ be fully qualified (i.e., prefixed with their package names).
 
             else:
                 # Retrieve component from cache
-                component = ComponentCatalog.instance().get_component(self._type, operation.classifier)
+                component = ComponentCache.instance().get_component(self._type, operation.classifier)
 
                 # Convert the user-entered value of certain properties according to their type
                 for component_property in component.properties:

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -277,12 +277,13 @@ class Component(object):
 
 
 class ComponentParser(LoggingConfigurable):  # ABC
-    _component_platform: RuntimeProcessorType = None
+    component_platform: RuntimeProcessorType = None
     _file_types: List[str] = None
 
-    @property
-    def component_platform(self) -> RuntimeProcessorType:
-        return self._component_platform
+    def __new__(cls, platform_type: str):
+        parser_class_map = {subclass.component_platform.name: subclass for subclass in cls.__subclasses__()}
+        parser_subclass = parser_class_map[platform_type]
+        return super(ComponentParser, parser_subclass).__new__(parser_subclass)
 
     @property
     def file_types(self) -> List[str]:

--- a/elyra/pipeline/component_catalog.py
+++ b/elyra/pipeline/component_catalog.py
@@ -95,8 +95,8 @@ class CacheUpdateManagerThread(Thread):
                 duration = int(time.time() - thread.last_warn_time)
                 if duration > CATALOG_UPDATE_TIMEOUT:
                     thread.last_warn_time = time.time()
-                    self.log.warning(f"Cache update for catalog '{thread.name}' is still "
-                                     f"processing after {duration} seconds ...")
+                    self.log.warning(f"Cache update for catalog '{thread.name}' is still processing after "
+                                     f"{int(thread.last_warn_time - thread.task_start_time)} seconds ...")
 
             else:
                 # Thread has been joined and can be removed from the list

--- a/elyra/pipeline/component_catalog.py
+++ b/elyra/pipeline/component_catalog.py
@@ -89,7 +89,7 @@ class CacheUpdateManagerThread(Thread):
             # Attempt to join thread within the given amount of time
             thread.join(timeout=NONBLOCKING_TIMEOUT)
 
-            cumulative_run_time = int(thread.last_warn_time - thread.task_start_time)
+            cumulative_run_time = int(time.time() - thread.task_start_time)
             if thread.is_alive():
                 # Thread is still running (thread join timed out)
                 outstanding_threads = True

--- a/elyra/pipeline/component_catalog.py
+++ b/elyra/pipeline/component_catalog.py
@@ -14,12 +14,12 @@
 # limitations under the License.
 #
 import json
-import time
 from logging import Logger
 from queue import Empty
 from queue import Queue
 from threading import Event
 from threading import Thread
+import time
 from types import SimpleNamespace
 from typing import Dict
 from typing import List
@@ -141,12 +141,12 @@ class CacheUpdateThread(Thread):
         else:
             # Replace all components for the given catalog
             self._component_cache[self._catalog.runtime_type.name][self._catalog.name] = \
-                ComponentCatalog.instance().read_component_catalog(self._catalog)
+                ComponentCache.instance().read_component_catalog(self._catalog)
 
         self._queue.task_done()
 
 
-class ComponentCatalog(SingletonConfigurable):
+class ComponentCache(SingletonConfigurable):
     # The component_cache is indexed at the top level by runtime type name, e.g. 'APACHE_AIRFLOW',
     # and has as it's value another dictionary. At the second level, each sub-dictionary is indexed by
     # a ComponentCatalogMetadata instance name and its value is also a sub-dictionary. This lowest
@@ -310,11 +310,11 @@ class ComponentCatalog(SingletonConfigurable):
 
     @staticmethod
     def get_generic_components() -> List[Component]:
-        return list(ComponentCatalog._generic_components.values())
+        return list(ComponentCache._generic_components.values())
 
     @staticmethod
     def get_generic_component(component_id: str) -> Component:
-        return ComponentCatalog._generic_components.get(component_id)
+        return ComponentCache._generic_components.get(component_id)
 
     @staticmethod
     def load_jinja_template(template_name: str) -> Template:
@@ -332,7 +332,7 @@ class ComponentCatalog(SingletonConfigurable):
         """
         Converts catalog components into appropriate canvas palette format
         """
-        template = ComponentCatalog.load_jinja_template('canvas_palette_template.jinja2')
+        template = ComponentCache.load_jinja_template('canvas_palette_template.jinja2')
 
         # Define a fallback category for components with no given categories
         fallback_category_name = "No Category"
@@ -368,9 +368,9 @@ class ComponentCatalog(SingletonConfigurable):
         otherwise, the  runtime-specific property template is rendered
         """
         if component.id in ('notebook', 'python-script', 'r-script'):
-            template = ComponentCatalog.load_jinja_template('generic_properties_template.jinja2')
+            template = ComponentCache.load_jinja_template('generic_properties_template.jinja2')
         else:
-            template = ComponentCatalog.load_jinja_template('canvas_properties_template.jinja2')
+            template = ComponentCache.load_jinja_template('canvas_properties_template.jinja2')
 
         canvas_properties = template.render(component=component)
         return json.loads(canvas_properties)

--- a/elyra/pipeline/component_metadata.py
+++ b/elyra/pipeline/component_metadata.py
@@ -16,7 +16,7 @@
 from typing import Any
 
 from elyra.metadata.metadata import Metadata
-from elyra.pipeline.processor import PipelineProcessorRegistry
+from elyra.pipeline.component_catalog import ComponentCatalog
 
 
 class ComponentRegistryMetadata(Metadata):
@@ -30,24 +30,14 @@ class ComponentCatalogMetadata(Metadata):
     """
 
     def post_save(self, **kwargs: Any) -> None:
-        processor_type = self.metadata.get('runtime_type')
-
-        # Get component catalog and update its cache
-        try:  # TODO: This should move to ComponentCatalog once made a singleton
-            component_catalog = PipelineProcessorRegistry.instance().get_catalog(processor_type)
-            if component_catalog.caching_enabled:
-                component_catalog.update_cache(catalog=self, operation='modify')
+        try:
+            ComponentCatalog.instance().update_cache_for_catalog(catalog=self, operation='modify')
         except Exception:
             pass
 
     def post_delete(self, **kwargs: Any) -> None:
-        processor_type = self.metadata.get('runtime_type')
-
-        # Get component catalog and update its cache
-        try:  # TODO: This should move to ComponentCatalog once made a singleton
-            component_catalog = PipelineProcessorRegistry.instance().get_catalog(processor_type)
-            if component_catalog.caching_enabled:
-                component_catalog.update_cache(catalog=self, operation='delete')
+        try:
+            ComponentCatalog.instance().update_cache_for_catalog(catalog=self, operation='delete')
         except Exception:
             pass
 

--- a/elyra/pipeline/component_metadata.py
+++ b/elyra/pipeline/component_metadata.py
@@ -16,7 +16,8 @@
 from typing import Any
 
 from elyra.metadata.metadata import Metadata
-from elyra.pipeline.component_catalog import ComponentCatalog
+from elyra.pipeline import component_catalog
+from elyra.pipeline.runtime_type import RuntimeProcessorType
 
 
 class ComponentRegistryMetadata(Metadata):
@@ -29,15 +30,19 @@ class ComponentCatalogMetadata(Metadata):
     and deletion of component catalog metadata instances.
     """
 
+    @property
+    def runtime_type(self) -> RuntimeProcessorType:
+        return RuntimeProcessorType.get_instance_by_name(self.metadata['runtime_type'])
+
     def post_save(self, **kwargs: Any) -> None:
         try:
-            ComponentCatalog.instance().update_cache_for_catalog(catalog=self, operation='modify')
+            component_catalog.ComponentCatalog.instance().update_cache_for_catalog(catalog=self, operation='modify')
         except Exception:
             pass
 
     def post_delete(self, **kwargs: Any) -> None:
         try:
-            ComponentCatalog.instance().update_cache_for_catalog(catalog=self, operation='delete')
+            component_catalog.ComponentCatalog.instance().update_cache_for_catalog(catalog=self, operation='delete')
         except Exception:
             pass
 

--- a/elyra/pipeline/component_metadata.py
+++ b/elyra/pipeline/component_metadata.py
@@ -16,6 +16,9 @@
 from typing import Any
 
 from elyra.metadata.metadata import Metadata
+# Rather than importing only the ComponentCache class needed in the post_save and
+# post_delete hooks below, the component_catalog module must be imported in its
+# entirety in order to avoid a circular reference issue
 from elyra.pipeline import component_catalog
 from elyra.pipeline.runtime_type import RuntimeProcessorType
 

--- a/elyra/pipeline/component_metadata.py
+++ b/elyra/pipeline/component_metadata.py
@@ -36,13 +36,13 @@ class ComponentCatalogMetadata(Metadata):
 
     def post_save(self, **kwargs: Any) -> None:
         try:
-            component_catalog.ComponentCatalog.instance().update_cache_for_catalog(catalog=self, operation='modify')
+            component_catalog.ComponentCache.instance().update_cache_for_catalog(catalog=self, operation='modify')
         except Exception:
             pass
 
     def post_delete(self, **kwargs: Any) -> None:
         try:
-            component_catalog.ComponentCatalog.instance().update_cache_for_catalog(catalog=self, operation='delete')
+            component_catalog.ComponentCache.instance().update_cache_for_catalog(catalog=self, operation='delete')
         except Exception:
             pass
 

--- a/elyra/pipeline/handlers.py
+++ b/elyra/pipeline/handlers.py
@@ -24,7 +24,7 @@ from jupyter_server.utils import url_path_join
 from tornado import web
 
 from elyra.pipeline.component import Component
-from elyra.pipeline.component_catalog import ComponentCatalog
+from elyra.pipeline.component_catalog import ComponentCache
 from elyra.pipeline.parser import PipelineParser
 from elyra.pipeline.processor import PipelineProcessorManager
 from elyra.pipeline.processor import PipelineProcessorRegistry
@@ -144,7 +144,7 @@ class PipelineComponentHandler(HttpErrorMixin, APIHandler):
             raise web.HTTPError(400, f"Invalid processor name '{processor}'")
 
         components: List[Component] = await PipelineProcessorManager.instance().get_components(processor)
-        palette_json = ComponentCatalog.to_canvas_palette(components=components)
+        palette_json = ComponentCache.to_canvas_palette(components=components)
 
         self.set_status(200)
         self.set_header("Content-Type", 'application/json')
@@ -166,7 +166,7 @@ class PipelineComponentPropertiesHandler(HttpErrorMixin, APIHandler):
 
         component: Optional[Component] = \
             await PipelineProcessorManager.instance().get_component(processor, component_id)
-        properties_json = ComponentCatalog.to_canvas_properties(component)
+        properties_json = ComponentCache.to_canvas_properties(component)
 
         self.set_status(200)
         self.set_header("Content-Type", 'application/json')

--- a/elyra/pipeline/kfp/component_parser_kfp.py
+++ b/elyra/pipeline/kfp/component_parser_kfp.py
@@ -28,8 +28,9 @@ from elyra.pipeline.runtime_type import RuntimeProcessorType
 
 
 class KfpComponentParser(ComponentParser):
-    _component_platform: RuntimeProcessorType = RuntimeProcessorType.KUBEFLOW_PIPELINES
     _file_types: List[str] = [".yaml"]
+
+    component_platform: RuntimeProcessorType = RuntimeProcessorType.KUBEFLOW_PIPELINES
 
     def parse(self, registry_entry: SimpleNamespace) -> Optional[List[Component]]:
         # Get YAML object from component definition

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -44,7 +44,7 @@ from elyra._version import __version__
 from elyra.kfp.operator import ExecuteFileOp
 from elyra.metadata.schemaspaces import RuntimeImages
 from elyra.metadata.schemaspaces import Runtimes
-from elyra.pipeline.component_catalog import ComponentCatalog
+from elyra.pipeline.component_catalog import ComponentCache
 from elyra.pipeline.kfp.kfp_authentication import AuthenticationError
 from elyra.pipeline.kfp.kfp_authentication import KFPAuthenticator
 from elyra.pipeline.pipeline import GenericOperation
@@ -614,7 +614,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
             # If operation is a "non-standard" component, load it's spec and create operation with factory function
             else:
                 # Retrieve component from cache
-                component = ComponentCatalog.instance().get_component(self._type, operation.classifier)
+                component = ComponentCache.instance().get_component(self._type, operation.classifier)
 
                 # Convert the user-entered value of certain properties according to their type
                 for component_property in component.properties:

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -614,7 +614,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
             # If operation is a "non-standard" component, load it's spec and create operation with factory function
             else:
                 # Retrieve component from cache
-                component = ComponentCatalog.instance().get_component(self._type.name, operation.classifier)
+                component = ComponentCatalog.instance().get_component(self._type, operation.classifier)
 
                 # Convert the user-entered value of certain properties according to their type
                 for component_property in component.properties:

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -44,6 +44,7 @@ from elyra._version import __version__
 from elyra.kfp.operator import ExecuteFileOp
 from elyra.metadata.schemaspaces import RuntimeImages
 from elyra.metadata.schemaspaces import Runtimes
+from elyra.pipeline.component_catalog import ComponentCatalog
 from elyra.pipeline.kfp.kfp_authentication import AuthenticationError
 from elyra.pipeline.kfp.kfp_authentication import KFPAuthenticator
 from elyra.pipeline.pipeline import GenericOperation
@@ -613,7 +614,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
             # If operation is a "non-standard" component, load it's spec and create operation with factory function
             else:
                 # Retrieve component from cache
-                component = self._component_catalog.get_component(operation.classifier)
+                component = ComponentCatalog.instance().get_component(self._type.name, operation.classifier)
 
                 # Convert the user-entered value of certain properties according to their type
                 for component_property in component.properties:

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -44,7 +44,6 @@ from elyra._version import __version__
 from elyra.kfp.operator import ExecuteFileOp
 from elyra.metadata.schemaspaces import RuntimeImages
 from elyra.metadata.schemaspaces import Runtimes
-from elyra.pipeline.kfp.component_parser_kfp import KfpComponentParser
 from elyra.pipeline.kfp.kfp_authentication import AuthenticationError
 from elyra.pipeline.kfp.kfp_authentication import KFPAuthenticator
 from elyra.pipeline.pipeline import GenericOperation
@@ -67,7 +66,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
     WCD = os.getenv('ELYRA_WRITABLE_CONTAINER_DIR', '/tmp').strip().rstrip('/')
 
     def __init__(self, root_dir, **kwargs):
-        super().__init__(root_dir, component_parser=KfpComponentParser(), **kwargs)
+        super().__init__(root_dir, **kwargs)
 
     def process(self, pipeline):
         """

--- a/elyra/pipeline/local/processor_local.py
+++ b/elyra/pipeline/local/processor_local.py
@@ -30,7 +30,7 @@ from jupyter_server.gateway.managers import GatewayClient
 import papermill
 from traitlets import log
 
-from elyra.pipeline.component_catalog import ComponentCatalog
+from elyra.pipeline.component_catalog import ComponentCache
 from elyra.pipeline.pipeline import GenericOperation
 from elyra.pipeline.processor import PipelineProcessor
 from elyra.pipeline.processor import PipelineProcessorResponse
@@ -66,7 +66,7 @@ class LocalPipelineProcessor(PipelineProcessor):
         }
 
     def get_components(self):
-        return ComponentCatalog.get_generic_components()
+        return ComponentCache.get_generic_components()
 
     def process(self, pipeline):
         """

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -36,7 +36,7 @@ from urllib3.exceptions import MaxRetryError
 
 from elyra.metadata.manager import MetadataManager
 from elyra.pipeline.component import Component
-from elyra.pipeline.component_catalog import ComponentCatalog
+from elyra.pipeline.component_catalog import ComponentCache
 from elyra.pipeline.pipeline import GenericOperation
 from elyra.pipeline.pipeline import Operation
 from elyra.pipeline.pipeline import Pipeline
@@ -227,10 +227,10 @@ class PipelineProcessor(LoggingConfigurable):  # ABC
         """
         Retrieve components common to all runtimes
         """
-        components: List[Component] = ComponentCatalog.get_generic_components()
+        components: List[Component] = ComponentCache.get_generic_components()
 
         # Retrieve runtime-specific components
-        components.extend(ComponentCatalog.instance().get_all_components(platform=self._type))
+        components.extend(ComponentCache.instance().get_all_components(platform=self._type))
 
         return components
 
@@ -240,9 +240,9 @@ class PipelineProcessor(LoggingConfigurable):  # ABC
         """
 
         if component_id not in ('notebook', 'python-script', 'r-script'):
-            return ComponentCatalog.instance().get_component(platform=self._type, component_id=component_id)
+            return ComponentCache.instance().get_component(platform=self._type, component_id=component_id)
 
-        return ComponentCatalog.get_generic_component(component_id)
+        return ComponentCache.get_generic_component(component_id)
 
     @abstractmethod
     def process(self, pipeline) -> PipelineProcessorResponse:

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -231,7 +231,7 @@ class PipelineProcessor(LoggingConfigurable):  # ABC
         components: List[Component] = ComponentCatalog.get_generic_components()
 
         # Retrieve runtime-specific components
-        components.extend(ComponentCatalog.instance().get_all_components(platform_type=self._type.name))
+        components.extend(ComponentCatalog.instance().get_all_components(platform=self._type))
 
         return components
 
@@ -241,7 +241,7 @@ class PipelineProcessor(LoggingConfigurable):  # ABC
         """
 
         if component_id not in ('notebook', 'python-script', 'r-script'):
-            return ComponentCatalog.instance().get_component(platform_type=self._type.name, component_id=component_id)
+            return ComponentCatalog.instance().get_component(platform=self._type, component_id=component_id)
 
         return ComponentCatalog.get_generic_component(component_id)
 

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -103,7 +103,7 @@ class PipelineProcessorManager(SingletonConfigurable):
         super().__init__(**kwargs)
         self.root_dir = get_expanded_path(kwargs.get('root_dir'))
         self._registry = PipelineProcessorRegistry.instance()
-        self._component_catalog = ComponentCatalog().instance(parent=self.parent)
+        self._component_catalog = ComponentCatalog.instance(parent=self.parent)
 
     def _get_processor_for_runtime(self, runtime_name: str):
         processor = self._registry.get_processor(runtime_name)
@@ -231,7 +231,7 @@ class PipelineProcessor(LoggingConfigurable):  # ABC
         components: List[Component] = ComponentCatalog.get_generic_components()
 
         # Retrieve runtime-specific components
-        components.extend(ComponentCatalog().instance().get_all_components(platform_type=self._type.name))
+        components.extend(ComponentCatalog.instance().get_all_components(platform_type=self._type.name))
 
         return components
 
@@ -241,7 +241,7 @@ class PipelineProcessor(LoggingConfigurable):  # ABC
         """
 
         if component_id not in ('notebook', 'python-script', 'r-script'):
-            return ComponentCatalog().instance().get_component(platform_type=self._type.name, component_id=component_id)
+            return ComponentCatalog.instance().get_component(platform_type=self._type.name, component_id=component_id)
 
         return ComponentCatalog.get_generic_component(component_id)
 

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -103,7 +103,6 @@ class PipelineProcessorManager(SingletonConfigurable):
         super().__init__(**kwargs)
         self.root_dir = get_expanded_path(kwargs.get('root_dir'))
         self._registry = PipelineProcessorRegistry.instance()
-        self._component_catalog = ComponentCatalog.instance(parent=self.parent)
 
     def _get_processor_for_runtime(self, runtime_name: str):
         processor = self._registry.get_processor(runtime_name)

--- a/elyra/pipeline/validation.py
+++ b/elyra/pipeline/validation.py
@@ -29,7 +29,7 @@ from elyra.metadata.manager import MetadataManager
 from elyra.metadata.schema import SchemaManager
 from elyra.metadata.schemaspaces import Runtimes
 from elyra.pipeline.component import Component
-from elyra.pipeline.component_catalog import ComponentCatalog
+from elyra.pipeline.component_catalog import ComponentCache
 from elyra.pipeline.pipeline import Operation
 from elyra.pipeline.pipeline import PIPELINE_CURRENT_SCHEMA
 from elyra.pipeline.pipeline import PIPELINE_CURRENT_VERSION
@@ -392,7 +392,7 @@ class PipelineValidationManager(SingletonConfigurable):
         """
 
         component_list = await PipelineProcessorManager.instance().get_components(pipeline_runtime)
-        components = ComponentCatalog.to_canvas_palette(component_list)
+        components = ComponentCache.to_canvas_palette(component_list)
 
         # Full dict of properties for the operation e.g. current params, optionals etc
         component_property_dict = await self._get_component_properties(pipeline_runtime, components, node.op)
@@ -709,7 +709,7 @@ class PipelineValidationManager(SingletonConfigurable):
                 if node_op == node_type['op']:
                     component: Component = \
                         await PipelineProcessorManager.instance().get_component(pipeline_runtime, node_op)
-                    component_properties = ComponentCatalog.to_canvas_properties(component)
+                    component_properties = ComponentCache.to_canvas_properties(component)
                     return component_properties
 
         return {}

--- a/elyra/tests/cli/test_pipeline_app.py
+++ b/elyra/tests/cli/test_pipeline_app.py
@@ -18,14 +18,13 @@ import json
 import os
 
 from click.testing import CliRunner
-from conftest import KFP_COMPONENT_CACHE_INSTANCE
 import pytest
 
 from elyra.cli.pipeline_app import pipeline
 from elyra.metadata.manager import MetadataManager
 from elyra.metadata.metadata import Metadata
 from elyra.metadata.schemaspaces import Runtimes
-from elyra.pipeline.component_catalog import ComponentCatalog
+from elyra.pipeline.component_catalog import ComponentCache
 
 SUB_COMMANDS = ['run', 'submit', 'describe', 'validate']
 
@@ -323,7 +322,7 @@ def test_describe_with_kfp_components():
 
 
 def test_validate_with_kfp_components(kfp_runtime_instance, component_cache_instance):
-    ComponentCatalog.instance().wait_for_all_cache_updates()
+    ComponentCache.instance().wait_for_all_cache_updates()
     runner = CliRunner()
     pipeline_file_path = os.path.join(os.path.dirname(__file__), 'resources', 'kfp_3_node_custom.pipeline')
 

--- a/elyra/tests/cli/test_pipeline_app.py
+++ b/elyra/tests/cli/test_pipeline_app.py
@@ -25,6 +25,7 @@ from elyra.cli.pipeline_app import pipeline
 from elyra.metadata.manager import MetadataManager
 from elyra.metadata.metadata import Metadata
 from elyra.metadata.schemaspaces import Runtimes
+from elyra.pipeline.component_catalog import ComponentCatalog
 
 SUB_COMMANDS = ['run', 'submit', 'describe', 'validate']
 
@@ -321,13 +322,12 @@ def test_describe_with_kfp_components():
     assert result.exit_code == 0
 
 
-@pytest.mark.parametrize('component_cache_instance', [KFP_COMPONENT_CACHE_INSTANCE], indirect=True)
 def test_validate_with_kfp_components(kfp_runtime_instance, component_cache_instance):
+    ComponentCatalog.instance().wait_for_all_cache_updates()
     runner = CliRunner()
     pipeline_file_path = os.path.join(os.path.dirname(__file__), 'resources', 'kfp_3_node_custom.pipeline')
 
     result = runner.invoke(pipeline, ['validate', pipeline_file_path, '--runtime-config', kfp_runtime_instance])
-
     assert "Validating pipeline..." in result.output
     assert result.exit_code == 0
 

--- a/elyra/tests/cli/test_pipeline_app.py
+++ b/elyra/tests/cli/test_pipeline_app.py
@@ -18,13 +18,13 @@ import json
 import os
 
 from click.testing import CliRunner
+from conftest import KFP_COMPONENT_CACHE_INSTANCE
 import pytest
 
 from elyra.cli.pipeline_app import pipeline
 from elyra.metadata.manager import MetadataManager
 from elyra.metadata.metadata import Metadata
 from elyra.metadata.schemaspaces import Runtimes
-from elyra.pipeline.component_catalog import ComponentCache
 
 SUB_COMMANDS = ['run', 'submit', 'describe', 'validate']
 
@@ -321,8 +321,8 @@ def test_describe_with_kfp_components():
     assert result.exit_code == 0
 
 
+@pytest.mark.parametrize('component_cache_instance', [KFP_COMPONENT_CACHE_INSTANCE], indirect=True)
 def test_validate_with_kfp_components(kfp_runtime_instance, component_cache_instance):
-    ComponentCache.instance().wait_for_all_cache_updates()
     runner = CliRunner()
     pipeline_file_path = os.path.join(os.path.dirname(__file__), 'resources', 'kfp_3_node_custom.pipeline')
 

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -16,6 +16,7 @@
 import os
 from types import SimpleNamespace
 
+from conftest import AIRFLOW_COMPONENT_CACHE_INSTANCE
 import jupyter_core.paths
 import pytest
 
@@ -45,11 +46,9 @@ def _get_resource_path(filename):
     return resource_path
 
 
-def test_component_catalog_can_load_components_from_registries():
-    # Initialize a ComponentCache instance and wait for all worker threads to compete
-    component_catalog = ComponentCache.instance()
-    component_catalog.wait_for_all_cache_updates()
-    components = component_catalog.get_all_components(RUNTIME_PROCESSOR)
+@pytest.mark.parametrize('component_cache_instance', [AIRFLOW_COMPONENT_CACHE_INSTANCE], indirect=True)
+def test_component_catalog_can_load_components_from_registries(component_cache_instance):
+    components = ComponentCache.instance().get_all_components(RUNTIME_PROCESSOR)
     assert len(components) > 0
 
 

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -16,7 +16,6 @@
 import os
 from types import SimpleNamespace
 
-from conftest import AIRFLOW_COMPONENT_CACHE_INSTANCE
 import jupyter_core.paths
 import pytest
 
@@ -46,8 +45,7 @@ def _get_resource_path(filename):
     return resource_path
 
 
-@pytest.mark.parametrize('component_cache_instance', [AIRFLOW_COMPONENT_CACHE_INSTANCE], indirect=True)
-def test_component_catalog_can_load_components_from_registries(component_cache_instance):
+def test_component_catalog_can_load_components_from_registries():
     components = ComponentCatalog.instance(for_test=True)\
         .get_all_components(RUNTIME_PROCESSOR_NAME)
     assert len(components) > 0

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -25,7 +25,7 @@ from elyra.metadata.schemaspaces import ComponentCatalogs
 from elyra.pipeline.catalog_connector import FilesystemComponentCatalogConnector
 from elyra.pipeline.catalog_connector import UrlComponentCatalogConnector
 from elyra.pipeline.component import ComponentParser
-from elyra.pipeline.component_catalog import ComponentCatalog
+from elyra.pipeline.component_catalog import ComponentCache
 from elyra.pipeline.runtime_type import RuntimeProcessorType
 
 COMPONENT_CATALOG_DIRECTORY = os.path.join(jupyter_core.paths.ENV_JUPYTER_PATH[0], 'components')
@@ -46,16 +46,16 @@ def _get_resource_path(filename):
 
 
 def test_component_catalog_can_load_components_from_registries():
-    # Initialize a ComponentCatalog instance and wait for all worker threads to compete
-    component_catalog = ComponentCatalog.instance()
+    # Initialize a ComponentCache instance and wait for all worker threads to compete
+    component_catalog = ComponentCache.instance()
     component_catalog.wait_for_all_cache_updates()
     components = component_catalog.get_all_components(RUNTIME_PROCESSOR)
     assert len(components) > 0
 
 
 def test_modify_component_catalogs():
-    # Initialize a ComponentCatalog instance and wait for all worker threads to compete
-    component_catalog = ComponentCatalog.instance()
+    # Initialize a ComponentCache instance and wait for all worker threads to compete
+    component_catalog = ComponentCache.instance()
     component_catalog.wait_for_all_cache_updates()
 
     # Get initial set of components from the current active registries
@@ -134,14 +134,14 @@ def test_modify_component_catalogs():
     assert post_delete_component_ids == initial_component_ids
 
     # Check that component palette is the same as before addition of the test registry
-    initial_palette = ComponentCatalog.to_canvas_palette(initial_components)
-    post_delete_palette = ComponentCatalog.to_canvas_palette(post_delete_components)
+    initial_palette = ComponentCache.to_canvas_palette(initial_components)
+    post_delete_palette = ComponentCache.to_canvas_palette(post_delete_components)
     assert initial_palette == post_delete_palette
 
 
 def test_directory_based_component_catalog():
-    # Initialize a ComponentCatalog instance and wait for all worker threads to compete
-    component_catalog = ComponentCatalog.instance()
+    # Initialize a ComponentCache instance and wait for all worker threads to compete
+    component_catalog = ComponentCache.instance()
     component_catalog.wait_for_all_cache_updates()
 
     # Get initial set of components from the current active registries
@@ -211,7 +211,7 @@ def test_parse_airflow_component_file():
     # Parse the component entry
     parser = ComponentParser.create_instance(platform=RUNTIME_PROCESSOR)
     component = parser.parse(component_entry)[0]
-    properties_json = ComponentCatalog.to_canvas_properties(component)
+    properties_json = ComponentCache.to_canvas_properties(component)
 
     # Ensure component parameters are prefixed (and system parameters are not), and hold correct values
     assert properties_json['current_parameters']['label'] == ''
@@ -289,7 +289,7 @@ def test_parse_airflow_component_url():
     # Parse the component entry
     parser = ComponentParser.create_instance(platform=RUNTIME_PROCESSOR)
     component = parser.parse(component_entry)[0]
-    properties_json = ComponentCatalog.to_canvas_properties(component)
+    properties_json = ComponentCache.to_canvas_properties(component)
 
     # Ensure component parameters are prefixed, and system parameters are not, and hold correct values
     assert properties_json['current_parameters']['label'] == ''
@@ -332,7 +332,7 @@ def test_parse_airflow_component_file_no_inputs():
     # Parse the component entry
     parser = ComponentParser.create_instance(platform=RUNTIME_PROCESSOR)
     component = parser.parse(component_entry)[0]
-    properties_json = ComponentCatalog.to_canvas_properties(component)
+    properties_json = ComponentCache.to_canvas_properties(component)
 
     # Properties JSON should only include the two parameters common to every
     # component:'label' and 'component_source'
@@ -374,7 +374,7 @@ def test_parse_airflow_component_file_type_hints():
     # Parse the component entry
     parser = ComponentParser.create_instance(platform=RUNTIME_PROCESSOR)
     component = parser.parse(component_entry)[0]
-    properties_json = ComponentCatalog.to_canvas_properties(component)
+    properties_json = ComponentCache.to_canvas_properties(component)
 
     # Ensure component parameters are prefixed (and system parameters are not), and hold correct values
     assert properties_json['current_parameters']['label'] == ''

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -46,6 +46,7 @@ def _get_resource_path(filename):
 
 
 def test_component_catalog_can_load_components_from_registries():
+    ComponentCatalog.clear_instance()
     components = ComponentCatalog.instance(for_test=True)\
         .get_all_components(RUNTIME_PROCESSOR_NAME)
     assert len(components) > 0

--- a/elyra/tests/pipeline/airflow/test_processor_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_processor_airflow.py
@@ -25,7 +25,7 @@ import pytest
 
 from elyra.metadata.metadata import Metadata
 from elyra.pipeline.airflow.processor_airflow import AirflowPipelineProcessor
-from elyra.pipeline.component_catalog import ComponentCatalog
+from elyra.pipeline.component_catalog import ComponentCache
 from elyra.pipeline.parser import PipelineParser
 from elyra.pipeline.pipeline import GenericOperation
 from elyra.pipeline.runtime_type import RuntimeProcessorType
@@ -44,7 +44,7 @@ def processor(setup_factory_data, component_cache_instance):
 
 @pytest.fixture
 def parsed_pipeline(request):
-    ComponentCatalog.instance().wait_for_all_cache_updates()
+    ComponentCache.instance().wait_for_all_cache_updates()
     pipeline_resource = _read_pipeline_resource(request.param)
     return PipelineParser().parse(pipeline_json=pipeline_resource)
 

--- a/elyra/tests/pipeline/airflow/test_processor_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_processor_airflow.py
@@ -25,6 +25,7 @@ import pytest
 
 from elyra.metadata.metadata import Metadata
 from elyra.pipeline.airflow.processor_airflow import AirflowPipelineProcessor
+from elyra.pipeline.component_catalog import ComponentCatalog
 from elyra.pipeline.parser import PipelineParser
 from elyra.pipeline.pipeline import GenericOperation
 from elyra.pipeline.runtime_type import RuntimeProcessorType
@@ -43,6 +44,7 @@ def processor(setup_factory_data, component_cache_instance):
 
 @pytest.fixture
 def parsed_pipeline(request):
+    ComponentCatalog.instance().wait_for_all_cache_updates()
     pipeline_resource = _read_pipeline_resource(request.param)
     return PipelineParser().parse(pipeline_json=pipeline_resource)
 

--- a/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
@@ -43,6 +43,7 @@ def _get_resource_path(filename):
 
 @pytest.mark.parametrize('component_cache_instance', [KFP_COMPONENT_CACHE_INSTANCE], indirect=True)
 def test_component_catalog_can_load_components_from_registries(component_cache_instance):
+    ComponentCatalog.clear_instance()
     components = ComponentCatalog.instance(for_test=True)\
         .get_all_components(RUNTIME_PROCESSOR_NAME)
     assert len(components) > 0

--- a/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
@@ -16,7 +16,9 @@
 import os
 from types import SimpleNamespace
 
+from conftest import KFP_COMPONENT_CACHE_INSTANCE
 import jupyter_core.paths
+import pytest
 
 from elyra.metadata.manager import MetadataManager
 from elyra.metadata.metadata import Metadata
@@ -39,11 +41,9 @@ def _get_resource_path(filename):
     return resource_path
 
 
+@pytest.mark.parametrize('component_cache_instance', [KFP_COMPONENT_CACHE_INSTANCE], indirect=True)
 def test_component_catalog_can_load_components_from_registries(component_cache_instance):
-    # Initialize a ComponentCache instance and wait for all worker threads to compete
-    component_catalog = ComponentCache.instance()
-    component_catalog.wait_for_all_cache_updates()
-    components = component_catalog.get_all_components(RUNTIME_PROCESSOR)
+    components = ComponentCache.instance().get_all_components(RUNTIME_PROCESSOR)
     assert len(components) > 0
 
 

--- a/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
@@ -30,7 +30,7 @@ from elyra.pipeline.component_catalog import ComponentCatalog
 from elyra.pipeline.runtime_type import RuntimeProcessorType
 
 COMPONENT_CATALOG_DIRECTORY = os.path.join(jupyter_core.paths.ENV_JUPYTER_PATH[0], 'components')
-RUNTIME_PROCESSOR_NAME = RuntimeProcessorType.KUBEFLOW_PIPELINES.name  # 'KUBEFLOW_PIPELINES'
+RUNTIME_PROCESSOR = RuntimeProcessorType.KUBEFLOW_PIPELINES
 
 
 def _get_resource_path(filename):
@@ -41,20 +41,21 @@ def _get_resource_path(filename):
     return resource_path
 
 
-@pytest.mark.parametrize('component_cache_instance', [KFP_COMPONENT_CACHE_INSTANCE], indirect=True)
 def test_component_catalog_can_load_components_from_registries(component_cache_instance):
-    ComponentCatalog.clear_instance()
-    components = ComponentCatalog.instance(for_test=True)\
-        .get_all_components(RUNTIME_PROCESSOR_NAME)
+    # Initialize a ComponentCatalog instance and wait for all worker threads to compete
+    component_catalog = ComponentCatalog.instance()
+    component_catalog.wait_for_all_cache_updates()
+    components = component_catalog.get_all_components(RUNTIME_PROCESSOR)
     assert len(components) > 0
 
 
 def test_modify_component_catalogs():
-    ComponentCatalog.clear_instance()
+    # Initialize a ComponentCatalog instance and wait for all worker threads to compete
+    component_catalog = ComponentCatalog.instance()
+    component_catalog.wait_for_all_cache_updates()
 
     # Get initial set of components from the current active registries
-    initial_components = ComponentCatalog.instance(for_test=True)\
-        .get_all_components(RUNTIME_PROCESSOR_NAME)
+    initial_components = component_catalog.get_all_components(RUNTIME_PROCESSOR)
 
     # Components must be sorted by id for the equality comparison with later component lists
     initial_components = sorted(initial_components, key=lambda component: component.id)
@@ -66,26 +67,29 @@ def test_modify_component_catalogs():
 
     instance_metadata = {
         "description": "A test registry",
-        "runtime_type": "KUBEFLOW_PIPELINES",
+        "runtime_type": RUNTIME_PROCESSOR.name,
         "categories": ["New Components"],
         "paths": paths
     }
     registry_instance = Metadata(schema_name="local-file-catalog",
-                                 name="new_registry",
-                                 display_name="New Registry",
+                                 name="new_test_registry",
+                                 display_name="New Test Registry",
                                  metadata=instance_metadata)
 
     try:
-        if metadata_manager.get("new_registry"):
-            metadata_manager.remove("new_registry")
+        if metadata_manager.get("new_test_registry"):
+            metadata_manager.remove("new_test_registry")
     except Exception:
         pass
 
-    metadata_manager.create("new_registry", registry_instance)
+    metadata_manager.create("new_test_registry", registry_instance)
+
+    # Wait for update to complete
+    component_catalog.wait_for_all_cache_updates()
 
     # Get new set of components from all active registries, including added test registry
-    added_components = ComponentCatalog.instance(for_test=True)\
-        .get_all_components(RUNTIME_PROCESSOR_NAME)
+    added_components = component_catalog.get_all_components(RUNTIME_PROCESSOR)
+    added_components = sorted(added_components, key=lambda component: component.id)
     assert len(added_components) > len(initial_components)
 
     added_component_names = [component.name for component in added_components]
@@ -94,11 +98,14 @@ def test_modify_component_catalogs():
 
     # Modify the test registry to add an additional path to
     paths.append(_get_resource_path('kfp_test_operator_no_inputs.yaml'))
-    metadata_manager.update("new_registry", registry_instance)
+    metadata_manager.update("new_test_registry", registry_instance)
+
+    # Wait for update to complete
+    component_catalog.wait_for_all_cache_updates()
 
     # Get set of components from all active registries, including modified test registry
-    modified_components = ComponentCatalog.instance(for_test=True)\
-        .get_all_components(RUNTIME_PROCESSOR_NAME)
+    modified_components = component_catalog.get_all_components(RUNTIME_PROCESSOR)
+    modified_components = sorted(modified_components, key=lambda component: component.id)
     assert len(modified_components) > len(added_components)
 
     modified_component_names = [component.name for component in modified_components]
@@ -106,9 +113,12 @@ def test_modify_component_catalogs():
     assert 'Test Operator No Inputs' in modified_component_names
 
     # Delete the test registry
-    metadata_manager.remove("new_registry")
-    post_delete_components = ComponentCatalog.instance(for_test=True)\
-        .get_all_components(RUNTIME_PROCESSOR_NAME)
+    metadata_manager.remove("new_test_registry")
+
+    # Wait for update to complete
+    component_catalog.wait_for_all_cache_updates()
+
+    post_delete_components = component_catalog.get_all_components(RUNTIME_PROCESSOR)
     post_delete_components = sorted(post_delete_components, key=lambda component: component.id)
     assert len(post_delete_components) == len(initial_components)
 
@@ -124,9 +134,12 @@ def test_modify_component_catalogs():
 
 
 def test_directory_based_component_catalog():
+    # Initialize a ComponentCatalog instance and wait for all worker threads to compete
+    component_catalog = ComponentCatalog.instance()
+    component_catalog.wait_for_all_cache_updates()
+
     # Get initial set of components from the current active registries
-    initial_components = ComponentCatalog.instance(for_test=True)\
-        .get_all_components(RUNTIME_PROCESSOR_NAME)
+    initial_components = component_catalog.get_all_components(RUNTIME_PROCESSOR)
 
     metadata_manager = MetadataManager(schemaspace=ComponentCatalogs.COMPONENT_CATALOGS_SCHEMASPACE_ID)
 
@@ -134,26 +147,28 @@ def test_directory_based_component_catalog():
     registry_path = _get_resource_path('')
     instance_metadata = {
         "description": "A test registry",
-        "runtime_type": "KUBEFLOW_PIPELINES",
+        "runtime_type": RUNTIME_PROCESSOR.name,
         "categories": ["New Components"],
         "paths": [registry_path]
     }
     registry_instance = Metadata(schema_name="local-directory-catalog",
-                                 name="new_registry",
-                                 display_name="New Registry",
+                                 name="new_test_registry",
+                                 display_name="New Test Registry",
                                  metadata=instance_metadata)
 
     try:
-        if metadata_manager.get("new_registry"):
-            metadata_manager.remove("new_registry")
+        if metadata_manager.get("new_test_registry"):
+            metadata_manager.remove("new_test_registry")
     except Exception:
         pass
 
-    metadata_manager.create("new_registry", registry_instance)
+    metadata_manager.create("new_test_registry", registry_instance)
+
+    # Wait for update to complete
+    component_catalog.wait_for_all_cache_updates()
 
     # Get new set of components from all active registries, including added test registry
-    added_components = ComponentCatalog.instance(for_test=True)\
-        .get_all_components(RUNTIME_PROCESSOR_NAME)
+    added_components = component_catalog.get_all_components(RUNTIME_PROCESSOR)
     assert len(added_components) > len(initial_components)
 
     # Check that all relevant components from the new registry have been added
@@ -163,7 +178,7 @@ def test_directory_based_component_catalog():
     assert 'Test Operator No Inputs' in added_component_names
 
     # Remove the test instance
-    metadata_manager.remove("new_registry")
+    metadata_manager.remove("new_test_registry")
 
 
 def test_parse_kfp_component_file():
@@ -189,7 +204,7 @@ def test_parse_kfp_component_file():
     component_entry = SimpleNamespace(**entry)
 
     # Parse the component entry
-    parser = ComponentParser(platform_type=RUNTIME_PROCESSOR_NAME)
+    parser = ComponentParser.create_instance(platform=RUNTIME_PROCESSOR)
     component = parser.parse(component_entry)[0]
     properties_json = ComponentCatalog.to_canvas_properties(component)
 
@@ -281,7 +296,7 @@ def test_parse_kfp_component_url():
     component_entry = SimpleNamespace(**entry)
 
     # Parse the component entry
-    parser = ComponentParser(platform_type=RUNTIME_PROCESSOR_NAME)
+    parser = ComponentParser.create_instance(platform=RUNTIME_PROCESSOR)
     component = parser.parse(component_entry)[0]
     properties_json = ComponentCatalog.to_canvas_properties(component)
 
@@ -319,7 +334,7 @@ def test_parse_kfp_component_file_no_inputs():
     component_entry = SimpleNamespace(**entry)
 
     # Parse the component entry
-    parser = ComponentParser(platform_type=RUNTIME_PROCESSOR_NAME)
+    parser = ComponentParser.create_instance(platform=RUNTIME_PROCESSOR)
     component = parser.parse(component_entry)[0]
     properties_json = ComponentCatalog.to_canvas_properties(component)
 

--- a/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
@@ -16,9 +16,7 @@
 import os
 from types import SimpleNamespace
 
-from conftest import KFP_COMPONENT_CACHE_INSTANCE
 import jupyter_core.paths
-import pytest
 
 from elyra.metadata.manager import MetadataManager
 from elyra.metadata.metadata import Metadata
@@ -26,7 +24,7 @@ from elyra.metadata.schemaspaces import ComponentCatalogs
 from elyra.pipeline.catalog_connector import FilesystemComponentCatalogConnector
 from elyra.pipeline.catalog_connector import UrlComponentCatalogConnector
 from elyra.pipeline.component import ComponentParser
-from elyra.pipeline.component_catalog import ComponentCatalog
+from elyra.pipeline.component_catalog import ComponentCache
 from elyra.pipeline.runtime_type import RuntimeProcessorType
 
 COMPONENT_CATALOG_DIRECTORY = os.path.join(jupyter_core.paths.ENV_JUPYTER_PATH[0], 'components')
@@ -42,16 +40,16 @@ def _get_resource_path(filename):
 
 
 def test_component_catalog_can_load_components_from_registries(component_cache_instance):
-    # Initialize a ComponentCatalog instance and wait for all worker threads to compete
-    component_catalog = ComponentCatalog.instance()
+    # Initialize a ComponentCache instance and wait for all worker threads to compete
+    component_catalog = ComponentCache.instance()
     component_catalog.wait_for_all_cache_updates()
     components = component_catalog.get_all_components(RUNTIME_PROCESSOR)
     assert len(components) > 0
 
 
 def test_modify_component_catalogs():
-    # Initialize a ComponentCatalog instance and wait for all worker threads to compete
-    component_catalog = ComponentCatalog.instance()
+    # Initialize a ComponentCache instance and wait for all worker threads to compete
+    component_catalog = ComponentCache.instance()
     component_catalog.wait_for_all_cache_updates()
 
     # Get initial set of components from the current active registries
@@ -128,14 +126,14 @@ def test_modify_component_catalogs():
     assert post_delete_component_ids == initial_component_ids
 
     # Check that component palette is the same as before addition of the test registry
-    initial_palette = ComponentCatalog.to_canvas_palette(post_delete_components)
-    post_delete_palette = ComponentCatalog.to_canvas_palette(initial_components)
+    initial_palette = ComponentCache.to_canvas_palette(post_delete_components)
+    post_delete_palette = ComponentCache.to_canvas_palette(initial_components)
     assert initial_palette == post_delete_palette
 
 
 def test_directory_based_component_catalog():
-    # Initialize a ComponentCatalog instance and wait for all worker threads to compete
-    component_catalog = ComponentCatalog.instance()
+    # Initialize a ComponentCache instance and wait for all worker threads to compete
+    component_catalog = ComponentCache.instance()
     component_catalog.wait_for_all_cache_updates()
 
     # Get initial set of components from the current active registries
@@ -206,7 +204,7 @@ def test_parse_kfp_component_file():
     # Parse the component entry
     parser = ComponentParser.create_instance(platform=RUNTIME_PROCESSOR)
     component = parser.parse(component_entry)[0]
-    properties_json = ComponentCatalog.to_canvas_properties(component)
+    properties_json = ComponentCache.to_canvas_properties(component)
 
     # Ensure component parameters are prefixed (and system parameters are not) and all hold correct values
     assert properties_json['current_parameters']['label'] == ''
@@ -298,7 +296,7 @@ def test_parse_kfp_component_url():
     # Parse the component entry
     parser = ComponentParser.create_instance(platform=RUNTIME_PROCESSOR)
     component = parser.parse(component_entry)[0]
-    properties_json = ComponentCatalog.to_canvas_properties(component)
+    properties_json = ComponentCache.to_canvas_properties(component)
 
     # Ensure component parameters are prefixed (and system parameters are not) and all hold correct values
     assert properties_json['current_parameters']['label'] == ''
@@ -336,7 +334,7 @@ def test_parse_kfp_component_file_no_inputs():
     # Parse the component entry
     parser = ComponentParser.create_instance(platform=RUNTIME_PROCESSOR)
     component = parser.parse(component_entry)[0]
-    properties_json = ComponentCatalog.to_canvas_properties(component)
+    properties_json = ComponentCache.to_canvas_properties(component)
 
     # Properties JSON should only include the two parameters common to every
     # component:'label' and 'component_source', the component description if

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -43,6 +43,7 @@ def processor(setup_factory_data, component_cache_instance):
 
 @pytest.fixture
 def pipeline():
+    ComponentCatalog.instance().wait_for_all_cache_updates()
     pipeline_resource = _read_pipeline_resource(
         'resources/sample_pipelines/pipeline_3_node_sample.json')
     return PipelineParser.parse(pipeline_resource)
@@ -293,7 +294,7 @@ def test_processing_url_runtime_specific_component(monkeypatch, processor, sampl
     component = Component(id=component_id,
                           name="Filter text",
                           description="",
-                          op="filter-text",  # TODO remove this??
+                          op="filter-text",
                           catalog_type="url-catalog",
                           source_identifier={"url": url},
                           definition=component_definition,
@@ -319,7 +320,7 @@ def test_processing_url_runtime_specific_component(monkeypatch, processor, sampl
     # Build a mock runtime config for use in _cc_pipeline
     mocked_runtime = Metadata(name="test-metadata",
                               display_name="test",
-                              schema_name="airflow",
+                              schema_name="kfp",
                               metadata=sample_metadata)
 
     mocked_func = mock.Mock(return_value="default", side_effect=[mocked_runtime, sample_metadata])
@@ -397,7 +398,7 @@ def test_processing_filename_runtime_specific_component(monkeypatch, processor, 
     # Build a mock runtime config for use in _cc_pipeline
     mocked_runtime = Metadata(name="test-metadata",
                               display_name="test",
-                              schema_name="airflow",
+                              schema_name="kfp",
                               metadata=sample_metadata)
 
     mocked_func = mock.Mock(return_value="default", side_effect=[mocked_runtime, sample_metadata])

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -26,7 +26,7 @@ from elyra.metadata.metadata import Metadata
 from elyra.pipeline.catalog_connector import FilesystemComponentCatalogConnector
 from elyra.pipeline.catalog_connector import UrlComponentCatalogConnector
 from elyra.pipeline.component import Component
-from elyra.pipeline.component_catalog import ComponentCatalog
+from elyra.pipeline.component_catalog import ComponentCache
 from elyra.pipeline.kfp.processor_kfp import KfpPipelineProcessor
 from elyra.pipeline.parser import PipelineParser
 from elyra.pipeline.pipeline import GenericOperation
@@ -43,7 +43,7 @@ def processor(setup_factory_data, component_cache_instance):
 
 @pytest.fixture
 def pipeline():
-    ComponentCatalog.instance().wait_for_all_cache_updates()
+    ComponentCache.instance().wait_for_all_cache_updates()
     pipeline_resource = _read_pipeline_resource(
         'resources/sample_pipelines/pipeline_3_node_sample.json')
     return PipelineParser.parse(pipeline_resource)
@@ -302,7 +302,7 @@ def test_processing_url_runtime_specific_component(monkeypatch, processor, sampl
                           properties=[])
 
     # Replace cached component registry with single url-based component for testing
-    ComponentCatalog.instance()._component_cache[processor._type.name]['some_catalog_name'] = {component_id: component}
+    ComponentCache.instance()._component_cache[processor._type.name]['some_catalog_name'] = {component_id: component}
 
     # Construct hypothetical operation for component
     operation_name = "Filter text test"
@@ -380,7 +380,7 @@ def test_processing_filename_runtime_specific_component(monkeypatch, processor, 
                           categories=[])
 
     # Replace cached component registry with single filename-based component for testing
-    ComponentCatalog.instance()._component_cache[processor._type.name]['some_catalog_name'] = {component_id: component}
+    ComponentCache.instance()._component_cache[processor._type.name]['some_catalog_name'] = {component_id: component}
 
     # Construct hypothetical operation for component
     operation_name = "Download data test"

--- a/elyra/tests/pipeline/resources/components/download_data.yaml
+++ b/elyra/tests/pipeline/resources/components/download_data.yaml
@@ -1,0 +1,40 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Download data
+inputs:
+- {name: Url, type: URI}
+- {name: curl options, type: string, default: '--location', description: 'Additional options given to the curl program. See https://curl.haxx.se/docs/manpage.html'}
+outputs:
+- {name: Data}
+metadata:
+  annotations:
+    author: Alexey Volkov <alexey.volkov@ark-kun.com>
+implementation:
+  container:
+    # image: curlimages/curl  # Sets a non-root user which cannot write to mounted volumes. See https://github.com/curl/curl-docker/issues/22
+    image: byrnedo/alpine-curl@sha256:548379d0a4a0c08b9e55d9d87a592b7d35d9ab3037f4936f5ccd09d0b625a342
+    command:
+    - sh
+    - -exc
+    - |
+      url="$0"
+      output_path="$1"
+      curl_options="$2"
+
+      mkdir -p "$(dirname "$output_path")"
+      curl --get "$url" --output "$output_path" $curl_options
+    - inputValue: Url
+    - outputPath: Data
+    - inputValue: curl options


### PR DESCRIPTION
Fixes #2162
Fixes #2278

### What changes were proposed in this pull request?
The major change proposed here is making the `ComponentCatalog` class a `SingletonConfigurable`. This has 2 benefits:

1. decouples the processors from the component cache stored in `ComponentCatalog` and from the `ComponentParser` classes as well (increases start-up speed)
2. enables async component cache updates and removes the need for the cache TTL

All interfaces remain the same, so no updates to, e.g. the catalog connectors or APIs, are required. Further details below.

With the new singleton `ComponentCatalog`, initialization of the class instance is moved to the `PipelineProcessorManager`, similar to how the `PipelineProcessorRegistry` singleton class is initialized. This removes the need for `RuntimePipelineProcessor`s to perform their own runtime-type-specific catalog initialization in their init function. Subsequent component cache accesses are also much faster, simply requiring accessing the existing instance of `ComponentCatalog` and its methods hence (I say! 🧐 ).

Similarly, the `post_save` and `post_delete` hooks in `ComponentMetadata` no longer require processor access in order to call for an update of the component cache. Instead, the post-hooks call the catalog instance methods directly. 

On initialization of the `ComponentCatalog` instance, all existing catalogs are read and parsed, which is similar to how this is currently done. This PR adds the creation of a cache update manager thread that is responsible for the creation and monitoring of child threads -- one per cache update task that exists in a queue. This allows for reads to occur asynchronously and to update the cache as necessary when complete. No lock is required, as Python built-in types are already thread-safe. A `wait_for_all_cache_updates` method is also added to `ComponentCatalog`. The purpose of this is to allow tests that require complete updates to the component cache the ability to call to wait for the cache update thread to finish (i.e. `join()`) _before_ checking against assertions. 

The combination of all the above factors allows for the removal of the cache TTL.

The `Processor` classes are also decoupled from the `ComponentParser`s and allow for the removal of the `component_parser` property. Parsers are, however, still runtime-type-specific by necessity. Assignment is taken care of using the `ComponentParser` `create_instance` method, which is passed the runtime platform type given in the catalog Metadata instance (e.g. 'APACHE_AIRFLOW', 'KUBEFLOW_PIPELINES'). The runtime platform type argument matches the `component_platform` class variable name on the relevant `ComponentParser` subclass (`AirflowComponentParser` and `KfpComponentParser`) and returns that subclass as the assigned parser.

As proposed in #2162, the component_cache dictionary is restructured to be of the following general format:

```
{
  "APACHE_AIRFLOW": {    # runtime type
    "aa_examples": {     # catalog instance name
      "elyra-airflow-examples-catalog:3a55d015ea96": <Component object>,
      "elyra-airflow-examples-catalog:a043648d3897": <Component object>,
      ...
    },
    "my_airflow_components": {    # catalog instance name
      "elyra-airflow-examples-catalog:b94cd49692e2": <Component object>
    }, 
    ...
  },
  "KUBEFLOW_PIPELINES": {    # runtime type
    "kfp_examples": {     # catalog instance name
      "elyra-kfp-examples-catalog:61e6f4141f65": <Component object>,
      "elyra-kfp-examples-catalog:737915b826e9": <Component object>
    },
    ...
  },
  ... (eventually, additional runtime types)
}
```

This enables faster per-runtime type access (i.e., in `get_components()` and `get_component()`) and simpler per-catalog updates to the cache (e.g. the modification of a catalog only requires update of the given catalog's sub-dictionary rather than all catalogs for a runtime).

Finally, the `ComponentCatalog` class has been renamed to `ComponentCache`. There's been a lot of renaming recently, but I think this new name is more indicative of the purpose of the class (to maintain the component cache). 

### How was this pull request tested?
Existing test cases have been updated and are passing locally and in the CI.

A new test resource has been added (`download_data.yaml`) in order to simplify the pipeline processor tests that construct a true pipeline. This is intended to replace the `filter_text.yaml` resource, which requires more complicated set of properties (those using `inputpath` and requiring upstream connections). I plan to remove `filter_text.yaml` and replace any uses with the new download test component in a future commit (or future PR since this will cause some test failures at first - see `test_processing_url_runtime_specific_component` in `test_processor_kfp`).

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
