### PR TITLE
Add support for CLI metadata and OVPs using JSON or file contents

### DIFF
--- a/docs/source/user_guide/command-line-interface.md
+++ b/docs/source/user_guide/command-line-interface.md
@@ -82,47 +82,58 @@ The `elyra-metadata` application derives its command-line options (aside from a 
 
 Application-level properties within a schema reside as top-level proeprties within the schema's `metadata` stanza.  For example, here's the `code-snippet` schema for the `code-snippets` schemaspace:
 
-```JSON
-    "metadata": {
-      "description": "Additional data specific to this Code Snippet",
-      "type": "object",
-      "properties": {
-        "description": {
-          "title": "Description",
-          "description": "Code snippet description",
-          "type": "string"
-        },
-        "tags": {
-          "title": "Tags",
-          "description": "Tags for categorizing snippets",
-          "type": "array",
-          "uihints": {
-            "field_type": "tags"
-          }
-        },
-        "language": {
-          "title": "Language",
-          "description": "Code snippet implementation language",
-          "type": "string",
-          "uihints": {
-            "field_type": "dropdown",
-            "default_choices": ["Python", "Java", "R", "Scala", "Markdown"],
-            "category": "Source"
-          },
-          "minLength": 1
-        },
-        "code": {
-          "title": "Code",
-          "description": "Code snippet code lines",
-          "type": "array",
-          "uihints": {
-            "field_type": "code",
-            "category": "Source"
-          }
+```json
+{
+  "metadata": {
+    "description": "Additional data specific to this Code Snippet",
+    "type": "object",
+    "properties": {
+      "description": {
+        "title": "Description",
+        "description": "Code snippet description",
+        "type": "string"
+      },
+      "tags": {
+        "title": "Tags",
+        "description": "Tags for categorizing snippets",
+        "type": "array",
+        "uihints": {
+          "field_type": "tags"
         }
       },
-      "required": ["language", "code"]
-    }
+      "language": {
+        "title": "Language",
+        "description": "Code snippet implementation language",
+        "type": "string",
+        "uihints": {
+          "field_type": "dropdown",
+          "default_choices": [
+            "Python",
+            "Java",
+            "R",
+            "Scala",
+            "Markdown"
+          ],
+          "category": "Source"
+        },
+        "minLength": 1
+      },
+      "code": {
+        "title": "Code",
+        "description": "Code snippet code lines",
+        "type": "array",
+        "uihints": {
+          "field_type": "code",
+          "category": "Source"
+        }
+      }
+    },
+    "required": [
+      "language",
+      "code"
+    ]
+  }
+}
 ```
 and `elyra-metadata` generates options corresponding to each of the `metadata` properties and including helpful tips like whether the property is required and a hint as to how its value should be entered:
 ```

--- a/docs/source/user_guide/command-line-interface.md
+++ b/docs/source/user_guide/command-line-interface.md
@@ -77,6 +77,79 @@ Refer to the topics below for detailed information on how to use `elyra-metadata
  - [Manage runtime images](runtime-image-conf.html#managing-runtime-images-with-the-command-line-interface)
  - [Manage pipeline components](pipeline-components.html#managing-custom-components-using-the-elyra-cli)
 
+#### Creating and updating metadata with complex properties
+The `elyra-metadata` application derives its command-line options (aside from a handful of system options) directly from the schema associated with the referenced schemaspace. In most cases, the schema properties are straightforward and easily determined.  However, JSON schemas can also contain complex properties and references that are not within the scope of `elyra-metadata`.  This section presents ways to create and update instances built from complex schemas.
+
+Application-level properties within a schema reside as top-level proeprties within the schema's `metadata` stanza.  For example, here's the `code-snippet` schema for the `code-snippets` schemaspace:
+
+```json
+    "metadata": {
+      "description": "Additional data specific to this Code Snippet",
+      "type": "object",
+      "properties": {
+        "description": {
+          "title": "Description",
+          "description": "Code snippet description",
+          "type": "string"
+        },
+        "tags": {
+          "title": "Tags",
+          "description": "Tags for categorizing snippets",
+          "type": "array",
+          "uihints": {
+            "field_type": "tags"
+          }
+        },
+        "language": {
+          "title": "Language",
+          "description": "Code snippet implementation language",
+          "type": "string",
+          "uihints": {
+            "field_type": "dropdown",
+            "default_choices": ["Python", "Java", "R", "Scala", "Markdown"],
+            "category": "Source"
+          },
+          "minLength": 1
+        },
+        "code": {
+          "title": "Code",
+          "description": "Code snippet code lines",
+          "type": "array",
+          "uihints": {
+            "field_type": "code",
+            "category": "Source"
+          }
+        }
+      },
+      "required": ["language", "code"]
+    }
+```
+and `elyra-metadata` generates options corresponding to each of the `metadata` properties and including helpful tips like whether the property is required and a hint as to how its value should be entered:
+```
+--description=<string> (Format: sequence of characters) 
+	Code snippet description
+--tags=<array> (Format: "['item1', 'item2']" or "item1,item2") 
+	Tags for categorizing snippets
+--language=<string> (Required. Format: sequence of characters) 
+	Code snippet implementation language
+--code=<array> (Required. Format: "['item1', 'item2']" or "item1,item2") 
+	Code snippet code lines
+```
+
+When complex properties are present, the complexity of interpreting their semantics into CLI options is not sustainable.  To address this, two options can be used that bypass the per-property processing and allow you to create or update the instance directly.
+
+The `--file` option takes a filepath to a JSON-formatted file.  The file can contain the entire JSON including the higher-level system properties that reside outside the `metadata` stanza.  Or, it may contain only the JSON that comprises the `metadata` stanza.
+
+The `--json` option works similar to `--file` but allows the specification of the bulk JSON to be referenced as a string.  Its behavior is the same as `--file` relative to what is expected in the data.  This option may be used in situations where file creation is not available or the metadata is small.
+
+The other, top-level properties can be specified directly on the command line and will act as overrides to whatever properties and values are referenced within the bulk JSON data.
+
+It should also be noted that individual object-valued properties can optionally take a filepath as their value.  If the value exists as a file, that file will be read and used to populate the object-valued property's value.
+
+Should a failure be encountered relative to a complex schema, the properties identified as complex will be identified in the tool's usage statement.  They will refer to a note at the bottom of the usage statement indicating that these approaches should be used.
+
+Finally, when updating instances using the `--replace` option.  You are not required to include unchanged values on the command line.  Instead, the existing object is read and any properties provided on the command line, or included in the bulk JSON data, are applied to the existing properties.
+
 ### Working with pipelines
 
 In Elyra, [a pipeline](pipelines.md) is a representation of a

--- a/docs/source/user_guide/command-line-interface.md
+++ b/docs/source/user_guide/command-line-interface.md
@@ -82,7 +82,7 @@ The `elyra-metadata` application derives its command-line options (aside from a 
 
 Application-level properties within a schema reside as top-level proeprties within the schema's `metadata` stanza.  For example, here's the `code-snippet` schema for the `code-snippets` schemaspace:
 
-```json
+```JSON
     "metadata": {
       "description": "Additional data specific to this Code Snippet",
       "type": "object",

--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -90,7 +90,7 @@ To create a runtime configuration for a Kubeflow Pipelines deployment:
 
 ```bash
 elyra-metadata install runtimes \
-       --schema_name=kfp
+       --schema_name=kfp \
        --display_name="My Kubeflow Pipelines Runtime" \
        --api_endpoint=https://kubernetes-service.ibm.com/pipeline \
        --auth_type="DEX_STATIC_PASSWORDS" \

--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -90,6 +90,7 @@ To create a runtime configuration for a Kubeflow Pipelines deployment:
 
 ```bash
 elyra-metadata install runtimes \
+       --schema_name=kfp
        --display_name="My Kubeflow Pipelines Runtime" \
        --api_endpoint=https://kubernetes-service.ibm.com/pipeline \
        --auth_type="DEX_STATIC_PASSWORDS" \
@@ -101,36 +102,25 @@ elyra-metadata install runtimes \
        --cos_username=minio \
        --cos_password=minio123 \
        --cos_bucket=test-bucket \
-       --tags="['kfp', 'v1.0']" \
-       --schema_name=kfp
+       --tags="['kfp', 'v1.0']"
 ```
 
 Refer to the [Kubeflow Pipelines Configuration settings](#kubeflow-pipelines-configuration-settings) section for an explanation of the parameters.
 
 #### Modifying a runtime configuration
 
-To edit a runtime configuration:
+To edit a runtime configuration, use the `--replace` option along with `--name` and `--schema_name` (to locate the instance), followed by the modified property values.  In this case, we're updating the `api_password` and `tags` properties:
 
 ```bash
 elyra-metadata install runtimes \
        --replace \
        --name="my_kubeflow_pipelines_runtime" \
-       --display_name="My Kubeflow Pipelines Runtime" \
-       --api_endpoint=https://kubernetes-service.ibm.com/pipeline \
-       --auth_type="DEX_STATIC_PASSWORDS" \
-       --api_username=username@email.com \
+       --schema_name=kfp \
        --api_password=mynewpassword \
-       --engine=Argo \
-       --cos_endpoint=http://minio-service.kubeflow:9000 \
-       --cos_auth_type="USER_CREDENTIALS" \
-       --cos_username=minio \
-       --cos_password=minio123 \
-       --cos_bucket=test-bucket \
-       --tags="['kfp', 'v1.1']" \
-       --schema_name=kfp
+       --tags="['kfp', 'v1.1']"
 ```
 
-Refer to the [Kubeflow Pipelines Configuration settings](#kubeflow-pipelines-configuration-settings) section for an explanation of the parameters. Note that you must specify the `--name` parameter. 
+Refer to the [Kubeflow Pipelines Configuration settings](#kubeflow-pipelines-configuration-settings) section for an explanation of the parameters. 
 
 #### Deleting a runtime configuration
 

--- a/elyra/metadata/manager.py
+++ b/elyra/metadata/manager.py
@@ -158,7 +158,7 @@ class MetadataManager(LoggingConfigurable):
             raise ValidationError(msg) from ve
 
     @staticmethod
-    def _get_normalized_name(name: str) -> str:
+    def get_normalized_name(name: str) -> str:
         # lowercase and replaces spaces with underscore
         name = re.sub('\\s+', '_', name.lower())
         # remove all invalid characters
@@ -194,7 +194,7 @@ class MetadataManager(LoggingConfigurable):
 
         if not name and not for_update:  # name is derived from display_name only on creates
             if metadata.display_name:
-                name = self._get_normalized_name(metadata.display_name)
+                name = MetadataManager.get_normalized_name(metadata.display_name)
                 metadata.name = name
 
         if not name:  # At this point, name must be set

--- a/elyra/metadata/metadata_app.py
+++ b/elyra/metadata/metadata_app.py
@@ -318,9 +318,13 @@ class SchemaspaceInstall(SchemaspaceBase):
             else:  # convert first-level metadata properties to options...
                 metadata_properties = properties['metadata']['properties']
                 for md_name, md_value in metadata_properties.items():
-                    options[md_name] = MetadataSchemaProperty(md_name, md_value)
-                    if options[md_name].unsupported_meta_props:
+                    msp = MetadataSchemaProperty(md_name, md_value)
+                    # skip if this property was not specified on the command line and its a replace/bulk op
+                    if msp.cli_option not in self.argv_mappings and relax_required:
+                        continue
+                    if msp.unsupported_meta_props:  # if this option includes complex meta-props, note that.
                         self.complex_properties.append(md_name)
+                    options[md_name] = msp
 
         # Now set required-ness on MetadataProperties, but only when creation is using fine-grained property options
         if not relax_required:

--- a/elyra/metadata/metadata_app.py
+++ b/elyra/metadata/metadata_app.py
@@ -239,7 +239,7 @@ class SchemaspaceInstall(SchemaspaceBase):
             elif isinstance(option, JSONBasedOption):
                 metadata.update(option.metadata)
 
-        if display_name is None:
+        if display_name is None and self.replace_flag.value is False:  # Only require
             self.log_and_exit("Could not determine display_name from schema '{}'".format(schema_name))
 
         ex_msg = None
@@ -248,7 +248,8 @@ class SchemaspaceInstall(SchemaspaceBase):
             if self.replace_flag.value:  # if replacing, fetch the instance so it can be updated
                 updated_instance = self.metadata_manager.get(name)
                 updated_instance.schema_name = schema_name
-                updated_instance.display_name = display_name
+                if display_name:
+                    updated_instance.display_name = display_name
                 updated_instance.metadata.update(metadata)
                 new_instance = self.metadata_manager.update(name, updated_instance)
             else:  # create a new instance
@@ -327,10 +328,11 @@ class SchemaspaceInstall(SchemaspaceBase):
             for required in required_props:
                 options.get(required).required = True
 
-        # ...  and top-level (schema) Properties
-        required_props = set(schema.get('required')) - {'schema_name', 'metadata'}  # skip schema_name & metadata
-        for required in required_props:
-            options.get(required).required = True
+        # ...  and top-level (schema) Properties if we're not replacing (updating)
+        if self.replace_flag.value is False:
+            required_props = set(schema.get('required')) - {'schema_name', 'metadata'}  # skip schema_name & metadata
+            for required in required_props:
+                options.get(required).required = True
         return list(options.values())
 
     def print_help(self):

--- a/elyra/metadata/metadata_app.py
+++ b/elyra/metadata/metadata_app.py
@@ -170,7 +170,7 @@ class SchemaspaceInstall(SchemaspaceBase):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
+        self.complex_properties: List[str] = []
         self.metadata_manager = MetadataManager(schemaspace=self.schemaspace)
         # First, process the schema_name option so we can then load the appropriate schema
         # file to build the schema-based options.  If help is requested, give it to them.
@@ -210,7 +210,6 @@ class SchemaspaceInstall(SchemaspaceBase):
         schema = self.schemas[self.schema_name_option.value]
 
         # Convert schema properties to options, gathering complex property names
-        self.complex_properties: List[str] = []
         schema_options = self._schema_to_options(schema, relax_required)
         self.options.extend(schema_options)
 
@@ -248,6 +247,8 @@ class SchemaspaceInstall(SchemaspaceBase):
         try:
             if self.replace_flag.value:  # if replacing, fetch the instance so it can be updated
                 updated_instance = self.metadata_manager.get(name)
+                updated_instance.schema_name = schema_name
+                updated_instance.display_name = display_name
                 updated_instance.metadata.update(metadata)
                 new_instance = self.metadata_manager.update(name, updated_instance)
             else:  # create a new instance
@@ -344,7 +345,7 @@ class SchemaspaceInstall(SchemaspaceBase):
                   "the schema or indirectly using `--file` or `--json` options.")
             print("If the property is of type \"object\" it can be set using a file containing only that property's "
                   "JSON.")
-            print(f"Here is the current set of unsupported keywords: {SchemaProperty.unsupported_keywords}")
+            print(f"The following are considered unsupported keywords: {SchemaProperty.unsupported_keywords}")
 
 
 class SchemaspaceMigrate(SchemaspaceBase):

--- a/elyra/metadata/metadata_app_utils.py
+++ b/elyra/metadata/metadata_app_utils.py
@@ -430,16 +430,18 @@ class AppBase(object):
         self.exit(1)
 
     @staticmethod
-    def schema_to_options(schema: Dict, bulk_metadata: bool = False):
+    def schema_to_options(schema: Dict, relax_required: bool = False):
         """Takes a JSON schema and builds a list of SchemaProperty instances corresponding to each
            property in the schema.  There are two sections of properties, one that includes
            schema_name and display_name and another within the metadata container - which
            will be separated by class type - SchemaProperty vs. MetadataSchemaProperty.
 
-           if bulk_metadata is true, a --json or --file option is in use and the primary metadata
-           comes from those options.  In such cases, skip setting required values since most will
-           come from the JSON-based option.  However, some metadata properties can also be used to
-           override the bulk entries.
+           If relax_required is true, a --json or --file option is in use and the primary metadata
+           comes from those options or the --replace option is in use, in which case the primary
+           metadata comes from the existing instance (being replaced).  In such cases, skip setting
+           required values since most will come from the JSON-based option or already be present
+           (in the case of replace).  This allows CLI-specified metadata properties to override the
+           primary metadata (either in the JSON options or from the existing instance).
         """
         options = {}
         properties = schema['properties']
@@ -454,7 +456,7 @@ class AppBase(object):
                     options[md_name] = MetadataSchemaProperty(md_name, md_value)
 
         # Now set required-ness on MetadataProperties, but only when creation is using fine-grained property options
-        if not bulk_metadata:
+        if not relax_required:
             required_props = properties['metadata'].get('required')
             for required in required_props:
                 options.get(required).required = True

--- a/elyra/metadata/metadata_app_utils.py
+++ b/elyra/metadata/metadata_app_utils.py
@@ -360,8 +360,8 @@ class JSONOption(JSONBasedOption):
         return self._name_arg
 
     def get_format_hint(self) -> str:
-        return "A JSON-formatted string.  Properties and string values must be double-quoted and " \
-               "escaped (e.g., --json=\"{\\\"prop1\\\": \\\"str1\\\", \\\"prop2\\\": 42}\")"
+        return "A JSON-formatted string consisting of at least the 'metadata' stanza " \
+               "(e.g., --json=\"{'metadata': { 'value1', 'int2': 2 }}\""
 
 
 class FileOption(JSONBasedOption):
@@ -380,7 +380,7 @@ class FileOption(JSONBasedOption):
         return self._name_arg
 
     def get_format_hint(self) -> str:
-        return "An existing file containing valid JSON"
+        return "An existing file containing valid JSON consisting of at least the 'metadata' stanza"
 
     def set_value(self, value: str):
         """Take the given value (file), open the file and load it into a dictionary to ensure it parses as JSON."""

--- a/elyra/metadata/schemas/metadata-test.json
+++ b/elyra/metadata/schemas/metadata-test.json
@@ -117,10 +117,52 @@
           "title": "Null Test",
           "description": "Property used to test null types",
           "type": "null"
-        }
+        },
+        "oneOf_test": {
+          "type": "object",
+          "description": "Property used to test behavior when a oneOf construct exists",
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "user": { "type": "string" },
+                "password": { "type": "string" },
+                "auth_type": { "enum": ["auth_1"] }
+              },
+              "required": ["auth_type", "user", "password"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "token": { "type": "string" },
+                "auth_type": { "enum": ["auth_2"] }
+              },
+              "required": ["auth_type", "token"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "user": { "type": "string" },
+                "auth_type": { "enum": ["auth_3"] }
+              },
+              "required": ["auth_type", "user"],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "defs_test": { "$ref":  "#/$defs/defs_entry"}
       },
       "required": ["required_test"]
     }
   },
-  "required": ["schema_name", "display_name", "metadata"]
+  "required": ["schema_name", "display_name", "metadata"],
+  "$defs": {
+    "defs_entry": {
+      "title": "Defs Test",
+      "description": "Property used to test $defs elements",
+      "type": "integer"
+    }
+  }
 }

--- a/elyra/metadata/schemas/metadata-test.json
+++ b/elyra/metadata/schemas/metadata-test.json
@@ -152,7 +152,7 @@
             }
           ]
         },
-        "defs_test": { "$ref":  "#/$defs/defs_entry"}
+        "defs_test": { "$ref": "#/$defs/defs_entry" }
       },
       "required": ["required_test"]
     }

--- a/elyra/metadata/schemas/metadata-test.json
+++ b/elyra/metadata/schemas/metadata-test.json
@@ -125,30 +125,65 @@
             {
               "type": "object",
               "properties": {
-                "user": { "type": "string" },
-                "password": { "type": "string" },
-                "auth_type": { "enum": ["auth_1"] }
+                "obj1_prop1": { "type": "string" },
+                "obj1_prop2": { "type": "string" },
+                "obj_switch": { "enum": ["obj1"] }
               },
-              "required": ["auth_type", "user", "password"],
+              "required": ["obj_switch", "obj1_prop1", "obj1_prop2"],
               "additionalProperties": false
             },
             {
               "type": "object",
               "properties": {
-                "token": { "type": "string" },
-                "auth_type": { "enum": ["auth_2"] }
+                "obj2_prop1": { "type": "integer" },
+                "obj2_prop2": { "type": "integer" },
+                "obj_switch": { "enum": ["obj2"] }
               },
-              "required": ["auth_type", "token"],
+              "required": ["obj_switch", "obj2_prop1", "obj2_prop2"],
               "additionalProperties": false
             },
             {
               "type": "object",
               "properties": {
-                "user": { "type": "string" },
-                "auth_type": { "enum": ["auth_3"] }
+                "obj3_prop1": { "type": "number" },
+                "obj3_prop2": { "type": "boolean" },
+                "obj_switch": { "enum": ["obj3"] }
               },
-              "required": ["auth_type", "user"],
+              "required": ["obj_switch", "obj3_prop1"],
               "additionalProperties": false
+            }
+          ]
+        },
+        "allOf_test": {
+          "type": "object",
+          "description": "Property used to test behavior when an allOf construct exists",
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "obj1_prop1": { "type": "string" },
+                "obj1_prop2": { "type": "string" },
+                "obj1_switch": { "enum": ["obj1"] }
+              },
+              "required": ["obj1_switch", "obj1_prop1", "obj1_prop2"]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "obj2_prop1": { "type": "integer" },
+                "obj2_prop2": { "type": "integer" },
+                "obj2_switch": { "enum": ["obj2"] }
+              },
+              "required": ["obj2_switch", "obj2_prop1", "obj2_prop2"]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "obj3_prop1": { "type": "number" },
+                "obj3_prop2": { "type": "boolean" },
+                "obj3_switch": { "enum": ["obj3"] }
+              },
+              "required": ["obj3_switch", "obj3_prop1"]
             }
           ]
         },

--- a/elyra/tests/metadata/test_metadata_app.py
+++ b/elyra/tests/metadata/test_metadata_app.py
@@ -574,10 +574,9 @@ def test_number_default(script_runner, mock_data_dir):
         assert instance_json["display_name"] == name
         assert instance_json["metadata"]["number_default_test"] == 42
 
+    # Note that we only include the properties that are changed, along with "identifiers" like name ans schema_name.
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_SCHEMASPACE, '--schema_name=metadata-test',
-                            '--name=' + name, '--display_name=' + name,
-                            '--required_test=required_value', '--replace',
-                            '--number_default_test=7.2')
+                            '--name=' + name, '--replace', '--number_default_test=7.2')
 
     assert ret.success
     assert "Metadata instance '" + name + "' for schema 'metadata-test' has been written" in ret.stdout

--- a/elyra/tests/metadata/test_metadata_app.py
+++ b/elyra/tests/metadata/test_metadata_app.py
@@ -187,7 +187,7 @@ def test_install_and_replace(script_runner, mock_data_dir):
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_SCHEMASPACE, '--schema_name=metadata-test',
                             '--display_name=display_name', '--required_test=required_value', '--replace')
     assert ret.success is False
-    assert "Name of metadata was not provided" in ret.stdout
+    assert "The 'name' parameter requires a value" in ret.stdout
 
     # Re-attempt with replace flag - success expected
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_SCHEMASPACE, '--schema_name=metadata-test',

--- a/elyra/tests/metadata/test_metadata_app.py
+++ b/elyra/tests/metadata/test_metadata_app.py
@@ -182,10 +182,16 @@ def test_install_and_replace(script_runner, mock_data_dir):
 
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_SCHEMASPACE, '--schema_name=metadata-test',
                             '--name=test-metadata_42_valid-name', '--display_name=display_name',
-                            '--required_test=required_value')
+                            '--required_test=required_value', '--number_default_test=24')
     assert ret.success
     assert "Metadata instance 'test-metadata_42_valid-name' for schema 'metadata-test' has been written" in ret.stdout
     assert expected_file in ret.stdout
+    assert os.path.isdir(os.path.join(mock_data_dir, 'metadata', METADATA_TEST_SCHEMASPACE))
+    assert os.path.isfile(expected_file)
+
+    with open(expected_file, "r") as fd:
+        instance_json = json.load(fd)
+        assert instance_json["metadata"]["number_default_test"] == 24  # ensure CLI value is used over default
 
     # Re-attempt w/o replace flag - failure expected
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_SCHEMASPACE, '--schema_name=metadata-test',
@@ -216,7 +222,7 @@ def test_install_and_replace(script_runner, mock_data_dir):
         assert instance_json["schema_name"] == 'metadata-test'
         assert instance_json["display_name"] == 'display_name'
         assert instance_json["metadata"]["required_test"] == 'required_value'
-        assert instance_json["metadata"]["number_default_test"] == 42  # defaults will always persist
+        assert instance_json["metadata"]["number_default_test"] == 24  # ensure original value is used over default
 
 
 @pytest.mark.parametrize("complex_keyword", ["defs", "oneOf", "allOf"])

--- a/elyra/tests/metadata/test_metadata_app.py
+++ b/elyra/tests/metadata/test_metadata_app.py
@@ -19,6 +19,7 @@ import json
 import os
 import shutil
 from tempfile import mkdtemp
+from typing import Optional
 
 import pytest
 
@@ -26,11 +27,13 @@ from elyra.metadata.manager import MetadataManager
 from elyra.metadata.metadata import Metadata
 from elyra.metadata.schema import METADATA_TEST_SCHEMASPACE
 from elyra.metadata.schema import METADATA_TEST_SCHEMASPACE_ID
+from elyra.tests.metadata.test_utils import all_of_json
 from elyra.tests.metadata.test_utils import another_metadata_json
 from elyra.tests.metadata.test_utils import create_json_file
 from elyra.tests.metadata.test_utils import invalid_metadata_json
 from elyra.tests.metadata.test_utils import invalid_no_display_name_json
 from elyra.tests.metadata.test_utils import invalid_schema_name_json
+from elyra.tests.metadata.test_utils import one_of_json
 from elyra.tests.metadata.test_utils import PropertyTester
 from elyra.tests.metadata.test_utils import valid_metadata_json
 
@@ -111,6 +114,15 @@ def test_install_no_name(script_runner, mock_data_dir):
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_SCHEMASPACE, '--schema_name=metadata-test')
     assert ret.success is False
     assert ret.stdout.startswith("'--display_name' is a required parameter.")
+
+
+def test_install_complex_usage(script_runner, mock_data_dir):
+    ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_SCHEMASPACE, '--schema_name=metadata-test')
+    assert ret.success is False
+    assert 'Note: The following properties in this schema contain JSON keywords that are not supported' in ret.stdout
+    assert '*** References unsupported keywords: {\'oneOf\'}' in ret.stdout
+    assert '*** References unsupported keywords: {\'allOf\'}' in ret.stdout
+    assert '*** References unsupported keywords: {\'$ref\'}' in ret.stdout
 
 
 def test_install_only_display_name(script_runner, mock_data_dir):
@@ -205,6 +217,112 @@ def test_install_and_replace(script_runner, mock_data_dir):
         assert instance_json["display_name"] == 'display_name'
         assert instance_json["metadata"]["required_test"] == 'required_value'
         assert instance_json["metadata"]["number_default_test"] == 42  # defaults will always persist
+
+
+@pytest.mark.parametrize("complex_keyword", ["defs", "oneOf", "allOf"])
+def test_install_and_replace_complex(script_runner, mock_data_dir, complex_keyword):
+
+    test_file: Optional[str] = None
+    name: str = f"test-complex-{complex_keyword}".lower()
+
+    if complex_keyword == "defs":
+        option = "--json"
+        value = "{ \"defs_test\": 42 }"
+
+    elif complex_keyword == "oneOf":
+        option = "--file"
+        # Build the file...
+        test_file = os.path.join(mock_data_dir, f'{complex_keyword}.json')
+        with open(test_file, mode='w') as one_of_fd:
+            json.dump(one_of_json, one_of_fd)
+        value = test_file
+    else:  # allOf
+        option = "--allOf_test"  # Use "ovp-from-file" approach
+        # Build the file...
+        test_file = os.path.join(mock_data_dir, f'{complex_keyword}.json')
+        with open(test_file, mode='w') as all_of_fd:
+            json.dump(all_of_json, all_of_fd)
+        value = test_file
+
+    expected_file = os.path.join(mock_data_dir, 'metadata', METADATA_TEST_SCHEMASPACE, f'{name}.json')
+    # Cleanup from any potential previous failures (should be rare)
+    if os.path.exists(expected_file):
+        os.remove(expected_file)
+
+    ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_SCHEMASPACE, '--schema_name=metadata-test',
+                            f'--name={name}', f'--display_name=Test Complex {complex_keyword}',
+                            '--required_test=required_value', f'{option}={value}')
+    assert ret.success
+    assert f"Metadata instance '{name}' for schema 'metadata-test' has been written" in ret.stdout
+    assert expected_file in ret.stdout
+    assert os.path.exists(expected_file)
+
+    with open(expected_file) as fd:
+        json_results = json.load(fd)
+
+    # Verify common stuff
+    assert json_results['display_name'] == f'Test Complex {complex_keyword}'
+    assert json_results['metadata']['required_test'] == 'required_value'
+
+    # Verify result and prepare for replace...
+    if complex_keyword == "defs":
+        assert json_results['metadata']['defs_test'] == 42
+        value = "{ \"defs_test\": 24 }"
+    elif complex_keyword == "oneOf":
+        assert json_results['metadata']['oneOf_test']['obj_switch'] == "obj2"
+        assert json_results['metadata']['oneOf_test']['obj2_prop1'] == 42
+        one_of_json['metadata']['oneOf_test']['obj2_prop1'] = 24
+        with open(test_file, mode='w+') as one_of_fd:
+            json.dump(one_of_json, one_of_fd)
+    elif complex_keyword == "allOf":
+        assert len(json_results['metadata']['allOf_test']) == 9
+        assert json_results['metadata']['allOf_test']['obj1_switch'] == "obj1"
+        assert json_results['metadata']['allOf_test']['obj1_prop1'] == "allOf-test-val1"
+        assert json_results['metadata']['allOf_test']['obj1_prop2'] == "allOf-test-val2"
+        all_of_json['obj1_prop1'] = "allOf-test-val1-replace"
+        assert json_results['metadata']['allOf_test']['obj2_switch'] == "obj2"
+        assert json_results['metadata']['allOf_test']['obj2_prop1'] == 42
+        assert json_results['metadata']['allOf_test']['obj2_prop2'] == 24
+        all_of_json['obj2_prop1'] = 24
+        assert json_results['metadata']['allOf_test']['obj3_switch'] == "obj3"
+        assert json_results['metadata']['allOf_test']['obj3_prop1'] == 42.7
+        assert json_results['metadata']['allOf_test']['obj3_prop2'] is True
+        all_of_json['obj3_prop1'] = 7.24
+
+        with open(test_file, mode='w+') as all_of_fd:
+            json.dump(all_of_json, all_of_fd)
+
+    # Replace the previously-created instance
+    ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_SCHEMASPACE, '--schema_name=metadata-test',
+                            f'--name={name}', f'--display_name=Test Complex {complex_keyword}2',
+                            '--required_test=required_value', f'{option}={value}', '--replace')
+    assert ret.success
+    assert f"Metadata instance '{name}' for schema 'metadata-test' has been written" in ret.stdout
+    assert expected_file in ret.stdout
+    assert os.path.exists(expected_file)
+
+    with open(expected_file) as fd:
+        json_results = json.load(fd)
+
+    # Verify common stuff
+    assert json_results['display_name'] == f'Test Complex {complex_keyword}2'
+    assert json_results['metadata']['required_test'] == 'required_value'
+
+    # Verify result following replace...
+    if complex_keyword == "defs":
+        assert json_results['metadata']['defs_test'] == 24
+    elif complex_keyword == "oneOf":
+        assert json_results['metadata']['oneOf_test']['obj_switch'] == "obj2"
+        assert json_results['metadata']['oneOf_test']['obj2_prop1'] == 24
+        assert json_results['metadata']['oneOf_test']['obj2_prop2'] == 24
+    elif complex_keyword == "allOf":
+        assert len(json_results['metadata']['allOf_test']) == 9
+        assert json_results['metadata']['allOf_test']['obj1_prop1'] == "allOf-test-val1-replace"
+        assert json_results['metadata']['allOf_test']['obj1_prop2'] == "allOf-test-val2"
+        assert json_results['metadata']['allOf_test']['obj2_prop1'] == 24
+        assert json_results['metadata']['allOf_test']['obj2_prop2'] == 24
+        assert json_results['metadata']['allOf_test']['obj3_prop1'] == 7.24
+        assert json_results['metadata']['allOf_test']['obj3_prop2'] is True
 
 
 def test_list_help(script_runner):

--- a/elyra/tests/metadata/test_utils.py
+++ b/elyra/tests/metadata/test_utils.py
@@ -161,6 +161,35 @@ byo_metadata_json = {
     }
 }
 
+# Used in test_install_and_replace_complex to test --file option
+one_of_json = {
+    "schema_name": "metadata-test",
+    "display_name": "oneOf Testing",
+    "metadata": {
+        "required_test": "required_value",
+        "oneOf_test": {
+            "obj2_prop1": 42,
+            "obj2_prop2": 24,
+            "obj_switch": "obj2"
+        }
+    }
+}
+
+# Used in test_install_and_replace_complex to test --allOf_test option (i.e., ovp option)
+all_of_json = {
+    "obj1_prop1": "allOf-test-val1",
+    "obj1_prop2": "allOf-test-val2",
+    "obj1_switch": "obj1",
+
+    "obj2_prop1": 42,
+    "obj2_prop2": 24,
+    "obj2_switch": "obj2",
+
+    "obj3_prop1": 42.7,
+    "obj3_prop2": True,
+    "obj3_switch": "obj3"
+}
+
 
 def create_json_file(location, file_name, content):
     create_file(location, file_name, json.dumps(content))

--- a/etc/docker/kubeflow/Dockerfile
+++ b/etc/docker/kubeflow/Dockerfile
@@ -25,10 +25,10 @@ ARG TAG="dev"
 # - with KFP Tekton support ('kfp-tekton')
 # - with component examples ('kfp-examples')
 RUN python -m pip install --quiet --no-cache-dir --use-deprecated=legacy-resolver \
-    elyra[kfp-tekton,kfp-examples]==3.4.0
- && jupyter lab build \
- && rm -rf $HOME/.cache/yarn \
- && rm -rf /opt/conda/share/jupyter/lab/staging/node_modules
+    elyra[kfp-tekton,kfp-examples]=="$TAG" \
+    && jupyter lab build \
+    && rm -rf $HOME/.cache/yarn \
+    && rm -rf /opt/conda/share/jupyter/lab/staging/node_modules
 
 # Install component examples catalog
 #  - this wail fail if the 'kfp-examples' pip extra is not installed


### PR DESCRIPTION
Per [this comment](https://github.com/elyra-ai/elyra/issues/2376#issuecomment-1006798310) we have a sustainability issue with attempting to interpret complex schemas (nested object-valued properties, schema composition, references, etc.). This pull request attempts to alleviate those concerns while also better-positioning us with the ability to replicate metadata configurations by enabling the following...

- Mutually exclusive options `--file` and `--json` have been added where:
    -  `--file`: will have a value of a file name containing the metadata for the instance being created or updated.  The contents must be valid JSON and can contain the complete metadata (with a `metadata` stanza and top-order properties like `schema_name` and `display_name`) or, if `metadata` is not present, treated as _the_ `metadata` stanza (thereby allowing external applications to _inject_ their JSON into the metadata service without knowledge of the system-owned properties as they can also be specified on the command-line).
    - `--json`: will have a value of JSON string, containing the metadata for the instance being created or updated.  As with `--file` the contents of the string could be the complete metadata or only the `metadata` stanza itself.
- Overrides of values _within_ the contents of the `--file` or `--json` references via the command-line are also supported.  As a result, one can specify a different `--display_name` value than is in the referenced content, or a different `--name` value than what is inferred by the filename, enabling replication.  
- `--replace` functionality has been updated to apply individual property updates and no longer requires the complete instance definition.  (I could see this having utility, both in terms of being able to update complex schema types, but also in terms of security since, in theory, the contents can be protected by filesystem permissions, etc.)
- General object-valued properties are also supported, such that a given _property_ could be overridden via a file or JSON reference.  (Note that this is also true for _any_ top-level property (metadata or above)).  For example, if the schema defines an object-valued property (e.g., `authentication`) and a user wishes to replace one instance's authentication with a new value, the following command could be issued:
```
elyra-metadata install runtimes --schema_name=kfp --name=my_kubeflow_config --replace --authentication=/path/to/my/authentication_values.json
```
and replace instance `my_kubeflow_config`'s current authentication OVP with the contents of `/path/to/my/authentication_values.json`.
~(Note: As of this moment the above example doesn't work because we make _replacement_ (i.e., update), fully specify the object.  We should make `--replace` only allow the specification of the _changed_ data - along with the necessary data to identify the existing instance.  This PR should address that as well. See 3rd item.)~


Still to do:
- [x] Auto-detect complex schemas and warn that `--file` or `--json` options should be used
- [x] Allow for `--replace` to only specify the properties that will be changed - along with necessary identifying options.
- [x] Add tests for the new functionality
- [x] Update docs to include new options

This PR will remain in **draft** until all items have been completed.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
