### PR TITLE
Move unit test file to proper test directory

### DIFF
--- a/packages/pipeline-editor/src/test/pipeline-hooks.spec.ts
+++ b/packages/pipeline-editor/src/test/pipeline-hooks.spec.ts
@@ -17,7 +17,7 @@ import {
   IRuntimeComponent,
   GENERIC_CATEGORY_ID,
   sortPalette
-} from './pipeline-hooks';
+} from '../pipeline-hooks';
 
 const GENERIC_CATEGORY = {
   label: 'ZZZZ should not matter',


### PR DESCRIPTION
Following organization guidelines from the [Elyra testing documentation](https://elyra.readthedocs.io/en/latest/developer_guide/contributing.html#ui-unit-tests), front end unit tests should be located in a folder called `test` in the `src` directory of the package being tested.

### What changes were proposed in this pull request?
This PR moves `pipeline-hooks.spec.ts` test file from `src/` into `src/test/` location, as per documentation.

### How was this pull request tested?
Ran `make test-ui-unit` and checked expected tests are still running.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
