### PR TITLE
Unpin click dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup_args = dict(
     packages=find_packages(),
     install_requires=[
         'autopep8>=1.5.0,<1.5.6',
-        'click>=7.1.1,<8',  # Required by kfp 1.6.3
+        'click',
         'colorama',
         'entrypoints>=0.3',
         'jinja2>=2.11',

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup_args = dict(
     packages=find_packages(),
     install_requires=[
         'autopep8>=1.5.0,<1.5.6',
-        'click',
+        'click>=7.1.1',
         'colorama',
         'entrypoints>=0.3',
         'jinja2>=2.11',


### PR DESCRIPTION

### What changes were proposed in this pull request?
Our recent test failures seem to be due to a conflicting pin of `click` (we pin <8 whereas the latest `black` release pins `click` at >= 8). This PR removes the pin on `click` (imposed in #2010) as further research revealed that the KFP `click` dependency is only for use in the KFP CLI.

### How was this pull request tested?
Tests are passing. Also ran some pipelines and all are passing.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
