### PR TITLE
Fix default value rendering in properties template for KFP 'inputvalue' types

### DIFF
--- a/elyra/templates/components/canvas_properties_template.jinja2
+++ b/elyra/templates/components/canvas_properties_template.jinja2
@@ -9,12 +9,14 @@
         "activeControl": "{{ property.default_control_type }}",
         "{{ property.default_control_type }}":
     {% endif %}
+    {% set property_data_type = property.data_type %}
+    {% if property.data_type == 'inputvalue' %}{% set property_data_type = property.default_data_type %}{% endif %}
     {% if property.default_control_type == "EnumControl" %}
         null
-    {% elif property.data_type|lower == "bool" or property.data_type|lower == "boolean" %}
+    {% elif property_data_type|lower == "bool" or property_data_type|lower == "boolean" %}
         {{ property.value|lower }}
-    {% elif property.data_type|lower == "int" or property.data_type|lower == "integer" or
-            property.data_type|lower == "number" or property.data_type|lower == "float" %}
+    {% elif property_data_type|lower == "int" or property_data_type|lower == "integer" or
+            property_data_type|lower == "number" or property_data_type|lower == "float" %}
         {{ property.value }}
     {% else %}
         "{{ property.value }}"

--- a/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
@@ -200,25 +200,25 @@ def test_parse_kfp_component_file():
            {'StringControl': '', 'activeControl': 'StringControl'}
 
     assert properties_json['current_parameters']['elyra_test_bool_default'] == \
-           {'BooleanControl': 'False', 'activeControl': 'BooleanControl'}
+           {'BooleanControl': False, 'activeControl': 'BooleanControl'}
     assert properties_json['current_parameters']['elyra_test_bool_false'] == \
-           {'BooleanControl': 'False', 'activeControl': 'BooleanControl'}
+           {'BooleanControl': False, 'activeControl': 'BooleanControl'}
     assert properties_json['current_parameters']['elyra_test_bool_true'] == \
-           {'BooleanControl': 'True', 'activeControl': 'BooleanControl'}
+           {'BooleanControl': True, 'activeControl': 'BooleanControl'}
 
     assert properties_json['current_parameters']['elyra_test_int_default'] == \
-           {'NumberControl': '0', 'activeControl': 'NumberControl'}
+           {'NumberControl': 0, 'activeControl': 'NumberControl'}
     assert properties_json['current_parameters']['elyra_test_int_zero'] == \
-           {'NumberControl': '0', 'activeControl': 'NumberControl'}
+           {'NumberControl': 0, 'activeControl': 'NumberControl'}
     assert properties_json['current_parameters']['elyra_test_int_non_zero'] == \
-           {'NumberControl': '1', 'activeControl': 'NumberControl'}
+           {'NumberControl': 1, 'activeControl': 'NumberControl'}
 
     assert properties_json['current_parameters']['elyra_test_float_default'] == \
-           {'NumberControl': '0.0', 'activeControl': 'NumberControl'}
+           {'NumberControl': 0.0, 'activeControl': 'NumberControl'}
     assert properties_json['current_parameters']['elyra_test_float_zero'] == \
-           {'NumberControl': '0.0', 'activeControl': 'NumberControl'}
+           {'NumberControl': 0.0, 'activeControl': 'NumberControl'}
     assert properties_json['current_parameters']['elyra_test_float_non_zero'] == \
-           {'NumberControl': '1.0', 'activeControl': 'NumberControl'}
+           {'NumberControl': 1.0, 'activeControl': 'NumberControl'}
 
     assert properties_json['current_parameters']['elyra_test_dict_default'] == \
            {'StringControl': '{}', 'activeControl': 'StringControl'}  # {}
@@ -408,19 +408,19 @@ async def test_parse_components_additional_metatypes():
     assert properties_json['current_parameters']['elyra_network_json'] == 'None'  # inputPath
     assert properties_json['current_parameters']['elyra_loss_name'] == {'StringControl': 'categorical_crossentropy',
                                                                         'activeControl': 'StringControl'}
-    assert properties_json['current_parameters']['elyra_num_classes'] == {'NumberControl': '0',
+    assert properties_json['current_parameters']['elyra_num_classes'] == {'NumberControl': 0,
                                                                           'activeControl': 'NumberControl'}
     assert properties_json['current_parameters']['elyra_optimizer'] == {'StringControl': 'rmsprop',
                                                                         'activeControl': 'StringControl'}
     assert properties_json['current_parameters']['elyra_optimizer_config'] == {'StringControl': '',
                                                                                'activeControl': 'StringControl'}
-    assert properties_json['current_parameters']['elyra_learning_rate'] == {'NumberControl': '0.01',
+    assert properties_json['current_parameters']['elyra_learning_rate'] == {'NumberControl': 0.01,
                                                                             'activeControl': 'NumberControl'}
-    assert properties_json['current_parameters']['elyra_num_epochs'] == {'NumberControl': '100',
+    assert properties_json['current_parameters']['elyra_num_epochs'] == {'NumberControl': 100,
                                                                          'activeControl': 'NumberControl'}
-    assert properties_json['current_parameters']['elyra_batch_size'] == {'NumberControl': '32',
+    assert properties_json['current_parameters']['elyra_batch_size'] == {'NumberControl': 32,
                                                                          'activeControl': 'NumberControl'}
     assert properties_json['current_parameters']['elyra_metrics'] == {'StringControl': "['accuracy']",
                                                                       'activeControl': 'StringControl'}
-    assert properties_json['current_parameters']['elyra_random_seed'] == {'NumberControl': '0',
+    assert properties_json['current_parameters']['elyra_random_seed'] == {'NumberControl': 0,
                                                                           'activeControl': 'NumberControl'}


### PR DESCRIPTION
Fixes #2466 

### What changes were proposed in this pull request?
This PR updates the jinja properties template for custom components to pull the correct value when checking data types. If the `property.data_type` == `inputvalue`, the `property.default_data_type` attribute must be used to access the fallback type information (e.g. whether it is boolean, integer/number, string, etc.) and render the default value in the appropriate form.

### How was this pull request tested?
Some tests needed to be updated to check against the correct data type, e.g. checking against the value `True` instead of the string `'True'`.

More specifically, the problem noted in #2466 is solved as evidenced by the following screenshot of the KFP `Test Operator` properties where the property with the default value of `False` is shown initially as an un-checked box:

<img width="757" alt="Screen Shot 2022-02-10 at 1 26 01 PM" src="https://user-images.githubusercontent.com/31816267/153481998-80828a96-6757-4c50-9baf-d88d3eb5a417.png">


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
