### PR TITLE
Restore tag variable, update release script

### DIFF
--- a/create-release.py
+++ b/create-release.py
@@ -152,10 +152,6 @@ def update_version_to_release() -> None:
         sed(_source('docs/source/recipes/using-elyra-with-kubeflow-notebook-server.md'),
             r"master",
             f"{new_version}")
-
-        sed(_source('etc/docker/kubeflow/Dockerfile'),
-            r"elyra\[kfp-tekton,kfp-examples\]==.*",
-            f"elyra\[kfp-tekton,kfp-examples\]=={new_version} \\\\")
         sed(_source('etc/docker/elyra/Dockerfile'),
             r"    cd /tmp/elyra && make UPGRADE_STRATEGY=eager install && rm -rf /tmp/elyra",
             f"    cd /tmp/elyra \&\& git checkout tags/v{new_version} -b v{new_version} \&\& make UPGRADE_STRATEGY=eager install \&\& rm -rf /tmp/elyra")
@@ -228,9 +224,6 @@ def update_version_to_dev() -> None:
         sed(_source('docs/source/recipes/using-elyra-with-kubeflow-notebook-server.md'),
             rf"{new_version}",
             "master")
-
-        # for now, this stays with the latest release
-        # sed(_source('etc/docker/kubeflow/Dockerfile'), r"elyra[all]==.*", f"elyra[all]=={new_version}")
 
         sed(_source('etc/docker/elyra/Dockerfile'),
             rf"\&\& git checkout tags/v{new_version} -b v{new_version} ",

--- a/etc/docker/kubeflow/Dockerfile
+++ b/etc/docker/kubeflow/Dockerfile
@@ -25,15 +25,16 @@ ARG TAG="dev"
 # - with KFP Tekton support ('kfp-tekton')
 # - with component examples ('kfp-examples')
 RUN python -m pip install --quiet --no-cache-dir --use-deprecated=legacy-resolver \
-    elyra[kfp-tekton,kfp-examples]==3.6.0 \
+    elyra[kfp-tekton,kfp-examples]=="$TAG" \
     && jupyter lab build \
     && rm -rf $HOME/.cache/yarn \
     && rm -rf /opt/conda/share/jupyter/lab/staging/node_modules
 
 # Install component examples catalog
-#  - this wail fail if the 'kfp-examples' pip extra is not installed
+#  - this will fail if the 'kfp-examples' pip extra is not installed
 RUN elyra-metadata install component-catalogs \
     --schema_name=elyra-kfp-examples-catalog \
     --display_name="Kubeflow Pipelines examples" \
     --runtime_type=KUBEFLOW_PIPELINES \
     --categories="['examples']"
+


### PR DESCRIPTION
This pull request restores the use of `$TAG` to [etc/docker/kubeflow/Dockerfile](https://github.com/elyra-ai/elyra/blob/master/etc/docker/kubeflow/Dockerfile) since that particular reference should be using the value of `TAG` that is set/conveyed during the `make kf-notebook-image` target.  

The `create_release.py` script has also been updated to remove the replacement code replacing the `$TAG` reference with the current release string.  In addition, the commented-out code that appeared to be related to a compensating change has been removed as well.

I'm not sure how the official release-based images are built, but I'm not sure we need to do the string replacement for the [`TAG:=dev`](https://github.com/elyra-ai/elyra/blob/0a296b711b44d1a3feb0be289b4c0b4d184ba2b6/Makefile#L25) statement in the Makefile, but use the TAG in the `make` commands instead (e.g., `make TAG=3.6.0 release` or `make TAG=3.6.0 container-images`).  Of course, the release would need to be pushed to pypi prior to building the images since they expect _released_ elyra packages - but that has to be the case anyway.

We could also gain a bit more flexibility by changing the assignment to `TAG?=dev` which would enable the variable to be set as an environment variable or prior to the `make` command (e.g., `TAG=3.6.0 make release`), but that's not a big deal.

Resolves #2456

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
