### PR TITLE
Add flag to hide label for description field

### DIFF
--- a/elyra/templates/components/canvas_properties_template.jinja2
+++ b/elyra/templates/components/canvas_properties_template.jinja2
@@ -52,6 +52,7 @@
             "default": " ",
             "placement": "on_panel"
           },
+          "label_visible": false,
           "data": {
             "required": false
           }


### PR DESCRIPTION
Adds a flag into the component template that hides the label for the readonly description field.

Original appearance:
![image](https://user-images.githubusercontent.com/6673460/149398441-9e6a978e-f72b-41d8-b146-2f0ce7662249.png)

Updated appearance:
![image](https://user-images.githubusercontent.com/6673460/149398278-5f21c95a-e164-4456-a0fd-6c89d5651a59.png)


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
