### PR TITLE
Fix templates for safe rendering of comments, pipeline & property descriptions

### DIFF
--- a/elyra/templates/airflow/airflow_template.jinja2
+++ b/elyra/templates/airflow/airflow_template.jinja2
@@ -88,7 +88,7 @@ op_{{ operation.id|regex_replace }} = KubernetesPodOperator(name='{{ operation.n
 
     {% if operation.doc %}
         op_{{ operation.id|regex_replace }}.doc = """
-        {{ operation.doc }}
+        {{ operation.doc|replace("\"\"\"", "\\\"\\\"\\\"") }}
     """
     {% endif %}
 

--- a/elyra/templates/airflow/airflow_template.jinja2
+++ b/elyra/templates/airflow/airflow_template.jinja2
@@ -14,7 +14,7 @@ dag = DAG(
     default_args=args,
     schedule_interval='@once',
     start_date=days_ago(1),
-    description='{{ pipeline_description }}',
+    description={{ pipeline_description|tojson|safe }},
     is_paused_upon_creation={{ is_paused_upon_creation }},
 )
 

--- a/elyra/templates/airflow/airflow_template.jinja2
+++ b/elyra/templates/airflow/airflow_template.jinja2
@@ -14,7 +14,9 @@ dag = DAG(
     default_args=args,
     schedule_interval='@once',
     start_date=days_ago(1),
-    description={{ pipeline_description|tojson|safe }},
+    description="""
+{{ pipeline_description|replace("\"\"\"", "\\\"\\\"\\\"") }}
+    """,
     is_paused_upon_creation={{ is_paused_upon_creation }},
 )
 

--- a/elyra/templates/components/canvas_properties_template.jinja2
+++ b/elyra/templates/components/canvas_properties_template.jinja2
@@ -1,6 +1,6 @@
 {
     "current_parameters": {
-      {% if component.description %}"component_description": "{{ component.description }}",{% endif %}
+      {% if component.description %}"component_description": {{ component.description|tojson|safe }},{% endif %}
       "label": "",
 {% for property in component.properties %}
         "elyra_{{ property.ref }}":
@@ -81,7 +81,7 @@
             "default": "{{ property.name }}"
           },
           "description": {
-            "default": "{{ property.description }}",
+            "default": {{ property.description|tojson|safe }},
             "placement": "on_panel"
           },
           "data": {

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -287,10 +287,10 @@ def test_parse_airflow_component_file():
 
     # Ensure that a long description with line wrapping and a backslash escape has rendered
     # (and hence did not raise an error during json.loads in the properties API request)
-    long_description = get_parameter_description('elyra_long_description_property')
-    assert long_description.startswith("a string parameter") and \
-           long_description.endswith("as shown here: \\_ (type: str)")
-
+    parsed_description = """a string parameter with a very long description
+        that wraps lines and also has an escaped underscore in it, as shown here: (\_)  # noqa W605"""
+    modified_description = parsed_description.replace("\n", " ") + " (type: str)"  # modify desc acc. to parser rules
+    assert get_parameter_description('elyra_long_description_property') == modified_description
 
     # Retrieve properties for DeriveFromTestOperator
     # DeriveFromTestOperator includes type hints for all init arguments

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -285,6 +285,13 @@ def test_parse_airflow_component_file():
                                                                    "(type: a list of strings)"
     assert get_parameter_description('elyra_fallback_type') == "(type: str)"
 
+    # Ensure that a long description with line wrapping and a backslash escape has rendered
+    # (and hence did not raise an error during json.loads in the properties API request)
+    long_description = get_parameter_description('elyra_long_description_property')
+    assert long_description.startswith("a string parameter") and \
+           long_description.endswith("as shown here: \\_ (type: str)")
+
+
     # Retrieve properties for DeriveFromTestOperator
     # DeriveFromTestOperator includes type hints for all init arguments
     properties_json = ComponentCache.to_canvas_properties(derive_test_op)

--- a/elyra/tests/pipeline/resources/components/airflow_test_operator.py
+++ b/elyra/tests/pipeline/resources/components/airflow_test_operator.py
@@ -55,7 +55,7 @@ class TestOperator(BaseOperator):
     :param unusual_type_list: a list parameter with the phrase 'string' in type description
     :type unusual_type_list: a list of strings
     :param long_description_property: a string parameter with a very long description
-        that wraps lines and also has an escaped underscore in it, as shown here: \_
+        that wraps lines and also has an escaped underscore in it, as shown here: (\_)  # noqa W605
     :type long_description_property: str
     """
 

--- a/elyra/tests/pipeline/resources/components/airflow_test_operator.py
+++ b/elyra/tests/pipeline/resources/components/airflow_test_operator.py
@@ -54,6 +54,9 @@ class TestOperator(BaseOperator):
     :type unusual_type_dict: a dictionary of arrays
     :param unusual_type_list: a list parameter with the phrase 'string' in type description
     :type unusual_type_list: a list of strings
+    :param long_description_property: a string parameter with a very long description
+        that wraps lines and also has an escaped underscore in it, as shown here: \_
+    :type long_description_property: str
     """
 
     def __init__(
@@ -75,6 +78,7 @@ class TestOperator(BaseOperator):
         unusual_type_dict=None,
         unusual_type_list=None,
         fallback_type=None,
+        long_description_property=None,
         *args,
         **kwargs
     ):

--- a/elyra/tests/pipeline/resources/sample_pipelines/pipeline_with_airflow_components.json
+++ b/elyra/tests/pipeline/resources/sample_pipelines/pipeline_with_airflow_components.json
@@ -390,9 +390,16 @@
         "ui_data": {
           "comments": []
         },
-        "version": 4,
+        "version": 7,
         "runtime": "airflow",
         "runtime_config": "airflow-yukked1",
+        "runtime_type": "APACHE_AIRFLOW",
+        "properties": {
+          "name": "pipeline_with_custom_components",
+          "runtime": "Apache Airflow",
+          "description": "This is a pipeline description that\nincludes newline characters\n\n\"\"\"Note that it also includes a help string\"\"\""
+        },
+        "name": "pipeline_with_custom_components",
         "source": "pipeline_with_custom_components.json"
       },
       "runtime_ref": ""


### PR DESCRIPTION
Fixes #2461
This also fixes a recent bug (no corresponding issue currently open) where certain Airflow operators were causing an error popup with JsonDecodeError due to unescaped characters in property descriptions.

### What changes were proposed in this pull request?
- Converts pipeline descriptions and node comments (in the airflow DAG template) to multi-line strings (`"""`) using the jinja `replace` filter and escapes any other existing instances of `"""` to avoid `black` formatting errors after DAG render.

DAG:
<img width="1232" alt="Screen Shot 2022-02-10 at 12 11 04 PM" src="https://user-images.githubusercontent.com/31816267/153470061-27205ee3-36f3-43be-97d9-55a10b396924.png">


Airflow GUI:
<img width="1283" alt="Screen Shot 2022-02-10 at 12 07 20 PM" src="https://user-images.githubusercontent.com/31816267/153469605-92c6c3a0-6ffe-4671-a6dd-b26414d2e76d.png">


- Converts property descriptions (in the canvas properties template) to JSON-safe strings using jinja's `tojson|safe` filter. This allows un-escaped characters to be caught before descriptions are converted to JSON in the properties API request.

Python operator file ([source](https://github.com/apache/airflow/blob/a2abf663157aea14525e1a55eb9735ba659ae8d6/airflow/providers/google/cloud/operators/datacatalog.py#L495-L496)):
<img width="828" alt="Screen Shot 2022-02-10 at 12 08 54 PM" src="https://user-images.githubusercontent.com/31816267/153469850-d9db1c6f-1b8d-4bc2-94b7-7bf6e0cd2a28.png">

Properties panel:
<img width="832" alt="Screen Shot 2022-02-10 at 12 12 53 PM" src="https://user-images.githubusercontent.com/31816267/153470385-77043352-0acd-4d6c-af7a-be33986cfc3f.png">



### How was this pull request tested?
A case has been added to an existing test for each scenario above.

This PR will remain in draft form until more manual testing occurs.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
