### PR TITLE
Support well-defined ComponentDefinition return values for catalog connectors

### DIFF
--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -42,7 +42,7 @@ class AirflowComponentParser(ComponentParser):
     def parse(self, registry_entry: SimpleNamespace) -> Optional[List[Component]]:
         components: List[Component] = []
 
-        component_definition = registry_entry.component_definition
+        component_definition = registry_entry.entry_data.definition
         if not component_definition:
             return None
 
@@ -51,7 +51,7 @@ class AirflowComponentParser(ComponentParser):
             parsed_class_nodes = self._parse_all_classes(component_definition)
             num_operator_classes = len(parsed_class_nodes)
         except Exception as e:
-            self.log.error(f"Content associated with identifier '{registry_entry.component_identifier}' "
+            self.log.error(f"Content associated with identifier '{registry_entry.entry_data.identifier_as_string}' "
                            f"could not be parsed: {e}. Skipping...")
             return None
 
@@ -59,12 +59,12 @@ class AirflowComponentParser(ComponentParser):
             if not content.get('init_function'):
                 # Without the init function, class can't be parsed for properties
                 self.log.warning(f"Operator '{component_class}' associated with identifier "
-                                 f"'{registry_entry.component_identifier}' does not have an __init__ "
+                                 f"'{registry_entry.entry_data.identifier_as_string}' does not have an __init__ "
                                  f"function. Skipping...")
                 continue
 
             # Assign component name and unique id
-            component_id = registry_entry.component_id
+            component_id = registry_entry.entry_data.entry_id
             if num_operator_classes > 1:
                 # This file contains more than one operator and id must be adjusted
                 # to include the Operator class name as well
@@ -75,7 +75,7 @@ class AirflowComponentParser(ComponentParser):
                 component_properties: List[ComponentParameter] = self._parse_properties_from_init(**content)
             except Exception as e:
                 self.log.error(f"Properties of operator '{component_class}' associated with "
-                               f"identifier '{registry_entry.component_identifier}' could not be "
+                               f"identifier '{registry_entry.entry_data.identifier_as_string}' could not be "
                                f"parsed: {e}. Skipping...")
                 continue
 
@@ -84,7 +84,7 @@ class AirflowComponentParser(ComponentParser):
                 name=component_class,
                 description=DEFAULT_DESCRIPTION,
                 catalog_type=registry_entry.catalog_type,
-                source_identifier=registry_entry.component_identifier,
+                source_identifier=registry_entry.entry_data.identifier,
                 definition=component_definition,
                 runtime_type=self.component_platform.name,
                 categories=registry_entry.categories,

--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -88,7 +88,8 @@ class AirflowComponentParser(ComponentParser):
                 definition=component_definition,
                 runtime_type=self.component_platform.name,
                 categories=registry_entry.categories,
-                properties=component_properties
+                properties=component_properties,
+                package_name=getattr(registry_entry.entry_data, 'package_name', None)
             )
 
             components.append(new_component)

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -353,8 +353,8 @@ be fully qualified (i.e., prefixed with their package names).
 
                 # Locate the import statement. If not found raise...
                 import_stmts = []
-                # Check for package name on Component object, otherwise get from class_import_map
-                import_stmt = component.package_name or self.class_import_map.get(component.name)
+                # Check for import statement on Component object, otherwise get from class_import_map
+                import_stmt = component.import_statement or self.class_import_map.get(component.name)
                 if import_stmt:
                     import_stmts.append(import_stmt)
                 else:

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -353,7 +353,8 @@ be fully qualified (i.e., prefixed with their package names).
 
                 # Locate the import statement. If not found raise...
                 import_stmts = []
-                import_stmt = self.class_import_map.get(component.name)
+                # Check for package name on Component object, otherwise get from class_import_map
+                import_stmt = component.package_name or self.class_import_map.get(component.name)
                 if import_stmt:
                     import_stmts.append(import_stmt)
                 else:

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -351,7 +351,6 @@ class ComponentCatalogConnector(LoggingConfigurable):
                 keys_to_hash = ComponentCatalogConnector.get_hash_keys()
 
             except Exception:
-                print('hello!')
                 keys_to_hash = self.get_hash_keys()
 
             # Add display_name attribute to the metadata dictionary

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -123,7 +123,7 @@ class ComponentCatalogConnector(LoggingConfigurable):
 
         For example, the FilesystemCatalogConnector includes both a base directory ('base_dir') key-value
         pair and a relative path ('path') key-value pair in its 'catalog_entry_data' dict. Both fields
-        are needed in order to access the corresponding component definition in read_catalog_entry().
+        are needed in order to access the corresponding component definition in get_component_definition().
 
         Every catalog_entry_data should contain each of the keys returned in get_hash_keys() to ensure
         uniqueness and portability among entries. For the same reason, no two catalog entries should have
@@ -143,7 +143,7 @@ class ComponentCatalogConnector(LoggingConfigurable):
                     }
 
         :returns: a list of catalog entry dictionaries, each of which contains the information
-                  needed to access a component definition in read_catalog_entry()
+                  needed to access a component definition in get_component_definition()
         """
         raise NotImplementedError(
             "abstract method 'get_catalog_entries()' must be implemented"
@@ -221,8 +221,8 @@ class ComponentCatalogConnector(LoggingConfigurable):
         also enables pipeline portability across installations when the keys returned here are
         chosen strategically. For example, the FilesystemCatalogConnector includes both a base
         directory key-value pair and a relative path key-value pair in its 'catalog_entry_data' dict.
-        Both fields are required to access the component definition in read_catalog_entry(), but
-        only the relative path field is used to create the unique hash. This allows a component
+        Both fields are required to access the component definition in get_component_definition(),
+        but only the relative path field is used to create the unique hash. This allows a component
         that has the same relative path defined in two separate a catalogs in two separate
         installations to resolve to the same unique id in each, and therefore to be portable across
         pipelines in these installations.

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -27,12 +27,14 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+from deprecation import deprecated
 from jupyter_core.paths import ENV_JUPYTER_PATH
 import requests
 from traitlets.config import LoggingConfigurable
 from traitlets.traitlets import default
 from traitlets.traitlets import Integer
 
+from elyra._version import __version__
 from elyra.metadata.metadata import Metadata
 
 
@@ -149,7 +151,9 @@ class ComponentCatalogConnector(LoggingConfigurable):
             "abstract method 'get_catalog_entries()' must be implemented"
         )
 
-    @abstractmethod
+    @deprecated(deprecated_in="3.7.0", removed_in="4.0",
+                current_version=__version__,
+                details="Implement the get_component_definition function instead")
     def read_catalog_entry(self,
                            catalog_entry_data: Dict[str, Any],
                            catalog_metadata: Dict[str, Any]) -> Optional[str]:

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -291,8 +291,10 @@ class Component(object):
         return self._parameter_refs
 
     @property
-    def package_name(self) -> str:
-        return self._package_name
+    def import_statement(self) -> Optional[str]:
+        if not self._package_name:
+            return None
+        return f"from {self._package_name} import {self._name}"
 
     @property
     def input_properties(self) -> List[ComponentParameter]:

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -171,7 +171,7 @@ class Component(object):
                  name: str,
                  description: Optional[str],
                  catalog_type: str,
-                 source_identifier: Any,
+                 component_reference: Any,
                  definition: Optional[str] = None,
                  runtime_type: Optional[str] = None,
                  op: Optional[str] = None,
@@ -186,7 +186,7 @@ class Component(object):
         :param description: The description of the component
         :param catalog_type: Indicates the type of component definition resource
                               location; one of ['url', filename', 'directory]
-        :param source_identifier: Source information to help locate the component definition
+        :param component_reference: Source information to help locate the component definition
         :param definition: The content of the specification file for this component
         :param runtime_type: The runtime type of the component (e.g. KUBEFLOW_PIPELINES, APACHE_AIRFLOW, etc.)
         :param op: The operation name of the component; used by generic components in rendering the palette
@@ -207,7 +207,7 @@ class Component(object):
         self._name = name
         self._description = description
         self._catalog_type = catalog_type
-        self._source_identifier = source_identifier
+        self._component_reference = component_reference
 
         self._definition = definition
         self._runtime_type = runtime_type
@@ -249,14 +249,19 @@ class Component(object):
         return self._catalog_type
 
     @property
-    def source_identifier(self) -> Any:
-        return self._source_identifier
+    def component_reference(self) -> Any:
+        return self._component_reference
 
     @property
     def component_source(self) -> str:
+        """
+        Informational property consisting of the catalog type from which
+        this component originates and the reference information used to
+        locate it within that catalog.
+        """
         return str({
             "catalog_type": self.catalog_type,
-            "component_ref": self.source_identifier
+            "component_ref": self.component_reference
         })
 
     @property

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -178,7 +178,8 @@ class Component(object):
                  categories: Optional[List[str]] = None,
                  properties: Optional[List[ComponentParameter]] = None,
                  extensions: Optional[List[str]] = None,
-                 parameter_refs: Optional[dict] = None):
+                 parameter_refs: Optional[dict] = None,
+                 package_name: Optional[str] = None):
         """
         :param id: Unique identifier for a component
         :param name: The name of the component for display
@@ -193,6 +194,8 @@ class Component(object):
                            in the palette
         :param properties: The set of properties for the component
         :param extensions: The file extension used by the component
+        :param package_name: The fully qualified package name (excluding class name) of the file associated
+            with this component
         """
 
         if not id:
@@ -227,6 +230,7 @@ class Component(object):
 
         self._extensions = extensions
         self._parameter_refs = parameter_refs
+        self._package_name = package_name
 
     @property
     def id(self) -> str:
@@ -285,6 +289,10 @@ class Component(object):
     @property
     def parameter_refs(self) -> dict:
         return self._parameter_refs
+
+    @property
+    def package_name(self) -> str:
+        return self._package_name
 
     @property
     def input_properties(self) -> List[ComponentParameter]:

--- a/elyra/pipeline/component_catalog.py
+++ b/elyra/pipeline/component_catalog.py
@@ -301,13 +301,13 @@ class ComponentCache(SingletonConfigurable):
 
         # Get content of component definition file for each component in this catalog
         self.log.debug(f"Processing components in catalog '{catalog.display_name}'")
-        component_entries = catalog_reader.read_component_definitions(catalog)
-        if not component_entries:
+        component_definitions = catalog_reader.read_component_definitions(catalog)
+        if not component_definitions:
             return components
 
-        for entry_data in component_entries:
+        for component_definition in component_definitions:
             component_entry = {
-                "entry_data": entry_data,
+                "component_definition": component_definition,
                 "catalog_type": catalog.schema_name,
                 "categories": catalog.metadata.get("categories", [])
             }

--- a/elyra/pipeline/component_catalog.py
+++ b/elyra/pipeline/component_catalog.py
@@ -20,7 +20,6 @@ from queue import Queue
 from threading import Event
 from threading import Thread
 import time
-from types import SimpleNamespace
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -173,7 +172,7 @@ class ComponentCache(SingletonConfigurable):
                               description="Run notebook file",
                               op="execute-notebook-node",
                               catalog_type="elyra",
-                              source_identifier="elyra",
+                              component_reference="elyra",
                               extensions=[".ipynb"],
                               categories=[_generic_category_label]),
         "python-script": Component(id="python-script",
@@ -181,7 +180,7 @@ class ComponentCache(SingletonConfigurable):
                                    description="Run Python script",
                                    op="execute-python-node",
                                    catalog_type="elyra",
-                                   source_identifier="elyra",
+                                   component_reference="elyra",
                                    extensions=[".py"],
                                    categories=[_generic_category_label]),
         "r-script": Component(id="r-script",
@@ -189,7 +188,7 @@ class ComponentCache(SingletonConfigurable):
                               description="Run R script",
                               op="execute-r-node",
                               catalog_type="elyra",
-                              source_identifier="elyra",
+                              component_reference="elyra",
                               extensions=[".r"],
                               categories=[_generic_category_label])}
 
@@ -301,19 +300,13 @@ class ComponentCache(SingletonConfigurable):
 
         # Get content of component definition file for each component in this catalog
         self.log.debug(f"Processing components in catalog '{catalog.display_name}'")
-        component_definitions = catalog_reader.read_component_definitions(catalog)
-        if not component_definitions:
+        catalog_entries = catalog_reader.read_component_definitions(catalog)
+        if not catalog_entries:
             return components
 
-        for component_definition in component_definitions:
-            component_entry = {
-                "component_definition": component_definition,
-                "catalog_type": catalog.schema_name,
-                "categories": catalog.metadata.get("categories", [])
-            }
-
-            # Parse the component entry to get a fully qualified Component object
-            parsed_components = parser.parse(SimpleNamespace(**component_entry)) or []
+        for catalog_entry in catalog_entries:
+            # Parse the entry to get a fully qualified Component object
+            parsed_components = parser.parse(catalog_entry) or []
             for component in parsed_components:
                 components[component.id] = component
 

--- a/elyra/pipeline/component_catalog.py
+++ b/elyra/pipeline/component_catalog.py
@@ -301,17 +301,15 @@ class ComponentCache(SingletonConfigurable):
 
         # Get content of component definition file for each component in this catalog
         self.log.debug(f"Processing components in catalog '{catalog.display_name}'")
-        component_data_dict = catalog_reader.read_component_definitions(catalog)
-        if not component_data_dict:
+        component_entries = catalog_reader.read_component_definitions(catalog)
+        if not component_entries:
             return components
 
-        for component_id, component_data in component_data_dict.items():
+        for entry_data in component_entries:
             component_entry = {
-                "component_id": component_id,
+                "entry_data": entry_data,
                 "catalog_type": catalog.schema_name,
-                "categories": catalog.metadata.get("categories", []),
-                "component_definition": component_data.get('definition'),
-                "component_identifier": component_data.get('identifier')
+                "categories": catalog.metadata.get("categories", [])
             }
 
             # Parse the component entry to get a fully qualified Component object

--- a/elyra/pipeline/kfp/component_parser_kfp.py
+++ b/elyra/pipeline/kfp/component_parser_kfp.py
@@ -48,12 +48,12 @@ class KfpComponentParser(ComponentParser):
         component_properties = self._parse_properties(component_yaml)
 
         component = Component(
-            id=registry_entry.entry_data.entry_id,
+            id=registry_entry.component_definition.id,
             name=component_yaml.get('name'),
             description=description,
             catalog_type=registry_entry.catalog_type,
-            source_identifier=registry_entry.entry_data.identifier,
-            definition=registry_entry.entry_data.definition,
+            source_identifier=registry_entry.component_definition.identifier,
+            definition=registry_entry.component_definition.definition,
             runtime_type=self.component_platform.name,
             categories=registry_entry.categories,
             properties=component_properties
@@ -167,10 +167,10 @@ class KfpComponentParser(ComponentParser):
         Convert component_definition string to YAML object
         """
         try:
-            return yaml.safe_load(registry_entry.entry_data.definition)
+            return yaml.safe_load(registry_entry.component_definition.definition)
         except Exception as e:
             self.log.warning(f"Could not load YAML definition for component with identifying information: "
-                             f"'{registry_entry.entry_data.identifier_as_string}' -> {str(e)}")
+                             f"'{registry_entry.component_definition.identifier_as_string}' -> {str(e)}")
             return None
 
     def _is_path_based_parameter(self, parameter_name: str, component_body: Dict[str, Any]) -> bool:

--- a/elyra/pipeline/kfp/component_parser_kfp.py
+++ b/elyra/pipeline/kfp/component_parser_kfp.py
@@ -48,12 +48,12 @@ class KfpComponentParser(ComponentParser):
         component_properties = self._parse_properties(component_yaml)
 
         component = Component(
-            id=registry_entry.component_id,
+            id=registry_entry.entry_data.entry_id,
             name=component_yaml.get('name'),
             description=description,
             catalog_type=registry_entry.catalog_type,
-            source_identifier=registry_entry.component_identifier,
-            definition=registry_entry.component_definition,
+            source_identifier=registry_entry.entry_data.identifier,
+            definition=registry_entry.entry_data.definition,
             runtime_type=self.component_platform.name,
             categories=registry_entry.categories,
             properties=component_properties
@@ -167,10 +167,10 @@ class KfpComponentParser(ComponentParser):
         Convert component_definition string to YAML object
         """
         try:
-            return yaml.safe_load(registry_entry.component_definition)
+            return yaml.safe_load(registry_entry.entry_data.definition)
         except Exception as e:
             self.log.warning(f"Could not load YAML definition for component with identifying information: "
-                             f"'{str(registry_entry.component_identifier)}' -> {str(e)}")
+                             f"'{registry_entry.entry_data.identifier_as_string}' -> {str(e)}")
             return None
 
     def _is_path_based_parameter(self, parameter_name: str, component_body: Dict[str, Any]) -> bool:

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -183,7 +183,7 @@ def test_parse_airflow_component_file():
 
     # Build entry for parsing
     entry = {
-        "entry_data": component_definition,
+        "component_definition": component_definition,
         "catalog_type": catalog_type,
         "categories": ["Test"]
     }
@@ -240,7 +240,8 @@ def test_parse_airflow_component_file():
     # Ensure system parameters are not prefixed and hold correct values
     assert properties_json['current_parameters']['label'] == ''
 
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.entry_data.identifier})
+    component_identifier = component_entry.component_definition.identifier
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_identifier})
     assert properties_json['current_parameters']['component_source'] == component_source
 
     # Ensure component parameters are prefixed with 'elyra_' and values are as expected
@@ -359,7 +360,7 @@ def test_parse_airflow_component_url():
 
     # Build entry for parsing
     entry = {
-        "entry_data": component_definition,
+        "component_definition": component_definition,
         "catalog_type": catalog_type,
         "categories": ["Test"]
     }
@@ -378,7 +379,8 @@ def test_parse_airflow_component_url():
         property_dict = properties_json['current_parameters'][param_name]
         return property_dict[property_dict['activeControl']]
 
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.entry_data.identifier})
+    component_identifier = component_entry.component_definition.identifier
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_identifier})
     assert properties_json['current_parameters']['component_source'] == component_source
     assert get_parameter('elyra_bash_command') == ''
     assert get_parameter('elyra_xcom_push') is True
@@ -403,7 +405,7 @@ def test_parse_airflow_component_file_no_inputs():
 
     # Build entry for parsing
     entry = {
-        "entry_data": component_definition,
+        "component_definition": component_definition,
         "catalog_type": catalog_type,
         "categories": ["Test"]
     }
@@ -429,7 +431,8 @@ def test_parse_airflow_component_file_no_inputs():
     # Ensure that template still renders the two common parameters correctly
     assert properties_json['current_parameters']['label'] == ""
 
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.entry_data.identifier})
+    component_identifier = component_entry.component_definition.identifier
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_identifier})
     assert properties_json['current_parameters']['component_source'] == component_source
 
 

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -22,6 +22,7 @@ import jupyter_core.paths
 import pytest
 
 from elyra.metadata.metadata import Metadata
+from elyra.pipeline.catalog_connector import ComponentDefinition
 from elyra.pipeline.catalog_connector import FilesystemComponentCatalogConnector
 from elyra.pipeline.catalog_connector import UrlComponentCatalogConnector
 from elyra.pipeline.component import ComponentParser
@@ -172,18 +173,19 @@ def test_parse_airflow_component_file():
 
     path = _get_resource_path('airflow_test_operator.py')
 
+    catalog_type = "local-file-catalog"
+
     # Read contents of given path -- read_component_definition() returns a
     # a dictionary of component definition content indexed by path
-    component_definition = reader.read_catalog_entry({"path": path}, {})
+    definition = reader.read_catalog_entry({"path": path}, {})
+    component_definition = ComponentDefinition(definition, {"path": path})
+    component_definition.set_entry_id(catalog_type, ['path'])
 
     # Build entry for parsing
-    catalog_type = "local-file-catalog"
     entry = {
-        "component_id": reader.get_unique_component_hash(catalog_type, {"path": path}, ["path"]),
+        "entry_data": component_definition,
         "catalog_type": catalog_type,
-        "categories": ["Test"],
-        "component_definition": component_definition,
-        "component_identifier": {"path": path}
+        "categories": ["Test"]
     }
     component_entry = SimpleNamespace(**entry)
 
@@ -238,7 +240,7 @@ def test_parse_airflow_component_file():
     # Ensure system parameters are not prefixed and hold correct values
     assert properties_json['current_parameters']['label'] == ''
 
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.component_identifier})
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.entry_data.identifier})
     assert properties_json['current_parameters']['component_source'] == component_source
 
     # Ensure component parameters are prefixed with 'elyra_' and values are as expected
@@ -346,18 +348,20 @@ def test_parse_airflow_component_url():
 
     url = 'https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/bash_operator.py'  # noqa: E501
 
+    catalog_type = "url-catalog"
+
     # Read contents of given path -- read_component_definition() returns a
     # a dictionary of component definition content indexed by path
-    component_definition = reader.read_catalog_entry({"url": url}, {})
+    definition = reader.read_catalog_entry({"url": url}, {})
+    component_definition = ComponentDefinition(definition, {"url": url})
+    component_definition.set_entry_id(catalog_type, ['url'
+                                                     ''])
 
     # Build entry for parsing
-    catalog_type = "url-catalog"
     entry = {
-        "component_id": reader.get_unique_component_hash(catalog_type, {"url": url}, ["url"]),
+        "entry_data": component_definition,
         "catalog_type": catalog_type,
-        "categories": ["Test"],
-        "component_definition": component_definition,
-        "component_identifier": {"url": url}
+        "categories": ["Test"]
     }
     component_entry = SimpleNamespace(**entry)
 
@@ -374,7 +378,7 @@ def test_parse_airflow_component_url():
         property_dict = properties_json['current_parameters'][param_name]
         return property_dict[property_dict['activeControl']]
 
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.component_identifier})
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.entry_data.identifier})
     assert properties_json['current_parameters']['component_source'] == component_source
     assert get_parameter('elyra_bash_command') == ''
     assert get_parameter('elyra_xcom_push') is True
@@ -389,18 +393,19 @@ def test_parse_airflow_component_file_no_inputs():
 
     path = _get_resource_path('airflow_test_operator_no_inputs.py')
 
+    catalog_type = "local-file-catalog"
+
     # Read contents of given path -- read_component_definition() returns a
     # a dictionary of component definition content indexed by path
-    component_definition = reader.read_catalog_entry({"path": path}, {})
+    definition = reader.read_catalog_entry({"path": path}, {})
+    component_definition = ComponentDefinition(definition, {"path": path})
+    component_definition.set_entry_id(catalog_type, ['path'])
 
     # Build entry for parsing
-    catalog_type = "local-file-catalog"
     entry = {
-        "component_id": reader.get_unique_component_hash(catalog_type, {"path": path}, ["path"]),
+        "entry_data": component_definition,
         "catalog_type": catalog_type,
-        "categories": ["Test"],
-        "component_definition": component_definition,
-        "component_identifier": {"path": path}
+        "categories": ["Test"]
     }
     component_entry = SimpleNamespace(**entry)
 
@@ -424,7 +429,7 @@ def test_parse_airflow_component_file_no_inputs():
     # Ensure that template still renders the two common parameters correctly
     assert properties_json['current_parameters']['label'] == ""
 
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.component_identifier})
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.entry_data.identifier})
     assert properties_json['current_parameters']['component_source'] == component_source
 
 

--- a/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 import os
-from types import SimpleNamespace
 
 from conftest import KFP_COMPONENT_CACHE_INSTANCE
 from conftest import TEST_CATALOG_NAME
@@ -22,10 +21,12 @@ import jupyter_core.paths
 import pytest
 
 from elyra.metadata.metadata import Metadata
-from elyra.pipeline.catalog_connector import ComponentDefinition
+from elyra.pipeline.catalog_connector import CatalogEntry
+from elyra.pipeline.catalog_connector import EntryData
 from elyra.pipeline.catalog_connector import FilesystemComponentCatalogConnector
 from elyra.pipeline.catalog_connector import UrlComponentCatalogConnector
 from elyra.pipeline.component_catalog import ComponentCache
+from elyra.pipeline.component_metadata import ComponentCatalogMetadata
 from elyra.pipeline.kfp.component_parser_kfp import KfpComponentParser
 from elyra.pipeline.runtime_type import RuntimeProcessorType
 
@@ -165,34 +166,34 @@ def test_parse_kfp_component_file():
     kfp_supported_file_types = [".yaml"]
     reader = FilesystemComponentCatalogConnector(kfp_supported_file_types)
 
+    # Read contents of given path
     path = _get_resource_path('kfp_test_operator.yaml')
+    catalog_entry_data = {"path": path}
+    definition = reader.read_catalog_entry(catalog_entry_data, {})
 
+    # Construct a catalog instance
     catalog_type = "local-file-catalog"
+    catalog_instance = ComponentCatalogMetadata(
+        schema_name=catalog_type,
+        metadata={
+            "categories": ['Test'],
+            "runtime_type": RUNTIME_PROCESSOR.name
+        }
+    )
 
-    # Read contents of given path -- read_component_definition() returns a
-    # a dictionary of component definition content indexed by path
-    definition = reader.read_catalog_entry({"path": path}, {})
-    component_definition = ComponentDefinition(definition, {"path": path})
-    component_definition.set_entry_id(catalog_type, ['path'])
-
-    # Build entry for parsing
-    entry = {
-        "component_definition": component_definition,
-        "catalog_type": catalog_type,
-        "categories": ["Test"]
-    }
-    component_entry = SimpleNamespace(**entry)
+    # Build the catalog entry data structures required for parsing
+    entry_data = EntryData(definition)
+    catalog_entry = CatalogEntry(entry_data, catalog_entry_data, catalog_instance, ['path'])
 
     # Parse the component entry
     parser = KfpComponentParser.create_instance(platform=RUNTIME_PROCESSOR)
-    component = parser.parse(component_entry)[0]
+    component = parser.parse(catalog_entry)[0]
     properties_json = ComponentCache.to_canvas_properties(component)
 
     # Ensure component parameters are prefixed (and system parameters are not) and all hold correct values
     assert properties_json['current_parameters']['label'] == ''
 
-    component_identifier = component_entry.component_definition.identifier
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_identifier})
+    component_source = str({"catalog_type": catalog_type, "component_ref": catalog_entry.entry_reference})
     assert properties_json['current_parameters']['component_source'] == component_source
     assert properties_json['current_parameters']['elyra_test_string_no_default'] == \
            {'StringControl': '', 'activeControl': 'StringControl'}
@@ -278,34 +279,34 @@ def test_parse_kfp_component_url():
     kfp_supported_file_types = [".yaml"]
     reader = UrlComponentCatalogConnector(kfp_supported_file_types)
 
+    # Read contents of given path
     url = 'https://raw.githubusercontent.com/kubeflow/pipelines/1.4.1/components/notebooks/Run_notebook_using_papermill/component.yaml'  # noqa: E501
+    catalog_entry_data = {"url": url}
+    definition = reader.read_catalog_entry(catalog_entry_data, {})
 
+    # Construct a catalog instance
     catalog_type = "url-catalog"
+    catalog_instance = ComponentCatalogMetadata(
+        schema_name=catalog_type,
+        metadata={
+            "categories": ['Test'],
+            "runtime_type": RUNTIME_PROCESSOR.name
+        }
+    )
 
-    # Read contents of given path -- read_component_definition() returns a
-    # a dictionary of component definition content indexed by path
-    definition = reader.read_catalog_entry({"url": url}, {})
-    component_definition = ComponentDefinition(definition, {"url": url})
-    component_definition.set_entry_id(catalog_type, ['url'])
-
-    # Build entry for parsing
-    entry = {
-        "component_definition": component_definition,
-        "catalog_type": catalog_type,
-        "categories": ["Test"]
-    }
-    component_entry = SimpleNamespace(**entry)
+    # Build the catalog entry data structures required for parsing
+    entry_data = EntryData(definition)
+    catalog_entry = CatalogEntry(entry_data, catalog_entry_data, catalog_instance, ['url'])
 
     # Parse the component entry
     parser = KfpComponentParser.create_instance(platform=RUNTIME_PROCESSOR)
-    component = parser.parse(component_entry)[0]
+    component = parser.parse(catalog_entry)[0]
     properties_json = ComponentCache.to_canvas_properties(component)
 
     # Ensure component parameters are prefixed (and system parameters are not) and all hold correct values
     assert properties_json['current_parameters']['label'] == ''
 
-    component_identifier = component_entry.component_definition.identifier
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_identifier})
+    component_source = str({"catalog_type": catalog_type, "component_ref": catalog_entry.entry_reference})
     assert properties_json['current_parameters']['component_source'] == component_source
     assert properties_json['current_parameters']['elyra_notebook'] == 'None'   # Default value for type `inputpath`
     assert properties_json['current_parameters']['elyra_parameters'] == \
@@ -321,27 +322,28 @@ def test_parse_kfp_component_file_no_inputs():
     kfp_supported_file_types = [".yaml"]
     reader = FilesystemComponentCatalogConnector(kfp_supported_file_types)
 
+    # Read contents of given path
     path = _get_resource_path('kfp_test_operator_no_inputs.yaml')
+    catalog_entry_data = {"path": path}
+    definition = reader.read_catalog_entry(catalog_entry_data, {})
 
+    # Construct a catalog instance
     catalog_type = "local-file-catalog"
+    catalog_instance = ComponentCatalogMetadata(
+        schema_name=catalog_type,
+        metadata={
+            "categories": ['Test'],
+            "runtime_type": RUNTIME_PROCESSOR.name
+        }
+    )
 
-    # Read contents of given path -- read_component_definition() returns a
-    # a dictionary of component definition content indexed by path
-    definition = reader.read_catalog_entry({"path": path}, {})
-    component_definition = ComponentDefinition(definition, {"path": path})
-    component_definition.set_entry_id(catalog_type, ['path'])
-
-    # Build entry for parsing
-    entry = {
-        "component_definition": component_definition,
-        "catalog_type": catalog_type,
-        "categories": ["Test"]
-    }
-    component_entry = SimpleNamespace(**entry)
+    # Build the catalog entry data structures required for parsing
+    entry_data = EntryData(definition)
+    catalog_entry = CatalogEntry(entry_data, catalog_entry_data, catalog_instance, ['path'])
 
     # Parse the component entry
     parser = KfpComponentParser.create_instance(platform=RUNTIME_PROCESSOR)
-    component = parser.parse(component_entry)[0]
+    component = parser.parse(catalog_entry)[0]
     properties_json = ComponentCache.to_canvas_properties(component)
 
     # Properties JSON should only include the two parameters common to every
@@ -362,12 +364,12 @@ def test_parse_kfp_component_file_no_inputs():
     # Ensure that template still renders the two common parameters correctly
     assert properties_json['current_parameters']['label'] == ""
 
-    component_identifier = component_entry.component_definition.identifier
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_identifier})
+    component_source = str({"catalog_type": catalog_type, "component_ref": catalog_entry.entry_reference})
     assert properties_json['current_parameters']['component_source'] == component_source
 
 
 async def test_parse_components_invalid_file():
+
     # Define the appropriate reader for a filesystem-type component definition
     kfp_supported_file_types = [".yaml"]
     reader = FilesystemComponentCatalogConnector(kfp_supported_file_types)
@@ -383,34 +385,34 @@ async def test_parse_components_additional_metatypes():
     kfp_supported_file_types = [".yaml"]
     reader = UrlComponentCatalogConnector(kfp_supported_file_types)
 
+    # Read contents of given path
     url = 'https://raw.githubusercontent.com/kubeflow/pipelines/1.4.1/components/keras/Train_classifier/from_CSV/component.yaml'  # noqa: E501
+    catalog_entry_data = {"url": url}
+    definition = reader.read_catalog_entry(catalog_entry_data, {})
 
+    # Construct a catalog instance
     catalog_type = "url-catalog"
+    catalog_instance = ComponentCatalogMetadata(
+        schema_name=catalog_type,
+        metadata={
+            "categories": ['Test'],
+            "runtime_type": RUNTIME_PROCESSOR.name
+        }
+    )
 
-    # Read contents of given path -- read_component_definition() returns a
-    # a dictionary of component definition content indexed by path
-    definition = reader.read_catalog_entry({"url": url}, {})
-    component_definition = ComponentDefinition(definition, {"url": url})
-    component_definition.set_entry_id(catalog_type, ['url'])
-
-    # Build entry for parsing
-    entry = {
-        "component_definition": component_definition,
-        "catalog_type": catalog_type,
-        "categories": ["Test"]
-    }
-    component_entry = SimpleNamespace(**entry)
+    # Build the catalog entry data structures required for parsing
+    entry_data = EntryData(definition)
+    catalog_entry = CatalogEntry(entry_data, {"url": url}, catalog_instance, ['url'])
 
     # Parse the component entry
     parser = KfpComponentParser()
-    component = parser.parse(component_entry)[0]
+    component = parser.parse(catalog_entry)[0]
     properties_json = ComponentCache.to_canvas_properties(component)
 
     # Ensure component parameters are prefixed (and system parameters are not) and all hold correct values
     assert properties_json['current_parameters']['label'] == ''
 
-    component_identifier = component_entry.component_definition.identifier
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_identifier})
+    component_source = str({"catalog_type": catalog_type, "component_ref": catalog_entry.entry_reference})
     assert properties_json['current_parameters']['component_source'] == component_source
     assert properties_json['current_parameters']['elyra_training_features'] == 'None'  # inputPath
     assert properties_json['current_parameters']['elyra_training_labels'] == 'None'  # inputPath

--- a/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
@@ -22,6 +22,7 @@ import jupyter_core.paths
 import pytest
 
 from elyra.metadata.metadata import Metadata
+from elyra.pipeline.catalog_connector import ComponentDefinition
 from elyra.pipeline.catalog_connector import FilesystemComponentCatalogConnector
 from elyra.pipeline.catalog_connector import UrlComponentCatalogConnector
 from elyra.pipeline.component_catalog import ComponentCache
@@ -166,18 +167,19 @@ def test_parse_kfp_component_file():
 
     path = _get_resource_path('kfp_test_operator.yaml')
 
+    catalog_type = "local-file-catalog"
+
     # Read contents of given path -- read_component_definition() returns a
     # a dictionary of component definition content indexed by path
-    component_definition = reader.read_catalog_entry({"path": path}, {})
+    definition = reader.read_catalog_entry({"path": path}, {})
+    component_definition = ComponentDefinition(definition, {"path": path})
+    component_definition.set_entry_id(catalog_type, ['path'])
 
     # Build entry for parsing
-    catalog_type = "local-file-catalog"
     entry = {
-        "component_id": reader.get_unique_component_hash(catalog_type, {"path": path}, ["path"]),
+        "entry_data": component_definition,
         "catalog_type": catalog_type,
-        "categories": ["Test"],
-        "component_definition": component_definition,
-        "component_identifier": {"path": path}
+        "categories": ["Test"]
     }
     component_entry = SimpleNamespace(**entry)
 
@@ -189,7 +191,7 @@ def test_parse_kfp_component_file():
     # Ensure component parameters are prefixed (and system parameters are not) and all hold correct values
     assert properties_json['current_parameters']['label'] == ''
 
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.component_identifier})
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.entry_data.identifier})
     assert properties_json['current_parameters']['component_source'] == component_source
     assert properties_json['current_parameters']['elyra_test_string_no_default'] == \
            {'StringControl': '', 'activeControl': 'StringControl'}
@@ -277,14 +279,17 @@ def test_parse_kfp_component_url():
 
     url = 'https://raw.githubusercontent.com/kubeflow/pipelines/1.4.1/components/notebooks/Run_notebook_using_papermill/component.yaml'  # noqa: E501
 
+    catalog_type = "url-catalog"
+
     # Read contents of given path -- read_component_definition() returns a
     # a dictionary of component definition content indexed by path
-    component_definition = reader.read_catalog_entry({"url": url}, {})
+    definition = reader.read_catalog_entry({"url": url}, {})
+    component_definition = ComponentDefinition(definition, {"url": url})
+    component_definition.set_entry_id(catalog_type, ['url'])
 
     # Build entry for parsing
-    catalog_type = "url-catalog"
     entry = {
-        "component_id": reader.get_unique_component_hash(catalog_type, {"url": url}, ["url"]),
+        "entry_data": component_definition,
         "catalog_type": catalog_type,
         "categories": ["Test"],
         "component_definition": component_definition,
@@ -300,7 +305,7 @@ def test_parse_kfp_component_url():
     # Ensure component parameters are prefixed (and system parameters are not) and all hold correct values
     assert properties_json['current_parameters']['label'] == ''
 
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.component_identifier})
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.entry_data.identifier})
     assert properties_json['current_parameters']['component_source'] == component_source
     assert properties_json['current_parameters']['elyra_notebook'] == 'None'   # Default value for type `inputpath`
     assert properties_json['current_parameters']['elyra_parameters'] == \
@@ -318,18 +323,19 @@ def test_parse_kfp_component_file_no_inputs():
 
     path = _get_resource_path('kfp_test_operator_no_inputs.yaml')
 
+    catalog_type = "local-file-catalog"
+
     # Read contents of given path -- read_component_definition() returns a
     # a dictionary of component definition content indexed by path
-    component_definition = reader.read_catalog_entry({"path": path}, {})
+    definition = reader.read_catalog_entry({"path": path}, {})
+    component_definition = ComponentDefinition(definition, {"path": path})
+    component_definition.set_entry_id(catalog_type, ['path'])
 
     # Build entry for parsing
-    catalog_type = "local-file-catalog"
     entry = {
-        "component_id": reader.get_unique_component_hash(catalog_type, {"path": path}, ["path"]),
+        "entry_data": component_definition,
         "catalog_type": catalog_type,
-        "categories": ["Test"],
-        "component_definition": component_definition,
-        "component_identifier": {"path": path}
+        "categories": ["Test"]
     }
     component_entry = SimpleNamespace(**entry)
 
@@ -356,7 +362,7 @@ def test_parse_kfp_component_file_no_inputs():
     # Ensure that template still renders the two common parameters correctly
     assert properties_json['current_parameters']['label'] == ""
 
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.component_identifier})
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.entry_data.identifier})
     assert properties_json['current_parameters']['component_source'] == component_source
 
 
@@ -378,18 +384,19 @@ async def test_parse_components_additional_metatypes():
 
     url = 'https://raw.githubusercontent.com/kubeflow/pipelines/1.4.1/components/keras/Train_classifier/from_CSV/component.yaml'  # noqa: E501
 
+    catalog_type = "url-catalog"
+
     # Read contents of given path -- read_component_definition() returns a
     # a dictionary of component definition content indexed by path
-    component_definition = reader.read_catalog_entry({"url": url}, {})
+    definition = reader.read_catalog_entry({"url": url}, {})
+    component_definition = ComponentDefinition(definition, {"url": url})
+    component_definition.set_entry_id(catalog_type, ['url'])
 
     # Build entry for parsing
-    catalog_type = "url-catalog"
     entry = {
-        "component_id": reader.get_unique_component_hash(catalog_type, {"url": url}, ["url"]),
+        "entry_data": component_definition,
         "catalog_type": catalog_type,
-        "categories": ["Test"],
-        "component_definition": component_definition,
-        "component_identifier": {"url": url}
+        "categories": ["Test"]
     }
     component_entry = SimpleNamespace(**entry)
 
@@ -401,7 +408,7 @@ async def test_parse_components_additional_metatypes():
     # Ensure component parameters are prefixed (and system parameters are not) and all hold correct values
     assert properties_json['current_parameters']['label'] == ''
 
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.component_identifier})
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.entry_data.identifier})
     assert properties_json['current_parameters']['component_source'] == component_source
     assert properties_json['current_parameters']['elyra_training_features'] == 'None'  # inputPath
     assert properties_json['current_parameters']['elyra_training_labels'] == 'None'  # inputPath

--- a/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
@@ -177,7 +177,7 @@ def test_parse_kfp_component_file():
 
     # Build entry for parsing
     entry = {
-        "entry_data": component_definition,
+        "component_definition": component_definition,
         "catalog_type": catalog_type,
         "categories": ["Test"]
     }
@@ -191,7 +191,8 @@ def test_parse_kfp_component_file():
     # Ensure component parameters are prefixed (and system parameters are not) and all hold correct values
     assert properties_json['current_parameters']['label'] == ''
 
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.entry_data.identifier})
+    component_identifier = component_entry.component_definition.identifier
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_identifier})
     assert properties_json['current_parameters']['component_source'] == component_source
     assert properties_json['current_parameters']['elyra_test_string_no_default'] == \
            {'StringControl': '', 'activeControl': 'StringControl'}
@@ -289,11 +290,9 @@ def test_parse_kfp_component_url():
 
     # Build entry for parsing
     entry = {
-        "entry_data": component_definition,
-        "catalog_type": catalog_type,
-        "categories": ["Test"],
         "component_definition": component_definition,
-        "component_identifier": {"url": url}
+        "catalog_type": catalog_type,
+        "categories": ["Test"]
     }
     component_entry = SimpleNamespace(**entry)
 
@@ -305,7 +304,8 @@ def test_parse_kfp_component_url():
     # Ensure component parameters are prefixed (and system parameters are not) and all hold correct values
     assert properties_json['current_parameters']['label'] == ''
 
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.entry_data.identifier})
+    component_identifier = component_entry.component_definition.identifier
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_identifier})
     assert properties_json['current_parameters']['component_source'] == component_source
     assert properties_json['current_parameters']['elyra_notebook'] == 'None'   # Default value for type `inputpath`
     assert properties_json['current_parameters']['elyra_parameters'] == \
@@ -333,7 +333,7 @@ def test_parse_kfp_component_file_no_inputs():
 
     # Build entry for parsing
     entry = {
-        "entry_data": component_definition,
+        "component_definition": component_definition,
         "catalog_type": catalog_type,
         "categories": ["Test"]
     }
@@ -362,7 +362,8 @@ def test_parse_kfp_component_file_no_inputs():
     # Ensure that template still renders the two common parameters correctly
     assert properties_json['current_parameters']['label'] == ""
 
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.entry_data.identifier})
+    component_identifier = component_entry.component_definition.identifier
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_identifier})
     assert properties_json['current_parameters']['component_source'] == component_source
 
 
@@ -394,7 +395,7 @@ async def test_parse_components_additional_metatypes():
 
     # Build entry for parsing
     entry = {
-        "entry_data": component_definition,
+        "component_definition": component_definition,
         "catalog_type": catalog_type,
         "categories": ["Test"]
     }
@@ -408,7 +409,8 @@ async def test_parse_components_additional_metatypes():
     # Ensure component parameters are prefixed (and system parameters are not) and all hold correct values
     assert properties_json['current_parameters']['label'] == ''
 
-    component_source = str({"catalog_type": catalog_type, "component_ref": component_entry.entry_data.identifier})
+    component_identifier = component_entry.component_definition.identifier
+    component_source = str({"catalog_type": catalog_type, "component_ref": component_identifier})
     assert properties_json['current_parameters']['component_source'] == component_source
     assert properties_json['current_parameters']['elyra_training_features'] == 'None'  # inputPath
     assert properties_json['current_parameters']['elyra_training_labels'] == 'None'  # inputPath

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -296,7 +296,7 @@ def test_processing_url_runtime_specific_component(monkeypatch, processor, sampl
                           description="",
                           op="filter-text",
                           catalog_type="url-catalog",
-                          source_identifier={"url": url},
+                          component_reference={"url": url},
                           definition=component_definition,
                           categories=[],
                           properties=[])
@@ -374,7 +374,7 @@ def test_processing_filename_runtime_specific_component(monkeypatch, processor, 
                           description="",
                           op="download-data",
                           catalog_type="elyra-kfp-examples-catalog",
-                          source_identifier={"path": absolute_path},
+                          component_reference={"path": absolute_path},
                           definition=component_definition,
                           properties=[],
                           categories=[])

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup_args = dict(
         'autopep8>=1.5.0,<1.5.6',
         'click>=7.1.1,<8',
         'colorama',
+        'deprecation',
         'entrypoints>=0.3',
         'jinja2>=2.11',
         'jsonschema>=3.2.0',


### PR DESCRIPTION
Fixes #2460
Supports #2488

### What changes were proposed in this pull request?
Defines a new `EntryData` object class that includes the definition string as well as any runtime-specific attributes (e.g. `package_name` for `AirflowEntryData`). A new function, `get_entry_data` is defined, which takes the place of `read_catalog_entry`, and returns an `EntryData` object. If no `get_entry_data` function is present for a given CCC, the return value of `read_catalog_entry` is manually coerced into a `EntryData` object. 

A new `CatalogEntry` object is also defined, which holds in its bag of properties the `EntryData` object above, a unique id, information on the source of the component, and some catalog information (such as the relevant categories). This object is constructed after the `EntryData` object is returned by the CCC author and is passed directly to the parse methods, eliminating the need to define a `SimpleNamespace` object as a middleman.

There have also been some minor changes to the `Component` object, namely the inclusion of an optional `package_name` attribute and changing the same of the `source_identifier` attribute to `component_reference`.

During processing of Airflow components, the `package_name` for that component is now accessed directly (using the `import_statement` property) if it is available. This eliminates the need to manually change the `available_airflow_operators`  configurable trait to include import statements for all custom components. 

Changes are backwards compatible, so any implementations of CCC's using the previous version that doesn't return the well-defined object will still work properly (e.g. the url catalog). Built-in CCC's will have to be updated (in a separate PR) to use the `get_entry_data`.

For now, here is what you will need to do (@ptitzler) to implement the new metadata return values:

- Change the name of the `read_catalog_entry` function to `get_entry_data` (parameters are the same)
- The new return value is an `EntryData` object, and more specifically for the Airflow package connector use-case, an `AirflowEntryData` object, so:
  - Add the import statement (duh) `from elyra.pipeline.catalog_connector import AirflowEntryData` and `from elyra.pipeline.catalog_connector import EntryData` 
  - Change type hint return value to `Optional[EntryData]`
  - The package name string should not include the class name (which should be the natural behavior)
  - Finally, instead of returning a string value, you'll now want to initialize an `AirflowEntryData` and return that instead:
```python
return AirflowEntryData(definition=<definition string>, package_name=<package name string>)
```

- Convert `get_hash_keys` to a `classmethod` by adding the decorator and changing the parameter from `self` to `cls`

Initial manual tests following the above structure are working.

### How was this pull request tested?
Tests have been updated.
Successful and error scenarios have been manually tested.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
