### PR TITLE
Fix KUBERNETES_SERVICE_ACCOUNT_TOKEN auth

### DIFF
--- a/elyra/pipeline/kfp/kfp_authentication.py
+++ b/elyra/pipeline/kfp/kfp_authentication.py
@@ -29,6 +29,8 @@ from urllib.parse import urlsplit
 
 from kfp.auth import KF_PIPELINES_SA_TOKEN_ENV
 from kfp.auth import KF_PIPELINES_SA_TOKEN_PATH
+from kfp.auth import ServiceAccountTokenVolumeCredentials
+from kfp.auth import TokenCredentialsBase
 import requests
 
 
@@ -226,6 +228,7 @@ class KFPAuthenticator():
             'auth_type': None,        # Authentication type, source: runtime config
             'kf_secured': False,      # Indicates whether KF API is secured
             'cookies': None,          # passed to KFP SDK client as "cookies" param value
+            'credentials': None,      # passed to KFP SDK client as "credentials" param value
             'existing_token': None    # passed to KFP SDK client as "existing_token" param value
         }
 
@@ -277,9 +280,11 @@ class KFPAuthenticator():
                 if auth_info.get('cookies') is not None:
                     auth_info['kf_secured'] = True
             elif auth_type == SupportedAuthProviders.KUBERNETES_SERVICE_ACCOUNT_TOKEN:
-                # see implementation for details; the authenticator returns None
-                K8sServiceAccountTokenAuthenticator().authenticate(kf_url,
-                                                                   runtime_config_name)
+                # see implementation for details; the authenticator returns
+                # an implementation of TokenCredentialsBase
+                auth_info['credentials'] =\
+                    K8sServiceAccountTokenAuthenticator().authenticate(kf_url,
+                                                                       runtime_config_name)
                 auth_info['kf_secured'] = True
             else:
                 # SupportedAuthProviders contains a member that is not yet
@@ -628,7 +633,7 @@ class K8sServiceAccountTokenAuthenticator(AbstractAuthenticator):
 
     def authenticate(self,
                      kf_endpoint: str,
-                     runtime_config_name: str) -> None:
+                     runtime_config_name: str) -> TokenCredentialsBase:
         """
         Verify that service account token authentication can be performed.
         An AuthenticationError is raised if a problem is encountered that
@@ -687,8 +692,9 @@ class K8sServiceAccountTokenAuthenticator(AbstractAuthenticator):
                                       provider=self._type,
                                       request_history=request_history)
 
-        # Nothing needs to be passed to the KFP client
-        return None
+        # return an instance of TokenCredentialsBase to be passed as the "credentials"
+        # argument of a `kfp.Client()` constructor
+        return ServiceAccountTokenVolumeCredentials(path=service_account_token_path)
 
 
 class DEXLegacyAuthenticator(AbstractAuthenticator):

--- a/elyra/pipeline/kfp/kfp_authentication.py
+++ b/elyra/pipeline/kfp/kfp_authentication.py
@@ -30,7 +30,6 @@ from urllib.parse import urlsplit
 from kfp.auth import KF_PIPELINES_SA_TOKEN_ENV
 from kfp.auth import KF_PIPELINES_SA_TOKEN_PATH
 from kfp.auth import ServiceAccountTokenVolumeCredentials
-from kfp.auth import TokenCredentialsBase
 import requests
 
 
@@ -281,7 +280,7 @@ class KFPAuthenticator():
                     auth_info['kf_secured'] = True
             elif auth_type == SupportedAuthProviders.KUBERNETES_SERVICE_ACCOUNT_TOKEN:
                 # see implementation for details; the authenticator returns
-                # an implementation of TokenCredentialsBase
+                # a ServiceAccountTokenVolumeCredentials
                 auth_info['credentials'] =\
                     K8sServiceAccountTokenAuthenticator().authenticate(kf_url,
                                                                        runtime_config_name)
@@ -633,7 +632,7 @@ class K8sServiceAccountTokenAuthenticator(AbstractAuthenticator):
 
     def authenticate(self,
                      kf_endpoint: str,
-                     runtime_config_name: str) -> TokenCredentialsBase:
+                     runtime_config_name: str) -> ServiceAccountTokenVolumeCredentials:
         """
         Verify that service account token authentication can be performed.
         An AuthenticationError is raised if a problem is encountered that
@@ -645,6 +644,7 @@ class K8sServiceAccountTokenAuthenticator(AbstractAuthenticator):
         :type runtime_config_name: str
         :raises AuthenticationError: A potential issue was detected that will
         likely cause a KFP client failure.
+        :return: ServiceAccountTokenVolumeCredentials
         """
 
         request_history = []
@@ -692,7 +692,7 @@ class K8sServiceAccountTokenAuthenticator(AbstractAuthenticator):
                                       provider=self._type,
                                       request_history=request_history)
 
-        # return an instance of TokenCredentialsBase to be passed as the "credentials"
+        # return a ServiceAccountTokenVolumeCredentials to be passed as the "credentials"
         # argument of a `kfp.Client()` constructor
         return ServiceAccountTokenVolumeCredentials(path=service_account_token_path)
 

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -127,6 +127,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                 client = TektonClient(
                     host=api_endpoint,
                     cookies=auth_info.get('cookies', None),
+                    credentials=auth_info.get('credentials', None),
                     existing_token=auth_info.get('existing_token', None),
                     namespace=user_namespace
                 )
@@ -134,6 +135,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                 client = ArgoClient(
                     host=api_endpoint,
                     cookies=auth_info.get('cookies', None),
+                    credentials=auth_info.get('credentials', None),
                     existing_token=auth_info.get('existing_token', None),
                     namespace=user_namespace
                 )

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,7 @@ setup_args = dict(
         'yaspin',
         'astunparse>=1.6.3',
         # KFP runtime dependencies
-        'kfp>=1.6.3,<2.0,!=1.7.2',
+        'kfp>=1.7.0,<2.0,!=1.7.2',
         # Airflow runtime dependencies
         'pygithub',
         'black',


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR fixes the `KUBERNETES_SERVICE_ACCOUNT_TOKEN` auth type, as it currently will never work.

The current problem is caused by a VERY bad assumption being made by Kubeflow itself. Inside the `kfp.Client()` initialization code, if a `host` is specified it will never enable ServiceAccount auth. ([Relevant code in `kfp.Client()`](https://github.com/kubeflow/pipelines/blob/1e032f550ce23cd40bfb6827b995248537b07d08/sdk/python/kfp/_client.py#L269-L271))

Because we require that `api_endpoint` is set and [pass it to the `kfp.Client()` constructor](https://github.com/elyra-ai/elyra/blob/741440086b7179c1fb14daf1f7a6a3a13777ac22/elyra/pipeline/kfp/processor_kfp.py#L135), we always specify a `host`.

Luckily the solution is relatively simple, we can explicitly tell the `kfp.Client()` constructor that we want to use ServiceAccount auth, by passing a `kfp.auth.ServiceAccountTokenVolumeCredentials()` to the `credentials` argument of `kfp.Client()`.

### How was this pull request tested?

- Running Elyra in a Kubeflow cluster with ServiceAcount auth

----
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
