### PR TITLE
Pipeline processing: catch cloud storage connectivity issues early

### DIFF
--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -187,22 +187,11 @@ be fully qualified (i.e., prefixed with their package names).
         # Sort operations based on dependency graph (topological order)
         sorted_operations = PipelineProcessor._sort_operations(pipeline.operations)
 
-        # Determine whether access to cloud storage is required
-        requires_cos = False
+        # Determine whether access to cloud storage is required and check connectivity
         for operation in sorted_operations:
             if isinstance(operation, GenericOperation):
-                requires_cos = True
+                self._verify_cos_connectivity(runtime_configuration)
                 break
-
-        # Verify cloud storage connectivity
-        if requires_cos:
-            self.log.debug('Verifying cloud storage connectivity using runtime configuration '
-                           f"'{runtime_configuration.display_name}'.")
-            try:
-                CosClient(runtime_configuration)
-            except Exception as ex:
-                raise RuntimeError(f'Error connecting to cloud storage: {ex}. Update runtime configuration '
-                                   f'\'{runtime_configuration.display_name}\' and try again.')
 
         # All previous operation outputs should be propagated throughout the pipeline.
         # In order to process this recursively, the current operation's inputs should be combined
@@ -436,6 +425,15 @@ be fully qualified (i.e., prefixed with their package names).
                 fh.write(output_to_file)
 
         return pipeline_export_path
+
+    def _verify_cos_connectivity(self, runtime_configuration) -> None:
+        self.log.debug('Verifying cloud storage connectivity using runtime configuration '
+                       f"'{runtime_configuration.display_name}'.")
+        try:
+            CosClient(runtime_configuration)
+        except Exception as ex:
+            raise RuntimeError(f'Error connecting to cloud storage: {ex}. Update runtime configuration '
+                               f'\'{runtime_configuration.display_name}\' and try again.')
 
     def _get_unique_operation_name(self, operation_name: str, operation_list: list) -> str:
         unique_name_counter = 1

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -426,15 +426,6 @@ be fully qualified (i.e., prefixed with their package names).
 
         return pipeline_export_path
 
-    def _verify_cos_connectivity(self, runtime_configuration) -> None:
-        self.log.debug('Verifying cloud storage connectivity using runtime configuration '
-                       f"'{runtime_configuration.display_name}'.")
-        try:
-            CosClient(runtime_configuration)
-        except Exception as ex:
-            raise RuntimeError(f'Error connecting to cloud storage: {ex}. Update runtime configuration '
-                               f'\'{runtime_configuration.display_name}\' and try again.')
-
     def _get_unique_operation_name(self, operation_name: str, operation_list: list) -> str:
         unique_name_counter = 1
         unique_operation_name = operation_name

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -40,7 +40,6 @@ from elyra.pipeline.processor import PipelineProcessor
 from elyra.pipeline.processor import PipelineProcessorResponse
 from elyra.pipeline.processor import RuntimePipelineProcessor
 from elyra.pipeline.runtime_type import RuntimeProcessorType
-from elyra.util.cos import CosClient
 from elyra.util.git import GithubClient
 from elyra.util.path import get_absolute_path
 

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -53,7 +53,6 @@ from elyra.pipeline.processor import PipelineProcessor
 from elyra.pipeline.processor import PipelineProcessorResponse
 from elyra.pipeline.processor import RuntimePipelineProcessor
 from elyra.pipeline.runtime_type import RuntimeProcessorType
-from elyra.util.cos import CosClient
 from elyra.util.path import get_absolute_path
 
 

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -540,21 +540,10 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
         sorted_operations = PipelineProcessor._sort_operations(pipeline.operations)
 
         # Determine whether access to cloud storage is required
-        requires_cos = False
         for operation in sorted_operations:
             if isinstance(operation, GenericOperation):
-                requires_cos = True
+                self._verify_cos_connectivity(runtime_configuration)
                 break
-
-        # Verify cloud storage connectivity
-        if requires_cos:
-            self.log.debug('Verifying cloud storage connectivity using runtime configuration '
-                           f"'{runtime_configuration.display_name}'.")
-            try:
-                CosClient(runtime_configuration)
-            except Exception as ex:
-                raise RuntimeError(f'Error connecting to cloud storage: {ex}. Update runtime configuration '
-                                   f'\'{runtime_configuration.display_name}\' and try again.')
 
         # All previous operation outputs should be propagated throughout the pipeline.
         # In order to process this recursively, the current operation's inputs should be combined

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -429,6 +429,15 @@ class RuntimePipelineProcessor(PipelineProcessor):
                            format(operation.name), exc_info=True)
             raise ex from ex
 
+    def _verify_cos_connectivity(self, runtime_configuration) -> None:
+        self.log.debug('Verifying cloud storage connectivity using runtime configuration '
+                       f"'{runtime_configuration.display_name}'.")
+        try:
+            CosClient(runtime_configuration)
+        except Exception as ex:
+            raise RuntimeError(f'Error connecting to cloud storage: {ex}. Update runtime configuration '
+                               f'\'{runtime_configuration.display_name}\' and try again.')
+
     def _get_metadata_configuration(self, schemaspace, name=None):
         """
         Retrieve associated metadata configuration based on schemaspace provided and optional instance name

--- a/elyra/tests/pipeline/airflow/test_processor_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_processor_airflow.py
@@ -111,6 +111,7 @@ def parsed_ordered_dict(monkeypatch, processor, parsed_pipeline,
     monkeypatch.setattr(processor, "_get_metadata_configuration", mocked_func)
     monkeypatch.setattr(processor, "_upload_dependencies_to_object_store", lambda x, y, z: True)
     monkeypatch.setattr(processor, "_get_dependency_archive_name", lambda x: True)
+    monkeypatch.setattr(processor, "_verify_cos_connectivity", lambda x: True)
 
     return processor._cc_pipeline(parsed_pipeline, pipeline_name="some-name")
 


### PR DESCRIPTION
Currently cloud storage connectivity issues are discovered during pipeline compilation. The resulting error doesn't prominently indicate what caused the failure. This PR updates the code to validate connectivity before any compilation is performed. Closes #2355 

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?

Verify cloud storage connectivity before "compiling" the pipeline.

Note that the new error message (highlighted) wraps the caught error.
Since the latter may produce rather cryptic output the result isn't that user friendly. Open for wording suggestions that place the Elyra message up front and the caught error message at the end:

![image](https://user-images.githubusercontent.com/13068832/145901367-047bcee0-084b-40c2-9eb6-e72eabcbcfa2.png)


<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?

Reviewed output for the following cloud storage configuration scenarios:

- [x] run KF pipeline: correct credentials
- [x] run KF pipeline: incorrect credentials
- [x] export KF pipeline: incorrect credentials
- [x] run Airflow pipeline: correct credentials
- [x] run Airflow pipeline: incorrect credentials
- [x] export Airflow pipeline: incorrect credentials

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
