### PR TITLE
Render user comments as docs of nodes in pipeline

### DIFF
--- a/elyra/kfp/operator.py
+++ b/elyra/kfp/operator.py
@@ -230,7 +230,7 @@ class ExecuteFileOp(ContainerOp):
             self.add_volume(V1Volume(empty_dir=V1EmptyDirVolumeSource(
                                      medium="",
                                      size_limit=self.emptydir_volume_size),
-                            name=self.emptydir_volume_name))
+                                     name=self.emptydir_volume_name))
 
             self.container.add_volume_mount(V1VolumeMount(mount_path=self.container_work_dir_root_path,
                                                           name=self.emptydir_volume_name))
@@ -316,7 +316,6 @@ class ExecuteFileOp(ContainerOp):
 
     @staticmethod
     def _normalize_label_value(value):
-
         """Produce a Kubernetes-compliant label from value
 
         Valid label values must be 63 characters or less and

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -277,7 +277,8 @@ be fully qualified (i.e., prefixed with their package names).
                              'mem_request': operation.memory,
                              'gpu_limit': operation.gpu,
                              'operator_source': operation.component_params['filename'],
-                             'is_generic_operator': True
+                             'is_generic_operator': True,
+                             'doc': operation.doc
                              }
 
                 if runtime_image_pull_secret is not None:

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -533,7 +533,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                                                          })
 
                 if operation.doc:
-                    target_ops[operation.id].add_pod_annotation('elyra/user-node-doc', operation.doc)
+                    target_ops[operation.id].add_pod_annotation('elyra/node-user-doc', operation.doc)
 
                 # TODO Can we move all of this to apply to non-standard components as well? Test when servers are up
                 if cos_secret and not export:

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -532,6 +532,9 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                                                                  .format(pipeline_envs['ELYRA_WRITABLE_CONTAINER_DIR'])  # noqa
                                                          })
 
+                if operation.doc:
+                    target_ops[operation.id].add_pod_annotation('elyra/user-doc', operation.doc)
+
                 # TODO Can we move all of this to apply to non-standard components as well? Test when servers are up
                 if cos_secret and not export:
                     target_ops[operation.id].apply(use_aws_secret(cos_secret))

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -533,7 +533,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                                                          })
 
                 if operation.doc:
-                    target_ops[operation.id].add_pod_annotation('elyra/user-doc', operation.doc)
+                    target_ops[operation.id].add_pod_annotation('elyra/user-node-doc', operation.doc)
 
                 # TODO Can we move all of this to apply to non-standard components as well? Test when servers are up
                 if cos_secret and not export:

--- a/elyra/pipeline/parser.py
+++ b/elyra/pipeline/parser.py
@@ -95,9 +95,15 @@ class PipelineParser(LoggingConfigurable):
                 raise NotImplementedError("Node type '{}' is currently not supported!".format(node.type))
             elif node.type != "execution_node":
                 raise ValueError("Node type '{}' is invalid!".format(node.type))
-
             # parse each node as a pipeline operation
+
             operation = self._create_pipeline_operation(node, super_node)
+
+            # assoicate user comment as docs to operations
+            comment = pipeline_definition.get_node_comments(node.id)
+            if comment:
+                operation.doc = comment
+
             self.log.debug("Adding operation for '{}' to pipeline: {}".format(operation.name, pipeline_object.name))
             pipeline_object.operations[operation.id] = operation
 

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -76,6 +76,7 @@ class Operation(object):
         self._name = name
         self._parent_operation_ids = parent_operation_ids or []
         self._component_params = component_params
+        self._doc = None
 
         # Scrub the inputs and outputs lists
         self._component_params["inputs"] = Operation._scrub_list(component_params.get('inputs', []))
@@ -96,6 +97,14 @@ class Operation(object):
     @property
     def name(self) -> str:
         return self._name
+
+    @property
+    def doc(self) -> str:
+        return self._doc
+
+    @doc.setter
+    def doc(self, value: str):
+        self._doc = value
 
     @property
     def parent_operation_ids(self) -> List[str]:

--- a/elyra/pipeline/pipeline_definition.py
+++ b/elyra/pipeline/pipeline_definition.py
@@ -484,10 +484,13 @@ class PipelineDefinition(object):
                     if ref['node_ref'] == node_id:
                         comments.append(comment.get("content", ""))
 
-        if not comments:
+        # remove empty (or whitespace-only) comment strings
+        comments = [c for c in comments if c.strip()]
+        comment_str = "\n\n".join(comments)
+        if not comment_str:
             return None
-        else:
-            return "\n\n".join(comments)
+
+        return comment_str
 
     def get_supernodes(self) -> List[Node]:
         """

--- a/elyra/pipeline/pipeline_definition.py
+++ b/elyra/pipeline/pipeline_definition.py
@@ -480,7 +480,7 @@ class PipelineDefinition(object):
             comment_list = pipeline.comments
             for comment in comment_list:
                 associated_node_id_list = comment.get("associated_id_refs", [])
-                for ref in assoicated_node_id_list:
+                for ref in associated_node_id_list:
                     if ref['node_ref'] == node_id:
                         comments.append(comment.get("content", ""))
 

--- a/elyra/pipeline/pipeline_definition.py
+++ b/elyra/pipeline/pipeline_definition.py
@@ -149,6 +149,14 @@ class Pipeline(AppDataBase):
 
         return self._nodes
 
+    @property
+    def comments(self) -> list:
+        """
+        The list of user comments in the pipeline
+        :rtype: list of comments
+        """
+        return self._node['app_data']['ui_data'].get("comments", [])
+
     def get_property(self, key: str, default_value=None) -> Any:
         """
         Retrieve pipeline values for a given key.
@@ -459,6 +467,27 @@ class PipelineDefinition(object):
                 if node.id == node_id:
                     return node
         return None
+
+    def get_node_comments(self, node_id: str) -> Optional[str]:
+        """
+        Given a node id returns the assoicated comments in the pipeline
+        :param node_id: the node id
+        :return: the comments or None
+        """
+        comments = []
+
+        for pipeline in self.pipelines:
+            comment_list = pipeline.comments
+            for comment in comment_list:
+                assoicated_node_id_list = comment.get("associated_id_refs", [])
+                for ref in assoicated_node_id_list:
+                    if ref['node_ref'] == node_id:
+                        comments.append(comment.get("content", ""))
+
+        if not comments:
+            return None
+        else:
+            return "\n\n".join(comments)
 
     def get_supernodes(self) -> List[Node]:
         """

--- a/elyra/pipeline/pipeline_definition.py
+++ b/elyra/pipeline/pipeline_definition.py
@@ -479,7 +479,7 @@ class PipelineDefinition(object):
         for pipeline in self.pipelines:
             comment_list = pipeline.comments
             for comment in comment_list:
-                assoicated_node_id_list = comment.get("associated_id_refs", [])
+                associated_node_id_list = comment.get("associated_id_refs", [])
                 for ref in assoicated_node_id_list:
                     if ref['node_ref'] == node_id:
                         comments.append(comment.get("content", ""))

--- a/elyra/templates/airflow/airflow_template.jinja2
+++ b/elyra/templates/airflow/airflow_template.jinja2
@@ -84,6 +84,12 @@ op_{{ operation.id|regex_replace }} = KubernetesPodOperator(name='{{ operation.n
         op_{{ operation.id|regex_replace }}.image_pull_policy = '{{ operation.image_pull_policy }}'
     {% endif %}
 
+    {% if operation.doc %}
+        op_{{ operation.id|regex_replace }}.doc = """
+        {{ operation.doc }}
+        """
+    {% endif %}
+
     {% if operation.parent_operation_ids %}
         {% for parent_operation_id in operation.parent_operation_ids %}
             op_{{ operation.id|regex_replace }} << op_{{ parent_operation_id|regex_replace }}

--- a/elyra/templates/airflow/airflow_template.jinja2
+++ b/elyra/templates/airflow/airflow_template.jinja2
@@ -87,7 +87,7 @@ op_{{ operation.id|regex_replace }} = KubernetesPodOperator(name='{{ operation.n
     {% if operation.doc %}
         op_{{ operation.id|regex_replace }}.doc = """
         {{ operation.doc }}
-        """
+    """
     {% endif %}
 
     {% if operation.parent_operation_ids %}

--- a/elyra/tests/pipeline/resources/sample_pipelines/pipeline_3_node_sample_with_comments.json
+++ b/elyra/tests/pipeline/resources/sample_pipelines/pipeline_3_node_sample_with_comments.json
@@ -1,0 +1,96 @@
+{
+  "doc_type": "pipeline",
+  "version": "3.0",
+  "json_schema": "http://api.dataplatform.ibm.com/schemas/common-pipeline/pipeline-flow/pipeline-flow-v3-schema.json",
+  "id": "c06ad0e7-8c86-462b-b3fc-a7d771f75707",
+  "primary_pipeline": "c06ad0e7-8c86-462b-b3fc-a7d771f75707",
+  "pipelines": [
+    {
+      "id": "c06ad0e7-8c86-462b-b3fc-a7d771f75707",
+      "nodes": [
+        {
+          "id": "d52ddfb4-dd0e-47ac-abc7-fa30bb95d45c",
+          "type": "execution_node",
+          "op": "execute-notebook-node",
+          "app_data": {
+            "label": "{{label}}",
+            "component_parameters": {
+              "filename": "demo-pipelines/generate-contributions.ipynb",
+              "runtime_image": "elyra/tensorflow:1.15.2-py3"
+            },
+            "ui_data": {
+              "label": "{{label}}",
+              "x_pos": 112,
+              "y_pos": 97,
+              "description": "Notebook file"
+            }
+          }
+        },
+        {
+          "id": "5ddfbd02-2f4e-462b-8349-ddd7ec7afb71",
+          "type": "execution_node",
+          "op": "execute-notebook-node",
+          "app_data": {
+            "label": "{{label}}",
+            "component_parameters": {
+              "filename": "demo-pipelines/generate-stats.ipynb",
+              "runtime_image": "elyra/tensorflow:1.15.2-py3"
+            },
+            "ui_data": {
+              "label": "{{label}}",
+              "x_pos": 130,
+              "y_pos": 80,
+              "description": "Notebook file"
+            }
+          }
+        },
+        {
+          "id": "acc4527d-7cc8-4c16-b520-5aa0f50a2e34",
+          "type": "execution_node",
+          "op": "execute-notebook-node",
+          "app_data": {
+            "label": "{{label}}",
+            "component_parameters": {
+              "filename": "demo-pipelines/overview.ipynb",
+              "runtime_image": "elyra/tensorflow:1.15.2-py3"
+            },
+            "ui_data": {
+              "label": "{{label}}",
+              "x_pos": 148,
+              "y_pos": 62,
+              "description": "Notebook file"
+            }
+          }
+        }
+      ],
+      "app_data": {
+        "runtime": "kfp",
+        "runtime_config": "kfp-yukked1",
+        "ui_data": {
+          "comments": [
+            {
+              "id": "22a171e4-f12b-4a6b-9399-f48c81e0906a",
+              "x_pos": 30.2166748046875,
+              "y_pos": 13,
+              "width": 175,
+              "height": 66,
+              "class_name": "d3-comment-rect",
+              "content": "Generate community stats and then aggregate them on an overview dashboard",
+              "associated_id_refs": [
+                {
+                  "node_ref": "d52ddfb4-dd0e-47ac-abc7-fa30bb95d45c"
+                }
+              ]
+            }
+          ]
+        },
+        "properties": {
+          "name": "pipeline-title"
+        },
+        "version": 5
+      },
+      "runtime_ref": ""
+    }
+  ],
+  "schemas": []
+}

--- a/elyra/tests/pipeline/test_pipeline_parser.py
+++ b/elyra/tests/pipeline/test_pipeline_parser.py
@@ -133,6 +133,14 @@ def test_pipeline_with_dependencies():
     assert len(pipeline.operations['acc4527d-7cc8-4c16-b520-5aa0f50a2e34'].parent_operation_ids) == 2
 
 
+def test_pipeline_with_comments():
+    pipeline_json = _read_pipeline_resource('resources/sample_pipelines/'
+                                            'pipeline_3_node_sample_with_comments.json')
+    pipeline = PipelineParser().parse(pipeline_json)
+    assert pipeline.operations['d52ddfb4-dd0e-47ac-abc7-fa30bb95d45c'].doc \
+        == "Generate community stats and then aggregate them on an overview dashboard"
+
+
 def test_pipeline_global_attributes():
     pipeline_json = _read_pipeline_resource('resources/sample_pipelines/pipeline_valid.json')
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

Closes #1358 

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->
* This feature associates user comment blocks to nodes in pipelines, as requested in #1358. 
* The comment blocks will be rendered as 
  * Pod annotations in KFP pipelines
  * `doc` field of a task in Airflow pipelines 
* Implementation details
  * An optional `doc` field is added to `Operation` class
  * During parsing phase, for each node in a pipeline_def we search for if there is any user comment block associated with it. If so, we set `doc` of the created `operation` to user comments (in case there are multiple comment blocks associated with one node, we concat them)
  * During processing phase, we add a pod annotation or add `op.doc="xxx"` in KFP and Airflow processors correspondingly, if an operation has a `doc` field.

### How was this pull request tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
* `make test-server`
* Added one pipeline JSON with user comment blocks `elyra/tests/pipeline/resources/sample_pipelines/pipeline_3_node_sample_with_comments.json`; a test (`elyra/tests/pipeline/test_pipeline_parser.py:test_pipeline_with_comments`) that verifies if `doc` field is correctly populated by the parser.
* Started a jupyterlab and tested exporting a pipeline with user comments to Airflow and KFP pipeline files.

<a href="https://www.loom.com/share/0b3100d0e7034537b9d0f20a66f510e6">
    <p>pipeline-wit… - JupyterLab - 18 January 2022 - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/0b3100d0e7034537b9d0f20a66f510e6-with-play.gif">
  </a>
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
