### PR TITLE
Group component properties by inputs and outputs

### DIFF
--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -288,11 +288,11 @@ class Component(object):
 
     @property
     def input_properties(self) -> List[ComponentParameter]:
-        return [prop for prop in self._properties if not prop.ref.startswith("output_")]
+        return [prop for prop in self._properties if prop.data_type != 'outputpath']
 
     @property
     def output_properties(self) -> List[ComponentParameter]:
-        return [prop for prop in self._properties if prop.ref.startswith("output_")]
+        return [prop for prop in self._properties if prop.data_type == 'outputpath']
 
     @staticmethod
     def _log_warning(msg: str, logger: Optional[Logger] = None):

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -286,6 +286,14 @@ class Component(object):
     def parameter_refs(self) -> dict:
         return self._parameter_refs
 
+    @property
+    def input_properties(self) -> List[ComponentParameter]:
+        return [prop for prop in self._properties if not prop.ref.startswith("output_")]
+
+    @property
+    def output_properties(self) -> List[ComponentParameter]:
+        return [prop for prop in self._properties if prop.ref.startswith("output_")]
+
     @staticmethod
     def _log_warning(msg: str, logger: Optional[Logger] = None):
         if logger:

--- a/elyra/pipeline/kfp/component_parser_kfp.py
+++ b/elyra/pipeline/kfp/component_parser_kfp.py
@@ -120,8 +120,6 @@ class KfpComponentParser(ComponentParser):
 
                 if data_type_info.data_type == 'outputpath':
                     ref_name = f"output_{ref_name}"
-                    # Add sentence to description to clarify that parameter is an output
-                    description = f"This is an output of this component. {description}"
 
                 one_of_control_types = data_type_info.one_of_control_types
                 default_control_type = data_type_info.control_id

--- a/elyra/templates/components/canvas_properties_template.jinja2
+++ b/elyra/templates/components/canvas_properties_template.jinja2
@@ -151,10 +151,15 @@
               "parameter_refs": ["label"]
             },
             {
-              "id": "elyra_inputs",
+              "id": "elyra_inputCategoryHeader",
+              "class_name": "elyra_categoryHeader",
+              "type": "textPanel",
               "label": {
                 "default": "Inputs"
-              },
+              }
+            },
+            {
+              "id": "elyra_inputs",
               "type": "controls",
               "parameter_refs": [
 {% for property in component.input_properties %}
@@ -163,10 +168,15 @@
               ]
             },
             {
-              "id": "elyra_outputs",
+              "id": "elyra_outputCategoryHeader",
+              "type": "textPanel",
+              "class_name": "elyra_categoryHeader",
               "label": {
                 "default": "Outputs"
-              },
+              }
+            },
+            {
+              "id": "elyra_outputs",
               "type": "controls",
               "parameter_refs": [
 {% for property in component.output_properties %}

--- a/elyra/templates/components/canvas_properties_template.jinja2
+++ b/elyra/templates/components/canvas_properties_template.jinja2
@@ -150,13 +150,30 @@
               "type": "controls",
               "parameter_refs": ["label"]
             },
-{% for property in component.properties %}
             {
-              "id": "elyra_{{ property.ref }}",
+              "id": "elyra_inputs",
+              "label": {
+                "default": "Inputs"
+              },
               "type": "controls",
-              "parameter_refs": ["elyra_{{ property.ref }}"]
-            },
+              "parameter_refs": [
+{% for property in component.input_properties %}
+                 "elyra_{{ property.ref }}"{% if not loop.last%},{% endif %}
 {% endfor %}
+              ]
+            },
+            {
+              "id": "elyra_outputs",
+              "label": {
+                "default": "Outputs"
+              },
+              "type": "controls",
+              "parameter_refs": [
+{% for property in component.output_properties %}
+                 "elyra_{{ property.ref }}"{% if not loop.last%},{% endif %}
+{% endfor %}
+              ]
+            },
             {
               "id": "component_source",
               "type": "controls",

--- a/elyra/templates/components/canvas_properties_template.jinja2
+++ b/elyra/templates/components/canvas_properties_template.jinja2
@@ -129,7 +129,7 @@
             "default": "Component Source"
           },
           "description": {
-            "default": "Unique information used to identify this component.",
+            "default": " ",
             "placement": "on_panel"
           },
           "data": {}
@@ -150,6 +150,7 @@
               "type": "controls",
               "parameter_refs": ["label"]
             },
+{% if component.input_properties|length > 0 %}
             {
               "id": "elyra_inputCategoryHeader",
               "class_name": "elyra_categoryHeader",
@@ -158,15 +159,15 @@
                 "default": "Inputs"
               }
             },
+    {% for property in component.input_properties %}
             {
-              "id": "elyra_inputs",
+              "id": "elyra_{{ property.ref }}",
               "type": "controls",
-              "parameter_refs": [
-{% for property in component.input_properties %}
-                 "elyra_{{ property.ref }}"{% if not loop.last%},{% endif %}
-{% endfor %}
-              ]
+              "parameter_refs": ["elyra_{{ property.ref }}"]
             },
+    {% endfor %}
+{% endif %}
+{% if component.output_properties|length > 0 %}
             {
               "id": "elyra_outputCategoryHeader",
               "type": "textPanel",
@@ -175,14 +176,21 @@
                 "default": "Outputs"
               }
             },
+    {% for property in component.output_properties %}
             {
-              "id": "elyra_outputs",
+              "id": "elyra_{{ property.ref }}",
               "type": "controls",
-              "parameter_refs": [
-{% for property in component.output_properties %}
-                 "elyra_{{ property.ref }}"{% if not loop.last%},{% endif %}
-{% endfor %}
-              ]
+              "parameter_refs": ["elyra_{{ property.ref }}"]
+            },
+    {% endfor %}
+{% endif %}
+            {
+              "id": "elyra_component_sourceCategoryHeader",
+              "type": "textPanel",
+              "class_name": "elyra_categoryHeader",
+              "label": {
+                "default": "Component Source"
+              }
             },
             {
               "id": "component_source",

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -339,7 +339,11 @@ def test_parse_airflow_component_file_no_inputs():
     assert len(properties_json['current_parameters'].keys()) == num_common_params
     assert len(properties_json['parameters']) == num_common_params
     assert len(properties_json['uihints']['parameter_info']) == num_common_params
-    assert len(properties_json['uihints']['group_info'][0]['group_info']) == num_common_params
+
+    # Total number of groups includes one for each parameter, plus 1 for the component_source header
+    # (Airflow does not include an output header since there are no formally defined outputs)
+    num_groups = num_common_params + 1
+    assert len(properties_json['uihints']['group_info'][0]['group_info']) == num_groups
 
     # Ensure that template still renders the two common parameters correctly
     assert properties_json['current_parameters']['label'] == ""

--- a/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
@@ -366,7 +366,12 @@ def test_parse_kfp_component_file_no_inputs():
     assert len(properties_json['current_parameters'].keys()) == num_common_params
     assert len(properties_json['parameters']) == num_common_params
     assert len(properties_json['uihints']['parameter_info']) == num_common_params
-    assert len(properties_json['uihints']['group_info'][0]['group_info']) == num_common_params
+
+    # Total number of groups includes one for each parameter,
+    # plus one for the output group header,
+    # plus 1 for the component_source header
+    num_groups = num_common_params + 2
+    assert len(properties_json['uihints']['group_info'][0]['group_info']) == num_groups
 
     # Ensure that template still renders the two common parameters correctly
     assert properties_json['current_parameters']['label'] == ""

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -756,6 +756,11 @@ input.elyra-Dialog-checkbox.jp-mod-styled {
   cursor: initial;
 }
 
+.elyra-PipelineEditor .elyra_categoryHeader .panel-label {
+  font-size: var(--jp-content-font-size2);
+  padding-left: 33px;
+}
+
 /* fix font ligatures */
 .lsp-completer-theme-vscode {
   letter-spacing: normal;


### PR DESCRIPTION
Fixes #2182

### What changes were proposed in this pull request?
Changes the palette groups to provide headers for `Inputs`, `Outputs`, and `Component Source` in the component properties panel. The header will not be rendered if there are no properties in that category or if properties are not otherwise exposed (e.g., no outputs are exposed for Airflow components, so the `Output` header is not rendered). 

The new header groups also have their own CSS.

- [x] We may want to remove the `"This is an output of this component"` phrase in the description of outputs.

### How was this pull request tested?

- [x] Update backend tests that check against properties.json

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
