### PR TITLE
Promote validation error debug message to simplify troubleshooting

### DIFF
--- a/elyra/metadata/manager.py
+++ b/elyra/metadata/manager.py
@@ -84,8 +84,8 @@ class MetadataManager(LoggingConfigurable):
                 # Since we may not have a metadata instance due to a failure during `from_dict()`,
                 # instantiate a bad instance directly to use in the message and invalid result.
                 invalid_instance = Metadata(**metadata_dict)
-                self.log.info("Fetch of instance '{}' of schemaspace '{}' encountered an exception: {}".
-                              format(invalid_instance.name, self.schemaspace, ex))
+                self.log.warning("Fetch of instance '{}' of schemaspace '{}' encountered an exception: {}".
+                                 format(invalid_instance.name, self.schemaspace, ex))
                 if include_invalid:
                     invalid_instance.reason = ex.__class__.__name__
                     instances.append(invalid_instance)

--- a/elyra/metadata/manager.py
+++ b/elyra/metadata/manager.py
@@ -84,8 +84,8 @@ class MetadataManager(LoggingConfigurable):
                 # Since we may not have a metadata instance due to a failure during `from_dict()`,
                 # instantiate a bad instance directly to use in the message and invalid result.
                 invalid_instance = Metadata(**metadata_dict)
-                self.log.debug("Fetch of instance '{}' of schemaspace '{}' encountered an exception: {}".
-                               format(invalid_instance.name, self.schemaspace, ex))
+                self.log.info("Fetch of instance '{}' of schemaspace '{}' encountered an exception: {}".
+                              format(invalid_instance.name, self.schemaspace, ex))
                 if include_invalid:
                     invalid_instance.reason = ex.__class__.__name__
                     instances.append(invalid_instance)

--- a/elyra/metadata/manager.py
+++ b/elyra/metadata/manager.py
@@ -84,8 +84,9 @@ class MetadataManager(LoggingConfigurable):
                 # Since we may not have a metadata instance due to a failure during `from_dict()`,
                 # instantiate a bad instance directly to use in the message and invalid result.
                 invalid_instance = Metadata(**metadata_dict)
-                self.log.warning("Fetch of instance '{}' of schemaspace '{}' encountered an exception: {}".
-                                 format(invalid_instance.name, self.schemaspace, ex))
+                self.log.warning(f"Fetch of instance '{invalid_instance.name}' "
+                                 f"of schemaspace '{self.schemaspace}' "
+                                 f"encountered an exception: {ex}")
                 if include_invalid:
                     invalid_instance.reason = ex.__class__.__name__
                     instances.append(invalid_instance)


### PR DESCRIPTION
Currently certain metadata validation issues are surfaced only when debug is enabled.

Example:
```
[D 2022-01-11 13:21:02.533 ElyraApp] Fetch of instance 'aa_with_secret' of schemaspace 'runtimes' encountered an exception: Username, password, and Kubernetes secret are required for the selected Object Storage authentication type.
```

This makes it harder to troubleshoot the issue because
 - debug is likely not enabled by default
 - there are many debug messages, which makes it hard to locate the one that is relevant

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?

Dump [error] message at a log level that is always included in the log.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
