### PR TITLE
Fix runtime pipeline property

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -284,6 +284,7 @@ const PipelineWrapper: React.FC<IProps> = ({
           PathExt.extname(pipeline_path)
         );
         pipelineJson.pipelines[0].app_data.properties.name = pipeline_name;
+        pipelineJson.pipelines[0].app_data.properties.runtime = runtimeDisplayName;
       }
       setPipeline(pipelineJson);
       setLoading(false);
@@ -295,7 +296,7 @@ const PipelineWrapper: React.FC<IProps> = ({
     return (): void => {
       currentContext.model.contentChanged.disconnect(changeHandler);
     };
-  }, [runtimeImages]);
+  }, [runtimeImages, runtimeDisplayName]);
 
   const onChange = useCallback(
     (pipelineJson: any): void => {

--- a/tests/snapshots/pipeline-editor-tests/matches-complex-pipeline-snapshot.1.snap
+++ b/tests/snapshots/pipeline-editor-tests/matches-complex-pipeline-snapshot.1.snap
@@ -8,6 +8,7 @@ Object {
       "app_data": Object {
         "properties": Object {
           "name": "complex",
+          "runtime": "Generic"
         },
         "ui_data": Object {
           "comments": Array [],

--- a/tests/snapshots/pipeline-editor-tests/matches-complex-pipeline-snapshot.1.snap
+++ b/tests/snapshots/pipeline-editor-tests/matches-complex-pipeline-snapshot.1.snap
@@ -8,7 +8,7 @@ Object {
       "app_data": Object {
         "properties": Object {
           "name": "complex",
-          "runtime": "Generic"
+          "runtime": "Generic",
         },
         "ui_data": Object {
           "comments": Array [],

--- a/tests/snapshots/pipeline-editor-tests/matches-empty-pipeline-snapshot.1.snap
+++ b/tests/snapshots/pipeline-editor-tests/matches-empty-pipeline-snapshot.1.snap
@@ -8,7 +8,7 @@ Object {
       "app_data": Object {
         "properties": Object {
           "name": "empty",
-          "runtime": "Generic"
+          "runtime": "Generic",
         },
         "ui_data": Object {
           "comments": Array [],

--- a/tests/snapshots/pipeline-editor-tests/matches-empty-pipeline-snapshot.1.snap
+++ b/tests/snapshots/pipeline-editor-tests/matches-empty-pipeline-snapshot.1.snap
@@ -8,6 +8,7 @@ Object {
       "app_data": Object {
         "properties": Object {
           "name": "empty",
+          "runtime": "Generic"
         },
         "ui_data": Object {
           "comments": Array [],

--- a/tests/snapshots/pipeline-editor-tests/matches-simple-pipeline-snapshot.1.snap
+++ b/tests/snapshots/pipeline-editor-tests/matches-simple-pipeline-snapshot.1.snap
@@ -8,7 +8,7 @@ Object {
       "app_data": Object {
         "properties": Object {
           "name": "simple",
-          "runtime": "Generic"
+          "runtime": "Generic",
         },
         "ui_data": Object {
           "comments": Array [],

--- a/tests/snapshots/pipeline-editor-tests/matches-simple-pipeline-snapshot.1.snap
+++ b/tests/snapshots/pipeline-editor-tests/matches-simple-pipeline-snapshot.1.snap
@@ -8,6 +8,7 @@ Object {
       "app_data": Object {
         "properties": Object {
           "name": "simple",
+          "runtime": "Generic"
         },
         "ui_data": Object {
           "comments": Array [],


### PR DESCRIPTION
Fixes #2347. Manually writes the runtime display name into the pipeline properties runtime property. 
![image](https://user-images.githubusercontent.com/6673460/146087898-20b22d7e-0c05-4b88-b35d-b52897a85ec6.png)
![image](https://user-images.githubusercontent.com/6673460/146087922-b45a0efd-0677-4685-94f8-d06f6a6cd844.png)
![image](https://user-images.githubusercontent.com/6673460/146087943-28350acc-6f9c-46af-8e17-3d99074034c6.png)


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
