### PR TITLE
Fix submit file dialog message

### DIFF
--- a/packages/pipeline-editor/src/SubmitFileButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitFileButtonExtension.tsx
@@ -30,9 +30,9 @@ import { createRuntimeData, getConfigDetails } from './runtime-utils';
 import Utils from './utils';
 
 /**
- * Submit notebook button extension
- *  - Attach button to notebook toolbar and launch a dialog requesting
- *  information about the remote location to where submit the notebook
+ * Submit file button extension
+ *  - Attach button to editor toolbar and launch a dialog requesting
+ *  information about the remote location to where submit the file
  *  for execution
  */
 
@@ -45,7 +45,7 @@ export class SubmitFileButtonExtension<
     if (context.model.dirty) {
       const dialogResult = await showDialog({
         title:
-          'This notebook contains unsaved changes. To run the notebook as pipeline the changes need to be saved.',
+          'This file contains unsaved changes. To run the file as pipeline the changes need to be saved.',
         buttons: [
           Dialog.cancelButton(),
           Dialog.okButton({ label: 'Save and Submit' })
@@ -125,7 +125,7 @@ export class SubmitFileButtonExtension<
 
     const configDetails = getConfigDetails(runtimeData, runtime_config);
 
-    // prepare notebook submission details
+    // prepare file submission details
     const pipeline = Utils.generateSingleFilePipeline(
       context.path,
       configDetails,
@@ -151,7 +151,7 @@ export class SubmitFileButtonExtension<
       tooltip: 'Run file as batch'
     });
 
-    // Add the toolbar button to the notebook
+    // Add the toolbar button to the editor
     editor.toolbar.insertItem(10, 'submitFile', submitFileButton);
 
     // The ToolbarButton class implements `IDisposable`, so the

--- a/tests/integration/scripteditor.ts
+++ b/tests/integration/scripteditor.ts
@@ -44,7 +44,7 @@ describe('Script Editor tests', () => {
   });
 
   it('close editor', () => {
-    cy.get('.lm-TabBar-tabCloseIcon:visible').click();
+    cy.closeTab(-1);
   });
 
   it('open Python file with expected content', () => {
@@ -76,19 +76,37 @@ describe('Script Editor tests', () => {
       cy.findByText(/test runtime/i).should('exist');
     });
     // Click Run as Pipeline button
-    cy.contains('Run as Pipeline').click();
+    cy.findByText(/run as pipeline/i).click();
     // Check for expected dialog title
     cy.get('.jp-Dialog-header').should('have.text', 'Run file as pipeline');
     // Dismiss  dialog
     cy.get('button.jp-mod-reject').click();
 
     // Close editor tab
-    cy.get('.lm-TabBar-tabCloseIcon:visible')
-      .eq(1)
-      .click();
+    cy.closeTab(-1);
+  });
 
-    // go back to file browser
-    cy.get('.lm-TabBar-tab[data-id="filebrowser"]').click();
+  it('click the Run as Pipeline button on unsaved file should display save dialog', () => {
+    // Create new python file
+    cy.createNewScriptFile('Python');
+
+    // Add some text to the editor
+    cy.get('span[role="presentation"]').type('print("test")');
+
+    // Click Run as Pipeline button
+    cy.findByText(/run as pipeline/i).click();
+
+    // Check expected save and submit dialog message
+    cy.contains('.jp-Dialog-header', /this file contains unsaved changes/i);
+
+    // Dismiss save and submit dialog
+    cy.get('button.jp-mod-reject').click();
+
+    // Close editor tab
+    cy.closeTab(-1);
+
+    // Dismiss save your work dialog by discarding changes
+    cy.get('button.jp-mod-warn').click();
   });
 
   // R Tests
@@ -102,7 +120,7 @@ describe('Script Editor tests', () => {
   });
 
   it('close R editor', () => {
-    cy.get('.lm-TabBar-tabCloseIcon:visible').click();
+    cy.closeTab(-1);
   });
 
   it('open R file with expected content', () => {
@@ -127,7 +145,7 @@ describe('Script Editor tests', () => {
     cy.get(
       '#filebrowser [title*="Name: untitled1.py"] svg[data-icon="elyra:pyIcon"]'
     );
-    cy.get('.lm-TabBar-tabCloseIcon:visible').click();
+    cy.closeTab(-1);
 
     // Check r icons from launcher & file explorer
     cy.get(
@@ -136,7 +154,7 @@ describe('Script Editor tests', () => {
     cy.get(
       '#filebrowser [title*="Name: untitled1.r"] svg[data-icon="elyra:rIcon"]'
     );
-    cy.get('.lm-TabBar-tabCloseIcon:visible').click();
+    cy.closeTab(-1);
   });
 
   it('opens blank R file from menu', () => {
@@ -228,13 +246,11 @@ const openFileAndCheckContent = (fileExtension: string): void => {
   cy.get('input#jp-dialog-input-id').type(`/helloworld.${fileExtension}`);
   cy.get('.p-Panel .jp-mod-accept').click();
 
-  // Ensure that the files contants are as expected
+  // Ensure that the file contents are as expected
   cy.get('span[role="presentation"]').should($span => {
     expect($span.get(0).innerText).to.eq("print('Hello Elyra')");
   });
 
   // Close the file editor
-  cy.get('.lm-TabBar-tabCloseIcon:visible')
-    .last()
-    .click();
+  cy.closeTab(-1);
 };


### PR DESCRIPTION
Fixes #2484 

### What changes were proposed in this pull request?
Remove notebook references from save and submit dialog in `SubmitFileButtonExtension` 
![image](https://user-images.githubusercontent.com/25207344/154566677-72c8a500-3b40-4bae-945a-6ad1420ac8b7.png)

### How was this pull request tested?
New integration test added.
Reuse existing `closeTab()` cypress command in script editor test file.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
