### PR TITLE
Add eslint rule for type-safe equality operators

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,7 +48,8 @@
         "alphabetize": { "order": "asc", "caseInsensitive": true },
         "newlines-between": "always-and-inside-groups"
       }
-    ]
+    ],
+    "eqeqeq": ["warn", "always"]
   },
   "overrides": [
     {

--- a/packages/code-snippet/src/CodeSnippetWidget.tsx
+++ b/packages/code-snippet/src/CodeSnippetWidget.tsx
@@ -443,7 +443,7 @@ class CodeSnippetDisplay extends MetadataDisplay<
                   this.props.shell.widgets('main'),
                   (value: Widget, index: number) => {
                     return (
-                      value.id ==
+                      value.id ===
                       `${METADATA_EDITOR_ID}:${CODE_SNIPPET_SCHEMASPACE}:${CODE_SNIPPET_SCHEMA}:${metadata.name}`
                     );
                   }

--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -74,7 +74,7 @@ const extension: JupyterFrontEndPlugin<void> = {
       const openWidget = find(
         app.shell.widgets('main'),
         (widget: Widget, index: number) => {
-          return widget.id == widgetId;
+          return widget.id === widgetId;
         }
       );
       if (openWidget) {
@@ -122,7 +122,7 @@ const extension: JupyterFrontEndPlugin<void> = {
       metadataWidget.title.caption = args.display_name;
 
       if (
-        find(app.shell.widgets('left'), value => value.id === widgetId) ==
+        find(app.shell.widgets('left'), value => value.id === widgetId) ===
         undefined
       ) {
         app.shell.add(metadataWidget, 'left', { rank: 1000 });

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -648,7 +648,7 @@ const PipelineWrapper: React.FC<IProps> = ({
 
       const dialogResult = await showFormDialog(dialogOptions);
 
-      if (dialogResult.value == null) {
+      if (dialogResult.value === null) {
         // When Cancel is clicked on the dialog, just return
         return;
       }

--- a/packages/pipeline-editor/src/PipelineService.tsx
+++ b/packages/pipeline-editor/src/PipelineService.tsx
@@ -159,7 +159,7 @@ export class PipelineService {
         dialogTitle = 'Job submission to ' + runtimeName + ' succeeded';
         dialogBody = (
           <p>
-            {response['platform'] == 'APACHE_AIRFLOW' ? (
+            {response['platform'] === 'APACHE_AIRFLOW' ? (
               <p>
                 Apache Airflow DAG has been pushed to the{' '}
                 <a

--- a/packages/pipeline-editor/src/SubmitFileButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitFileButtonExtension.tsx
@@ -107,7 +107,7 @@ export class SubmitFileButtonExtension<
 
     const dialogResult = await showFormDialog(dialogOptions);
 
-    if (dialogResult.value == null) {
+    if (dialogResult.value === null) {
       // When Cancel is clicked on the dialog, just return
       return;
     }

--- a/packages/services/src/requests.ts
+++ b/packages/services/src/requests.ts
@@ -203,10 +203,10 @@ export class RequestHandler {
             },
             // handle 404 if the server is not found
             (reason: any) => {
-              if (response.status == 404) {
+              if (response.status === 404) {
                 response['requestPath'] = requestPath;
                 return reject(response);
-              } else if (response.status == 204) {
+              } else if (response.status === 204) {
                 resolve({});
               } else {
                 return reject(reason);

--- a/packages/ui-components/src/RequestErrors.tsx
+++ b/packages/ui-components/src/RequestErrors.tsx
@@ -48,7 +48,7 @@ export class RequestErrors {
    * @returns A promise that resolves with whether the dialog was accepted.
    */
   static serverError(response: any): Promise<Dialog.IResult<any>> {
-    if (response.status == 404) {
+    if (response.status === 404) {
       return this.server404(response.requestPath);
     }
 


### PR DESCRIPTION
In JS and TS, it is considered good practice to use the type-safe equality operators `===` and `!==` instead of ` ==` and `!=` to avoid possible obscure type castings in comparisons. For instance, the following statements are all considered true 🤷‍♀️
```
[] == false
[] == ![]
3 == "03"
```
 Elyra should enforce type-safe equality operators to avoid future errors/misleading behaviors not that obvious to spot related to the operators above.

### What changes were proposed in this pull request?
Add eslint rule to enforce type-safe equality operators.
Fix existing comparisons with `==` found in code.

### How was this pull request tested?
Run `make install-ui` runs `eslint-ui`
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
