### PR TITLE
Allow pipelines to be opened with the JSON widget

### DIFF
--- a/packages/pipeline-editor/src/index.ts
+++ b/packages/pipeline-editor/src/index.ts
@@ -108,12 +108,15 @@ const extension: JupyterFrontEndPlugin<void> = {
     });
 
     // Add the default behavior of opening the widget for .pipeline files
-    app.docRegistry.addFileType({
-      name: PIPELINE,
-      displayName: 'Pipeline',
-      extensions: ['.pipeline'],
-      icon: pipelineIcon
-    });
+    app.docRegistry.addFileType(
+      {
+        name: PIPELINE,
+        displayName: 'Pipeline',
+        extensions: ['.pipeline'],
+        icon: pipelineIcon
+      },
+      ['JSON']
+    );
     app.docRegistry.addWidgetFactory(pipelineEditorFactory);
 
     const tracker = new WidgetTracker<DocumentWidget>({


### PR DESCRIPTION
Pipeline files can currently be opened in either the pipeline
editor or the file editor. This update also allows users to open
pipeline files with the JSON viewer.

Fixes #1943

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
