### PR TITLE
Add explicit support for COS authentication types to runtime configurations

### DIFF
--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -268,9 +268,26 @@ This should be the URL address of your S3-compatible Object Storage. If running 
 
 Example: `https://minio-service.kubeflow:9000`
 
+##### Cloud Object Storage bucket name (cos_bucket)
+
+Name of the bucket you want Elyra to store pipeline artifacts in. This setting is required. If the bucket doesn't exist, it will be created. The specified bucket name must meet the naming conventions imposed by the Object Storage service.
+
+Example: `test-bucket`
+
+> If using IBM Cloud Object Storage, you must generate a set of [HMAC Credentials](https://cloud.ibm.com/docs/services/cloud-object-storage/hmac?topic=cloud-object-storage-uhc-hmac-credentials-main)
+and grant that key at least [Writer](https://cloud.ibm.com/docs/services/cloud-object-storage/iam?topic=cloud-object-storage-iam-bucket-permissions) level privileges.
+Specify `access_key_id` and `secret_access_key` as `cos_username` and `cos_password`, respectively.
+
+##### Cloud Object Storage Authentication Type (cos_auth_type)
+
+Authentication type Elyra uses to gain access to Cloud Object Storage. This setting is required. Supported types are:
+- Username and password (`USER_CREDENTIALS`). This authentication type requires a username and password. Caution: this authentication mechanism exposes the credentials in plain text. When running Elyra on Kubernetes, it is highly recommended to use the `KUBERNETES_SECRET` authentication type instead.
+- Username, password, and Kubernetes secret (`KUBERNETES_SECRET`). This authentication type requires a username, password, and the name of an existing Kubernetes secret in the target runtime environment. Refer to section [Cloud Object Storage Credentials Secret](#cloud-object-storage-credentials-secret) for details.
+- IAM roles for service accounts (`AWS_IAM_ROLES_FOR_SERVICE_ACCOUNTS`). Supported for AWS only. Refer to the [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) for details.
+
 ##### Cloud Object Storage Credentials Secret (cos_secret)
 
-(Optional) Kubernetes secret that's defined in the specified user namespace, containing the Cloud Object Storage username and password.
+Kubernetes secret that's defined in the specified user namespace, containing the Cloud Object Storage username and password.
 If specified, this secret must exist on the Kubernetes cluster hosting your pipeline runtime in order to successfully
 execute pipelines. This setting is optional but is recommended for use in shared environments to avoid exposing a user's 
 Cloud Object Storage credentials. 
@@ -294,32 +311,16 @@ data:
 
 ##### Cloud Object Storage username (cos_username)
 
-Username used to access the Object Storage. 
-This setting is optional, but if not specified, you must provide Minio/S3 credentials using another method.
+Username used to connect to Object Storage, if credentials are required for the selected authentication type.
 
 Example: `minio`
 
-When `cos_username` and `cos_password` are not specified, we try the following environment variables in order:
-
-1. `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (could be set external to Elyra, or with `cos_secret`)
-1. `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` (usually set by AWS [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html))
-
 ##### Cloud Object Storage password (cos_password)
 
-Password for cos_username. 
-This setting is optional, but if not specified, you must provide Minio/S3 credentials using another method (see `cos_username` for more information).
+Password for cos_username, if credentials are required for the selected authentication type.
 
 Example: `minio123`
 
-##### Cloud Object Storage bucket name (cos_bucket)
-
-Name of the bucket you want Elyra to store pipeline artifacts in. This setting is required. If the bucket doesn't exist, it will be created. The specified bucket name must meet the naming conventions imposed by the Object Storage service.
-
-Example: `test-bucket`
-
-> If using IBM Cloud Object Storage, you must generate a set of [HMAC Credentials](https://cloud.ibm.com/docs/services/cloud-object-storage/hmac?topic=cloud-object-storage-uhc-hmac-credentials-main)
-and grant that key at least [Writer](https://cloud.ibm.com/docs/services/cloud-object-storage/iam?topic=cloud-object-storage-iam-bucket-permissions) level privileges.
-Specify `access_key_id` and `secret_access_key` as `cos_username` and `cos_password`, respectively.
 
 ### Verifying runtime configurations
 

--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -97,6 +97,7 @@ elyra-metadata install runtimes \
        --api_password=mypassword \
        --engine=Argo \
        --cos_endpoint=http://minio-service.kubeflow:9000 \
+       --cos_auth_type="USER_CREDENTIALS" \
        --cos_username=minio \
        --cos_password=minio123 \
        --cos_bucket=test-bucket \
@@ -121,6 +122,7 @@ elyra-metadata install runtimes \
        --api_password=mynewpassword \
        --engine=Argo \
        --cos_endpoint=http://minio-service.kubeflow:9000 \
+       --cos_auth_type="USER_CREDENTIALS" \
        --cos_username=minio \
        --cos_password=minio123 \
        --cos_bucket=test-bucket \

--- a/elyra/metadata/schemas/airflow.json
+++ b/elyra/metadata/schemas/airflow.json
@@ -5,7 +5,7 @@
   "name": "airflow",
   "schemaspace": "runtimes",
   "schemaspace_id": "130b8e00-de7c-4b32-b553-b4a52824a3b5",
-  "metadata_class_name": "elyra.pipeline.runtimes_metadata.RuntimesMetadata",
+  "metadata_class_name": "elyra.pipeline.airflow.airflow_metadata.AirflowMetadata",
   "runtime_type": "APACHE_AIRFLOW",
   "uihints": {
     "title": "Apache Airflow runtimes",
@@ -111,6 +111,32 @@
             "placeholder": "https://your-cos-service:port"
           }
         },
+        "cos_bucket": {
+          "title": "Cloud Object Storage Bucket Name",
+          "description": "The Cloud Object Storage bucket name",
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-.]*[a-z0-9]$",
+          "minLength": 3,
+          "maxLength": 222,
+          "uihints": {
+            "category": "Cloud Object Storage"
+          }
+        },
+        "cos_auth_type": {
+          "title": "Cloud Object Storage Authentication Type",
+          "description": "Authentication type Elyra uses to authenticate with Cloud Object Storage",
+          "type": "string",
+          "enum": [
+            "AWS_IAM_ROLES_FOR_SERVICE_ACCOUNTS",
+            "KUBERNETES_SECRET",
+            "USER_CREDENTIALS"
+          ],
+          "default": "USER_CREDENTIALS",
+          "uihints": {
+            "field_type": "dropdown",
+            "category": "Cloud Object Storage"
+          }
+        },
         "cos_secret": {
           "title": "Cloud Object Storage Credentials Secret",
           "description": "Kubernetes secret that's defined in the specified user namespace, containing the Cloud Object Storage username and password.",
@@ -138,17 +164,6 @@
             "category": "Cloud Object Storage"
           }
         },
-        "cos_bucket": {
-          "title": "Cloud Object Storage Bucket Name",
-          "description": "The Cloud Object Storage bucket name",
-          "type": "string",
-          "pattern": "^[a-z0-9][a-z0-9-.]*[a-z0-9]$",
-          "minLength": 3,
-          "maxLength": 222,
-          "uihints": {
-            "category": "Cloud Object Storage"
-          }
-        },
         "tags": {
           "title": "Tags",
           "description": "Tags for categorizing Apache Airflow",
@@ -161,6 +176,7 @@
       "required": [
         "api_endpoint",
         "cos_endpoint",
+        "cos_auth_type",
         "cos_bucket",
         "github_api_endpoint",
         "github_branch",

--- a/elyra/metadata/schemas/airflow.json
+++ b/elyra/metadata/schemas/airflow.json
@@ -139,7 +139,7 @@
         },
         "cos_secret": {
           "title": "Cloud Object Storage Credentials Secret",
-          "description": "Kubernetes secret that's defined in the specified user namespace, containing the Cloud Object Storage username and password.",
+          "description": "Kubernetes secret that's defined in the specified user namespace, containing the Cloud Object Storage username and password. This property is required for authentication type KUBERNETES_SECRET.",
           "type": "string",
           "uihints": {
             "secure": true,
@@ -148,7 +148,7 @@
         },
         "cos_username": {
           "title": "Cloud Object Storage Username",
-          "description": "The Cloud Object Storage username",
+          "description": "The Cloud Object Storage username. This property is required for authentication type USER_CREDENTIALS and KUBERNETES_SECRET.",
           "type": "string",
           "uihints": {
             "category": "Cloud Object Storage"
@@ -156,7 +156,7 @@
         },
         "cos_password": {
           "title": "Cloud Object Storage Password",
-          "description": "The Cloud Object Storage password",
+          "description": "The Cloud Object Storage password. This property is required for authentication type USER_CREDENTIALS and KUBERNETES_SECRET.",
           "type": "string",
           "minLength": 8,
           "uihints": {

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -112,6 +112,32 @@
             "placeholder": "https://your-cos-service:port"
           }
         },
+        "cos_bucket": {
+          "title": "Cloud Object Storage Bucket Name",
+          "description": "The Cloud Object Storage bucket name",
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-.]*[a-z0-9]$",
+          "minLength": 3,
+          "maxLength": 222,
+          "uihints": {
+            "category": "Cloud Object Storage"
+          }
+        },
+        "cos_auth_type": {
+          "title": "Cloud Object Storage Authentication Type",
+          "description": "Authentication type Elyra uses to authenticate with Cloud Object Storage",
+          "type": "string",
+          "enum": [
+            "AWS_IAM_ROLES_FOR_SERVICE_ACCOUNTS",
+            "KUBERNETES_SECRET",
+            "USER_CREDENTIALS"
+          ],
+          "default": "USER_CREDENTIALS",
+          "uihints": {
+            "field_type": "dropdown",
+            "category": "Cloud Object Storage"
+          }
+        },
         "cos_secret": {
           "title": "Cloud Object Storage Credentials Secret",
           "description": "Kubernetes secret that's defined in the specified user namespace, containing the Cloud Object Storage username and password.",
@@ -139,17 +165,6 @@
             "category": "Cloud Object Storage"
           }
         },
-        "cos_bucket": {
-          "title": "Cloud Object Storage Bucket Name",
-          "description": "The Cloud Object Storage bucket name",
-          "type": "string",
-          "pattern": "^[a-z0-9][a-z0-9-.]*[a-z0-9]$",
-          "minLength": 3,
-          "maxLength": 222,
-          "uihints": {
-            "category": "Cloud Object Storage"
-          }
-        },
         "tags": {
           "title": "Tags",
           "description": "Tags for categorizing Kubeflow pipelines",
@@ -159,7 +174,12 @@
           }
         }
       },
-      "required": ["api_endpoint", "cos_endpoint", "cos_bucket"]
+      "required": [
+        "api_endpoint",
+        "cos_auth_type",
+        "cos_endpoint",
+        "cos_bucket"
+      ]
     }
   },
   "required": ["schema_name", "display_name", "metadata"]

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -140,7 +140,7 @@
         },
         "cos_secret": {
           "title": "Cloud Object Storage Credentials Secret",
-          "description": "Kubernetes secret that's defined in the specified user namespace, containing the Cloud Object Storage username and password.",
+          "description": "Kubernetes secret that's defined in the specified user namespace, containing the Cloud Object Storage username and password. This property is required for authentication type KUBERNETES_SECRET.",
           "type": "string",
           "uihints": {
             "secure": true,
@@ -149,7 +149,7 @@
         },
         "cos_username": {
           "title": "Cloud Object Storage Username",
-          "description": "The Cloud Object Storage username",
+          "description": "The Cloud Object Storage username. This property is required for authentication type USER_CREDENTIALS and KUBERNETES_SECRET.",
           "type": "string",
           "uihints": {
             "category": "Cloud Object Storage"
@@ -157,7 +157,7 @@
         },
         "cos_password": {
           "title": "Cloud Object Storage Password",
-          "description": "The Cloud Object Storage password",
+          "description": "The Cloud Object Storage password. This property is required for authentication type USER_CREDENTIALS and KUBERNETES_SECRET.",
           "type": "string",
           "minLength": 8,
           "uihints": {

--- a/elyra/pipeline/airflow/airflow_metadata.py
+++ b/elyra/pipeline/airflow/airflow_metadata.py
@@ -22,7 +22,7 @@ from elyra.pipeline.runtimes_metadata import RuntimesMetadata
 
 class AirflowMetadata(RuntimesMetadata):
     """
-    Applies changes specific to the kfp schema
+    Applies changes specific to the Airflow schema
     """
 
     def on_load(self, **kwargs: Any) -> None:
@@ -43,3 +43,36 @@ class AirflowMetadata(RuntimesMetadata):
             MetadataManager(schemaspace="runtimes").update(self.name, self, for_migration=True)
 
         return None
+
+    def pre_save(self, **kwargs: Any) -> None:
+        """
+        This method enforces conditional constraints related to
+        COS authentication type properties.
+        TODO: Remove after https://github.com/elyra-ai/elyra/issues/2338 was resolved.
+        """
+        super().pre_save(**kwargs)
+
+        if self.metadata.get('cos_auth_type') is None:
+            # nothing to do
+            return
+
+        if self.metadata['cos_auth_type'] == 'USER_CREDENTIALS':
+            if len(self.metadata.get('cos_username', '').strip()) == 0 or\
+               len(self.metadata.get('cos_password', '').strip()) == 0:
+                raise ValueError('A username and password are required '
+                                 'for the selected Object Storage authentication type.')
+            if len(self.metadata.get('cos_secret', '').strip()) > 0:
+                raise ValueError('Kubernetes secrets are not supported '
+                                 'for the selected Object Storage authentication type.')
+        elif self.metadata['cos_auth_type'] == 'KUBERNETES_SECRET':
+            if len(self.metadata.get('cos_username', '').strip()) == 0 or\
+               len(self.metadata.get('cos_password', '').strip()) == 0 or\
+               len(self.metadata.get('cos_secret', '').strip()) == 0:
+                raise ValueError('Username, password, and Kubernetes secret are required '
+                                 'for the selected Object Storage authentication type.')
+        elif self.metadata['cos_auth_type'] == 'AWS_IAM_ROLES_FOR_SERVICE_ACCOUNTS':
+            if len(self.metadata.get('cos_username', '').strip()) > 0 or\
+               len(self.metadata.get('cos_password', '').strip()) > 0 or\
+               len(self.metadata.get('cos_secret', '').strip()) > 0:
+                raise ValueError('Username, password, and Kubernetes secret are not supported '
+                                 'for the selected Object Storage authentication type.')

--- a/elyra/pipeline/airflow/airflow_metadata.py
+++ b/elyra/pipeline/airflow/airflow_metadata.py
@@ -17,11 +17,10 @@
 from typing import Any
 
 from elyra.metadata.manager import MetadataManager
-from elyra.pipeline.kfp.kfp_authentication import SupportedAuthProviders
 from elyra.pipeline.runtimes_metadata import RuntimesMetadata
 
 
-class KfpMetadata(RuntimesMetadata):
+class AirflowMetadata(RuntimesMetadata):
     """
     Applies changes specific to the kfp schema
     """
@@ -29,23 +28,13 @@ class KfpMetadata(RuntimesMetadata):
     def on_load(self, **kwargs: Any) -> None:
         super().on_load(**kwargs)
 
-        if self.metadata.get('auth_type') is None:
-            # Inject auth_type property for metadata persisted using Elyra < 3.3:
-            # - api_username and api_password present -> use DEX Legacy
-            # - otherwise -> use no authentication type
-            if len(self.metadata.get('api_username', '').strip()) == 0 or\
-               len(self.metadata.get('api_password', '').strip()) == 0:
-                self.metadata['auth_type'] = SupportedAuthProviders.NO_AUTHENTICATION.name
-            else:
-                self.metadata['auth_type'] = SupportedAuthProviders.DEX_LEGACY.name
-
         if self.metadata.get('cos_auth_type') is None:
             # Inject cos_auth_type property for metadata persisted using Elyra < 3.4:
             # - cos_username and cos_password must be present
             # - cos_secret may be present (above statement also applies in this case)
             if self.metadata.get('cos_username') and\
                self.metadata.get('cos_password'):
-                if len(self.metadata.get('cos_secret', '').strip()) == 0:
+                if len(self.metadata.get('cos_secret', '')) == 0:
                     self.metadata['cos_auth_type'] = 'USER_CREDENTIALS'
                 else:
                     self.metadata['cos_auth_type'] = 'KUBERNETES_SECRET'

--- a/elyra/pipeline/kfp/kfp_metadata.py
+++ b/elyra/pipeline/kfp/kfp_metadata.py
@@ -54,3 +54,37 @@ class KfpMetadata(RuntimesMetadata):
             MetadataManager(schemaspace="runtimes").update(self.name, self, for_migration=True)
 
         return None
+
+    def pre_save(self, **kwargs: Any) -> None:
+        """
+        This method enforces conditional constraints related to
+        COS authentication type properties.
+        TODO: Remove after https://github.com/elyra-ai/elyra/issues/2338
+        was resolved.
+        """
+        super().pre_save(**kwargs)
+
+        if self.metadata.get('cos_auth_type') is None:
+            # nothing to do
+            return
+
+        if self.metadata['cos_auth_type'] == 'USER_CREDENTIALS':
+            if len(self.metadata.get('cos_username', '').strip()) == 0 or\
+               len(self.metadata.get('cos_password', '').strip()) == 0:
+                raise ValueError('A username and password are required '
+                                 'for the selected Object Storage authentication type.')
+            if len(self.metadata.get('cos_secret', '').strip()) > 0:
+                raise ValueError('Kubernetes secrets are not supported '
+                                 'for the selected Object Storage authentication type.')
+        elif self.metadata['cos_auth_type'] == 'KUBERNETES_SECRET':
+            if len(self.metadata.get('cos_username', '').strip()) == 0 or\
+               len(self.metadata.get('cos_password', '').strip()) == 0 or\
+               len(self.metadata.get('cos_secret', '').strip()) == 0:
+                raise ValueError('Username, password, and Kubernetes secret are required '
+                                 'for the selected Object Storage authentication type.')
+        elif self.metadata['cos_auth_type'] == 'AWS_IAM_ROLES_FOR_SERVICE_ACCOUNTS':
+            if len(self.metadata.get('cos_username', '').strip()) > 0 or\
+               len(self.metadata.get('cos_password', '').strip()) > 0 or\
+               len(self.metadata.get('cos_secret', '').strip()) > 0:
+                raise ValueError('Username, password, and Kubernetes secret are not supported '
+                                 'for the selected Object Storage authentication type.')

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -419,11 +419,21 @@ class RuntimePipelineProcessor(PipelineProcessor):
             raise RuntimeError("Connection was refused when attempting to upload artifacts to : '{}'. Please "
                                "check your object storage settings. ".format(cos_endpoint)) from ex
         except S3Error as ex:
+            msg_prefix = f'Error connecting to object storage: {ex.code}.'
             if ex.code == "SignatureDoesNotMatch":
-                raise RuntimeError("Connection was refused due to incorrect Object Storage credentials. " +
-                                   "Please validate your runtime configuration details and retry.") from ex
+                # likely cause: incorrect password
+                raise RuntimeError(f"{msg_prefix} Verify the password "
+                                   f"in runtime configuration '{runtime_configuration.display_name}' "
+                                   "and try again.") from ex
+            elif ex.code == 'InvalidAccessKeyId':
+                # likely cause: incorrect user id
+                raise RuntimeError(f"{msg_prefix} Verify the username "
+                                   f"in runtime configuration '{runtime_configuration.display_name}' "
+                                   "and try again.") from ex
             else:
-                raise RuntimeError("Please validate your runtime configuration details and retry.") from ex
+                raise RuntimeError(f"{msg_prefix} Verify "
+                                   f"runtime configuration '{runtime_configuration.display_name}' "
+                                   "and try again.") from ex
         except BaseException as ex:
             self.log.error("Error uploading artifacts to object storage for operation: {}".
                            format(operation.name), exc_info=True)


### PR DESCRIPTION
This PR is a follow up to https://github.com/elyra-ai/elyra/pull/2335, which introduced implicit support for COS authentication types in runtime configurations.

With this change the runtime configuration requires a new authentication type property:

![image](https://user-images.githubusercontent.com/13068832/145456108-87bce568-2ab4-492f-abec-d4ac36d12571.png)

The property takes the following values:
 - `AWS_IAM_ROLES_FOR_SERVICE_ACCOUNTS` (applicable to AWS only)
 - `KUBERNETES_SECRET`
 - `USER_CREDENTIALS`

Behavior:
- For new runtime configurations the default selection is `USER_CREDENTIALS` (the most likely choice users are making today).
- For existing runtime configurations the following heuristic is used to determine which type to set during on-the-fly migration, which is performed when configurations are loaded:
   - if user id and password are set, use `USER_CREDENTIALS` type
   - if user id,  password, and secret are set, use `KUBERNETES_SECRET` type
- Notes:
   -  Migration only covers scenarios for runtime configurations that were created using 3.3.0 or earlier, but not the master branch that includes https://github.com/elyra-ai/elyra/pull/2335 but not this PR
   - Custom code enforces the following conditional schema constraints:
      - `AWS_IAM_ROLES_FOR_SERVICE_ACCOUNTS` -> no values must be set for the following properties: `cos_secret`, `cos_username`, and `cos_password` 
      - `KUBERNETES_SECRET` -> values must be present for the following properties: `cos_secret`, `cos_username`, and `cos_password` 
      - `USER_CREDENTIALS` -> values must be present in the following properties: `cos_username`, `cos_password`, but not `cos_secret`


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?

 - Add new required `cos_auth_type` property to Kubeflow Pipelines schema
 - Re-organize order of COS properties in the Kubeflow Pipelines schema
 - Add on-load migration code to Kubeflow Pipelines metadata class that adds `cos_auth_type` to existing runtime configurations
 - Add new required `cos_auth_type` property to Airflow schema
 - Re-organize order of COS properties in the Kubeflow Pipelines schema
 - Add new Airflow metadata class that contains on-load migration code that adds `cos_auth_type` to existing runtime configurations
 - Improve COS connectivity error handling and messages. (Identify what kind of connection attempt is failing, why it is failing, and add reference to problematic RTC) Example:
   ```
   Error connecting to object storage: SignatureDoesNotMatch. Verify the password in runtime configuration 'aa with secret' and try again.
   ```
 - Update _Runtime Configuration_ topic in the User Guide

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?

Reviewed the output of `make docs`

Tested default COS auth type assignments:
- [x] New KFP RTC
- [x] New Airflow RTC
- [x] Migrated KFP RTC with kubernetes secret
- [x] Migrated KFP RTC without kubernetes secret
- [x] Migrated Airflow RTC with kubernetes secret
- [x] Migrated Airflow RTC without kubernetes secret

Tested connectivity and error handling for KFP:
- [x] USER_CREDENTIALS: constraints fulfilled
- [x] USER_CREDENTIALS: invalid credentials (username or password)
- [x] USER_CREDENTIALS: constraints violated
- [x] KUBERNETES_SECRET: constraints fulfilled
- [x] KUBERNETES_SECRET: invalid credentials (username or password)
- [x] KUBERNETES_SECRET: constraints violated
- [x] AWS_IAM_ROLES_FOR_SERVICE_ACCOUNTS: constraints fulfilled
- [x] AWS_IAM_ROLES_FOR_SERVICE_ACCOUNTS: constraints violated

Tested connectivity and error handling for Airflow:
- [x] USER_CREDENTIALS: constraints fulfilled
- [x] USER_CREDENTIALS: invalid credentials (username or password)
- [x] USER_CREDENTIALS: constraints violated
- [x] KUBERNETES_SECRET: constraints fulfilled
- [x] KUBERNETES_SECRET: invalid credentials (username or password)
- [x] KUBERNETES_SECRET: constraints violated
- [x] AWS_IAM_ROLES_FOR_SERVICE_ACCOUNTS: constraints fulfilled
- [x] AWS_IAM_ROLES_FOR_SERVICE_ACCOUNTS: constraints violated

For testing set environment variables as follows prior to launching JupyterLab:

- `export ELYRA_GITHUB_ORG=ptitzler`
- `export ELYRA_GITHUB_BRANCH=cos-auth`

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
