### PR TITLE
Resolve naming conflict in case of multiple Airflow operators defined in single file

### DIFF
--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -83,11 +83,9 @@ class AirflowComponentParser(ComponentParser):
 
     def _get_all_classes(self, component_definition: str) -> Dict[str, Dict]:
         # Organize lines and arguments according to the class to which they belong
-        class_to_content = {
-            "no_class": {"lines": [], "args": []}
-        }
+        class_to_content = {}
 
-        class_name = "no_class"
+        class_name = None
         class_regex = re.compile(r"class ([\w]+[.\w]*)\(\w*\):")
         for line in component_definition.split('\n'):
             # Remove any inline comments (must follow the '2 preceding spaces and one following space'
@@ -95,14 +93,13 @@ class AirflowComponentParser(ComponentParser):
             line = re.sub(r"  # .*\n?", "", line)
             match = class_regex.search(line)
             if match:
-                # Do not include any non-Operator classes
-                if not line.strip().endswith("Operator):"):
-                    continue
-                class_name = match.group(1)
-                class_to_content[class_name] = {"lines": [], "args": []}
-            class_to_content[class_name]['lines'].append(line)
-
-        class_to_content.pop("no_class")
+                if line.strip().endswith("Operator):"):
+                    class_name = match.group(1)
+                    class_to_content[class_name] = {"lines": [], "args": []}
+                else:
+                    class_name = None
+            if class_name:
+                class_to_content[class_name]['lines'].append(line)
 
         init_regex = re.compile(r"def __init__\(([\s\d\w,=\-\'\"\[\]\{\}\*\s\#.\\\/:?]*)\):")
         for class_name, content in class_to_content.items():

--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -59,16 +59,23 @@ class AirflowComponentParser(ComponentParser):
             # Create a Component object for each class
             component_properties = self._parse_properties(component_content)
 
-            new_component = Component(id=registry_entry.component_id,
-                                      name=component_class,
-                                      description='',
-                                      catalog_type=registry_entry.catalog_type,
-                                      source_identifier=registry_entry.component_identifier,
-                                      definition=self.get_class_def_as_string(component_content),
-                                      runtime_type=self.component_platform.name,
-                                      categories=registry_entry.categories,
-                                      properties=component_properties
-                                      )
+            component_id = registry_entry.component_id
+            # If this file contains more than one operator, adjust name to avoid
+            # overwriting components with same id
+            if len(component_classes) > 1:
+                component_id += f":{component_class}"
+
+            new_component = Component(
+                id=component_id,
+                name=component_class,
+                description='',
+                catalog_type=registry_entry.catalog_type,
+                source_identifier=registry_entry.component_identifier,
+                definition=self.get_class_def_as_string(component_content),
+                runtime_type=self.component_platform.name,
+                categories=registry_entry.categories,
+                properties=component_properties
+            )
 
             components.append(new_component)
 

--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -95,6 +95,9 @@ class AirflowComponentParser(ComponentParser):
             line = re.sub(r"  # .*\n?", "", line)
             match = class_regex.search(line)
             if match:
+                # Do not include any non-Operator classes
+                if not line.strip().endswith("Operator):"):
+                    continue
                 class_name = match.group(1)
                 class_to_content[class_name] = {"lines": [], "args": []}
             class_to_content[class_name]['lines'].append(line)

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -66,7 +66,8 @@ def test_modify_component_catalogs():
     metadata_manager = MetadataManager(schemaspace=ComponentCatalogs.COMPONENT_CATALOGS_SCHEMASPACE_ID)
 
     # Create new registry instance with a single URL-based component
-    urls = ["https://raw.githubusercontent.com/elyra-ai/elyra/master/elyra/tests/pipeline/resources/components/"
+    urls = ["https://raw.githubusercontent.com/elyra-ai/elyra/"
+            "133e74732517d39accced6840485c9603c1b79f7/elyra/tests/pipeline/resources/components/"
             "airflow_test_operator.py"]
 
     instance_metadata = {

--- a/elyra/tests/pipeline/resources/components/airflow_test_operator.py
+++ b/elyra/tests/pipeline/resources/components/airflow_test_operator.py
@@ -18,7 +18,7 @@ from airflow.utils.decorators import apply_defaults
 
 
 class TestOperator(BaseOperator):
-    r"""
+    """
     Execute a test script.
 
     :param test_string_no_default: The test command description
@@ -43,13 +43,6 @@ class TestOperator(BaseOperator):
     :type test_int_zero: int
     :param test_int_non_zero: The test command int description
     :type test_int_non_zero: int
-    :param test_unusual_type_dict: The test command description
-    :type test_unusual_type_dict: a dictionary of arrays
-    :param test_unusual_type_list: The test command description
-    :type test_unusual_type_list: a list of strings
-    :param test_unusual_type_string: The test command description
-    :type test_unusual_type_string: a string
-    :param test_unusual_type_notgiven: The test command description
     """
 
     @apply_defaults
@@ -65,10 +58,38 @@ class TestOperator(BaseOperator):
                  test_bool_true=True,
                  test_int_zero=0,
                  test_int_non_zero=1,
+                 *args, **kwargs):
+
+        super().__init__(*args, **kwargs)
+
+
+class TestUnusualTypesOperator(BaseOperator):
+    """
+    A second operator defined within the same file.
+
+    :param test_unusual_type_dict: The test command description
+    :type test_unusual_type_dict: a dictionary of arrays
+    :param test_unusual_type_list: The test command description
+    :type test_unusual_type_list: a list of strings
+    :param test_unusual_type_string: The test command description
+    :type test_unusual_type_string: a string
+    :param test_unusual_type_not_given: The test command description
+    """
+
+    def __init__(self,
                  test_unusual_type_dict=None,
                  test_unusual_type_list=None,
                  test_unusual_type_string="",
-                 test_unusual_type_notgiven="",
+                 test_unusual_type_not_given="",
                  *args, **kwargs):
 
+        super().__init__(*args, **kwargs)
+
+
+class HelperClass(object):
+    """
+    A class that should not be parsed as an operator.
+    """
+
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
After several recent PRs that refactored the component catalog and parser functionality, a bug was introduced that does not persist a `Component` object in the case where multiple operators are present in the same file.

### What changes were proposed in this pull request?
When parsing Airflow operators, a `Component` object is created for each operator defined in that file, and a component id is assigned. This component id is passed through from the relevant component catalog connector (recall that this class 1.) reads in the full python file, and 2.) builds a unique id based on the catalog connector type and the relevant unique-ifying keys as defined by the connector). This means that if multiple operators exist in a file, they are all getting assigned the same component id on init.

`Component` objects are added to the component cache keyed by their id. This results in the most recently parsed operator in a given file overwriting all previous operators also parsed from that file. 

This PR appends the operator classname string to the id in the case of multiple operators defined in the same file. The id for a `Component` that is one of several in a single file would now have the format: `<catalog-connector-type>:<hash-of-relevant-keys>:<class_name_of_operator>`. Note that this would not require migration, as all our existing supported example operators have a 1:1 class:file ratio.

A related change is also included that prevents helper classes from being parsed as operators. Classes are only parsed if the class from which they derive ends in the phrase `'Operator'`. See lines 96-102 in this PR.

### How was this pull request tested?

- [x] Add a test case for this scenario

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
