### PR TITLE
Enforce authentication type constraints in KFP RTCs

### DIFF
--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -87,7 +87,7 @@
         },
         "api_username": {
           "title": "Kubeflow Pipelines API Endpoint Username",
-          "description": "The Kubeflow Pipelines API endpoint username",
+          "description": "The Kubeflow Pipelines API endpoint username. This property is required for all authentication types, except NO_AUTHENTICATION and KUBERNETES_SERVICE_ACCOUNT_TOKEN.",
           "type": "string",
           "uihints": {
             "category": "Kubeflow Pipelines"
@@ -95,7 +95,7 @@
         },
         "api_password": {
           "title": "Kubeflow Pipelines API Endpoint Password",
-          "description": "Password for the specified username",
+          "description": "Password for the specified username. This property is required for all authentication types, except NO_AUTHENTICATION and KUBERNETES_SERVICE_ACCOUNT_TOKEN.",
           "type": "string",
           "uihints": {
             "secure": true,
@@ -112,33 +112,6 @@
             "placeholder": "https://your-cos-service:port"
           }
         },
-        "cos_secret": {
-          "title": "Cloud Object Storage Credentials Secret",
-          "description": "Kubernetes secret that's defined in the specified user namespace, containing the Cloud Object Storage username and password.",
-          "type": "string",
-          "uihints": {
-            "secure": true,
-            "category": "Cloud Object Storage"
-          }
-        },
-        "cos_username": {
-          "title": "Cloud Object Storage Username",
-          "description": "The Cloud Object Storage username",
-          "type": "string",
-          "uihints": {
-            "category": "Cloud Object Storage"
-          }
-        },
-        "cos_password": {
-          "title": "Cloud Object Storage Password",
-          "description": "The Cloud Object Storage password",
-          "type": "string",
-          "minLength": 8,
-          "uihints": {
-            "secure": true,
-            "category": "Cloud Object Storage"
-          }
-        },
         "cos_bucket": {
           "title": "Cloud Object Storage Bucket Name",
           "description": "The Cloud Object Storage bucket name",
@@ -147,6 +120,48 @@
           "minLength": 3,
           "maxLength": 222,
           "uihints": {
+            "category": "Cloud Object Storage"
+          }
+        },
+        "cos_auth_type": {
+          "title": "Cloud Object Storage Authentication Type",
+          "description": "Authentication type Elyra uses to authenticate with Cloud Object Storage",
+          "type": "string",
+          "enum": [
+            "AWS_IAM_ROLES_FOR_SERVICE_ACCOUNTS",
+            "KUBERNETES_SECRET",
+            "USER_CREDENTIALS"
+          ],
+          "default": "USER_CREDENTIALS",
+          "uihints": {
+            "field_type": "dropdown",
+            "category": "Cloud Object Storage"
+          }
+        },
+        "cos_secret": {
+          "title": "Cloud Object Storage Credentials Secret",
+          "description": "Kubernetes secret that's defined in the specified user namespace, containing the Cloud Object Storage username and password. This property is required for authentication type KUBERNETES_SECRET.",
+          "type": "string",
+          "uihints": {
+            "secure": true,
+            "category": "Cloud Object Storage"
+          }
+        },
+        "cos_username": {
+          "title": "Cloud Object Storage Username",
+          "description": "The Cloud Object Storage username. This property is required for authentication type USER_CREDENTIALS and KUBERNETES_SECRET.",
+          "type": "string",
+          "uihints": {
+            "category": "Cloud Object Storage"
+          }
+        },
+        "cos_password": {
+          "title": "Cloud Object Storage Password",
+          "description": "The Cloud Object Storage password. This property is required for authentication type USER_CREDENTIALS and KUBERNETES_SECRET.",
+          "type": "string",
+          "minLength": 8,
+          "uihints": {
+            "secure": true,
             "category": "Cloud Object Storage"
           }
         },
@@ -159,7 +174,12 @@
           }
         }
       },
-      "required": ["api_endpoint", "cos_endpoint", "cos_bucket"]
+      "required": [
+        "api_endpoint",
+        "cos_auth_type",
+        "cos_endpoint",
+        "cos_bucket"
+      ]
     }
   },
   "required": ["schema_name", "display_name", "metadata"]

--- a/elyra/pipeline/kfp/kfp_metadata.py
+++ b/elyra/pipeline/kfp/kfp_metadata.py
@@ -33,15 +33,96 @@ class KfpMetadata(RuntimesMetadata):
             # Inject auth_type property for metadata persisted using Elyra < 3.3:
             # - api_username and api_password present -> use DEX Legacy
             # - otherwise -> use no authentication type
-            if self.metadata.get('api_username') is None or\
-               len(self.metadata.get('api_username').strip()) == 0 or\
-               self.metadata.get('api_password') is None or\
-               len(self.metadata.get('api_password').strip()) == 0:
+            if len(self.metadata.get('api_username', '').strip()) == 0 or\
+               len(self.metadata.get('api_password', '').strip()) == 0:
                 self.metadata['auth_type'] = SupportedAuthProviders.NO_AUTHENTICATION.name
             else:
                 self.metadata['auth_type'] = SupportedAuthProviders.DEX_LEGACY.name
+
+        if self.metadata.get('cos_auth_type') is None:
+            # Inject cos_auth_type property for metadata persisted using Elyra < 3.4:
+            # - cos_username and cos_password must be present
+            # - cos_secret may be present (above statement also applies in this case)
+            if self.metadata.get('cos_username') and\
+               self.metadata.get('cos_password'):
+                if len(self.metadata.get('cos_secret', '').strip()) == 0:
+                    self.metadata['cos_auth_type'] = 'USER_CREDENTIALS'
+                else:
+                    self.metadata['cos_auth_type'] = 'KUBERNETES_SECRET'
 
             # save changes
             MetadataManager(schemaspace="runtimes").update(self.name, self, for_migration=True)
 
         return None
+
+    def pre_save(self, **kwargs: Any) -> None:
+        """
+        This method enforces conditional constraints related to
+        authentication type properties.
+        TODO: Remove after https://github.com/elyra-ai/elyra/issues/2338
+        was resolved.
+        """
+        super().pre_save(**kwargs)
+
+        # validation of Kubeflow authentication constraints
+        if self.metadata.get('auth_type') is not None:
+            try:
+                kfp_auth_provider = SupportedAuthProviders.get_instance_by_name(self.metadata['auth_type'])
+            except Exception:
+                kfp_auth_provider = None
+
+            if kfp_auth_provider == SupportedAuthProviders.NO_AUTHENTICATION:
+                if len(self.metadata.get('api_username', '').strip()) > 0 or\
+                   len(self.metadata.get('api_password', '').strip()) > 0:
+                    raise ValueError('Username and password are not supported '
+                                     'for the selected Kubeflow authentication type.')
+            elif kfp_auth_provider == SupportedAuthProviders.DEX_STATIC_PASSWORDS:
+                if len(self.metadata.get('api_username', '').strip()) == 0 or\
+                   len(self.metadata.get('api_password', '').strip()) == 0:
+                    raise ValueError('A username and password are required '
+                                     'for the selected Kubeflow authentication type.')
+            elif kfp_auth_provider == SupportedAuthProviders.DEX_LDAP:
+                if len(self.metadata.get('api_username', '').strip()) == 0 or\
+                   len(self.metadata.get('api_password', '').strip()) == 0:
+                    raise ValueError('A username and password are required '
+                                     'for the selected Kubeflow authentication type.')
+            elif kfp_auth_provider == SupportedAuthProviders.DEX_LEGACY:
+                is_empty_api_username = len(self.metadata.get('api_username', '').strip()) == 0
+                is_empty_api_password = len(self.metadata.get('api_password', '').strip()) == 0
+                if is_empty_api_username is False and is_empty_api_password:
+                    raise ValueError('A username requires a password '
+                                     'for the selected Kubeflow authentication type.')
+                if is_empty_api_password is False and is_empty_api_username:
+                    raise ValueError('A password requires a username '
+                                     'for the selected Kubeflow authentication type.')
+            elif kfp_auth_provider == SupportedAuthProviders.KUBERNETES_SERVICE_ACCOUNT_TOKEN:
+                if len(self.metadata.get('api_username', '').strip()) > 0 or\
+                   len(self.metadata.get('api_password', '').strip()) > 0:
+                    raise ValueError('Username and password are not supported '
+                                     'for the selected Kubeflow authentication type.')
+
+        # validation of Object Storage authentication constraints
+        if self.metadata.get('cos_auth_type') is None:
+            # nothing to do
+            return
+
+        if self.metadata['cos_auth_type'] == 'USER_CREDENTIALS':
+            if len(self.metadata.get('cos_username', '').strip()) == 0 or\
+               len(self.metadata.get('cos_password', '').strip()) == 0:
+                raise ValueError('A username and password are required '
+                                 'for the selected Object Storage authentication type.')
+            if len(self.metadata.get('cos_secret', '').strip()) > 0:
+                raise ValueError('Kubernetes secrets are not supported '
+                                 'for the selected Object Storage authentication type.')
+        elif self.metadata['cos_auth_type'] == 'KUBERNETES_SECRET':
+            if len(self.metadata.get('cos_username', '').strip()) == 0 or\
+               len(self.metadata.get('cos_password', '').strip()) == 0 or\
+               len(self.metadata.get('cos_secret', '').strip()) == 0:
+                raise ValueError('Username, password, and Kubernetes secret are required '
+                                 'for the selected Object Storage authentication type.')
+        elif self.metadata['cos_auth_type'] == 'AWS_IAM_ROLES_FOR_SERVICE_ACCOUNTS':
+            if len(self.metadata.get('cos_username', '').strip()) > 0 or\
+               len(self.metadata.get('cos_password', '').strip()) > 0 or\
+               len(self.metadata.get('cos_secret', '').strip()) > 0:
+                raise ValueError('Username, password, and Kubernetes secret are not supported '
+                                 'for the selected Object Storage authentication type.')


### PR DESCRIPTION
Inspired by the solution used in https://github.com/elyra-ai/elyra/pull/2354, this PR takes the same approach to enforce Kubeflow authentication properties constraints.

![image](https://user-images.githubusercontent.com/13068832/145649006-031f9fc8-258b-44b8-bf1e-207cd31a8c3a.png)

This PR should be merged after https://github.com/elyra-ai/elyra/pull/2354 to avoid potential merge conflicts.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?

- Added code that verifies that only required KFP authentication properties are defined for the selected authentication type. For example, for static password authentication, a user name and a password must be provided by the user.
- Updated the property definitions in the KFP schema to make it clearer which properties are required.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?

Manually tested every possible property combination for all KFP authentication types.

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
