### PR TITLE
Add setting to specify node double click behavior

### DIFF
--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -105,6 +105,7 @@
   },
   "jupyterlab": {
     "extension": true,
+    "schemaDir": "schema",
     "outputDir": "../../dist/labextensions/@elyra/pipeline-editor-extension"
   }
 }

--- a/packages/pipeline-editor/schema/plugin.json
+++ b/packages/pipeline-editor/schema/plugin.json
@@ -1,0 +1,16 @@
+{
+  "jupyter.lab.setting-icon": "elyra:pipeline",
+  "jupyter.lab.setting-icon-label": "Elyra Pipeline Editor",
+  "title": "Pipeline Editor",
+  "description": "Pipeline editor settings.",
+  "properties": {
+    "doubleClickBehavior": {
+      "title": "Double-click Behavior",
+      "description": "Double click to open properties",
+      "type": "boolean",
+      "default": true
+    }
+  },
+  "additionalProperties": false,
+  "type": "object"
+}

--- a/packages/pipeline-editor/schema/plugin.json
+++ b/packages/pipeline-editor/schema/plugin.json
@@ -1,12 +1,12 @@
 {
   "jupyter.lab.setting-icon": "elyra:pipeline",
   "jupyter.lab.setting-icon-label": "Elyra Pipeline Editor",
-  "title": "Pipeline Editor",
-  "description": "Pipeline editor settings.",
+  "title": "Elyra Pipeline Editor",
+  "description": "Elyra Pipeline Editor Configuration.",
   "properties": {
     "doubleClickToOpenProperties": {
-      "title": "Double-click node to open properties",
-      "description": "If not checked, double-clicking a node opens the file referenced by the node. If checked, double-clicking a node opens its properties panel.",
+      "title": "Double-click on pipeline node opens properties.",
+      "description": "If enabled, double-clicking a node opens the node's properties. If disabled (the default), the node's source file is opened.",
       "type": "boolean",
       "default": false
     }

--- a/packages/pipeline-editor/schema/plugin.json
+++ b/packages/pipeline-editor/schema/plugin.json
@@ -4,11 +4,11 @@
   "title": "Pipeline Editor",
   "description": "Pipeline editor settings.",
   "properties": {
-    "doubleClickBehavior": {
-      "title": "Double-click Behavior",
-      "description": "Double click to open properties",
+    "doubleClickToOpenProperties": {
+      "title": "Double-click node to open properties",
+      "description": "If not checked, double-clicking a node opens the file referenced by the node. If checked, double-clicking a node opens its properties panel.",
       "type": "boolean",
-      "default": true
+      "default": false
     }
   },
   "additionalProperties": false,

--- a/packages/pipeline-editor/src/EmptyPipelineContent.tsx
+++ b/packages/pipeline-editor/src/EmptyPipelineContent.tsx
@@ -20,6 +20,8 @@ import { settingsIcon } from '@jupyterlab/ui-components';
 import React from 'react';
 
 const HEADER_CLASS = 'empty-pipeline-header';
+const BUTTON_CLASS = 'empty-pipeline-button';
+const ICON_CLASS = 'empty-pipeline-icon';
 
 export interface IEmptyGenericPipelineProps {
   onOpenSettings: () => void;
@@ -43,12 +45,12 @@ export const EmptyGenericPipeline: React.FC<IEmptyGenericPipelineProps> = ({
       <br />
       <h3 className={HEADER_CLASS}>
         Click{' '}
-        <button className={'empty-pipeline-button'} onClick={onOpenSettings}>
-          <settingsIcon.react
-            className="component-catalog-icon"
-            tag="div"
-            height="24px"
-          />
+        <button
+          title="Settings"
+          className={BUTTON_CLASS}
+          onClick={onOpenSettings}
+        >
+          <settingsIcon.react className={ICON_CLASS} tag="div" height="24px" />
         </button>{' '}
         to configure the pipeline editor.
       </h3>
@@ -81,9 +83,9 @@ export const EmptyPlatformSpecificPipeline: React.FC<IEmptyPlatformSpecificPipel
       <h3 className={HEADER_CLASS}>
         Start your new pipeline by dragging files from the file browser pane or
         add custom components by clicking the{' '}
-        <button className={'empty-pipeline-button'} onClick={onOpenCatalog}>
+        <button className={BUTTON_CLASS} onClick={onOpenCatalog}>
           <componentCatalogIcon.react
-            className="component-catalog-icon"
+            className={ICON_CLASS}
             tag="div"
             height="24px"
           />
@@ -106,12 +108,12 @@ export const EmptyPlatformSpecificPipeline: React.FC<IEmptyPlatformSpecificPipel
       <br />
       <h3 className={HEADER_CLASS}>
         Click{' '}
-        <button className={'empty-pipeline-button'} onClick={onOpenSettings}>
-          <settingsIcon.react
-            className="component-catalog-icon"
-            tag="div"
-            height="24px"
-          />
+        <button
+          title="Settings"
+          className={BUTTON_CLASS}
+          onClick={onOpenSettings}
+        >
+          <settingsIcon.react className={ICON_CLASS} tag="div" height="24px" />
         </button>{' '}
         to configure the pipeline editor.
       </h3>

--- a/packages/pipeline-editor/src/EmptyPipelineContent.tsx
+++ b/packages/pipeline-editor/src/EmptyPipelineContent.tsx
@@ -15,6 +15,7 @@
  */
 
 import { componentCatalogIcon, dragDropIcon } from '@elyra/ui-components';
+import { settingsIcon } from '@jupyterlab/ui-components';
 
 import React from 'react';
 
@@ -38,10 +39,12 @@ export const EmptyGenericPipeline: React.FC = () => {
 
 export interface IEmptyPlatformSpecificPipelineProps {
   onOpenCatalog: () => void;
+  onOpenSettings: () => void;
 }
 
 export const EmptyPlatformSpecificPipeline: React.FC<IEmptyPlatformSpecificPipelineProps> = ({
-  onOpenCatalog
+  onOpenCatalog,
+  onOpenSettings
 }) => {
   // Note: the URL is rewritten by the release script by replacing `latest` with a
   // specific version number, e.g. https://.../en/v3.6.0/user_guide/pi...
@@ -53,10 +56,7 @@ export const EmptyPlatformSpecificPipeline: React.FC<IEmptyPlatformSpecificPipel
       <EmptyGenericPipeline />
       <h3 className={HEADER_CLASS}>
         or add custom components by clicking the{' '}
-        <button
-          className={'open-component-catalog-button'}
-          onClick={onOpenCatalog}
-        >
+        <button className={'empty-pipeline-button'} onClick={onOpenCatalog}>
           <componentCatalogIcon.react
             className="component-catalog-icon"
             tag="div"
@@ -79,6 +79,19 @@ export const EmptyPlatformSpecificPipeline: React.FC<IEmptyPlatformSpecificPipel
         </a>
         for details.
       </h4>
+      <h3 className={HEADER_CLASS}>
+        Click{' '}
+        <button className={'empty-pipeline-button'} onClick={onOpenSettings}>
+          <settingsIcon.react
+            className="component-catalog-icon"
+            tag="div"
+            height="24px"
+          />
+        </button>{' '}
+        to configure the pipeline editor.
+        <br />
+        <br />
+      </h3>
     </div>
   );
 };

--- a/packages/pipeline-editor/src/EmptyPipelineContent.tsx
+++ b/packages/pipeline-editor/src/EmptyPipelineContent.tsx
@@ -21,7 +21,13 @@ import React from 'react';
 
 const HEADER_CLASS = 'empty-pipeline-header';
 
-export const EmptyGenericPipeline: React.FC = () => {
+export interface IEmptyGenericPipelineProps {
+  onOpenSettings: () => void;
+}
+
+export const EmptyGenericPipeline: React.FC<IEmptyGenericPipelineProps> = ({
+  onOpenSettings
+}) => {
   return (
     <div>
       <dragDropIcon.react
@@ -32,6 +38,19 @@ export const EmptyGenericPipeline: React.FC = () => {
       />
       <h3 className={HEADER_CLASS}>
         Start your new pipeline by dragging files from the file browser pane
+      </h3>
+      <br />
+      <br />
+      <h3 className={HEADER_CLASS}>
+        Click{' '}
+        <button className={'empty-pipeline-button'} onClick={onOpenSettings}>
+          <settingsIcon.react
+            className="component-catalog-icon"
+            tag="div"
+            height="24px"
+          />
+        </button>{' '}
+        to configure the pipeline editor.
       </h3>
     </div>
   );
@@ -53,9 +72,15 @@ export const EmptyPlatformSpecificPipeline: React.FC<IEmptyPlatformSpecificPipel
 
   return (
     <div>
-      <EmptyGenericPipeline />
+      <dragDropIcon.react
+        className="drag-drop-icon"
+        tag="div"
+        elementPosition="center"
+        height="120px"
+      />
       <h3 className={HEADER_CLASS}>
-        or add custom components by clicking the{' '}
+        Start your new pipeline by dragging files from the file browser pane or
+        add custom components by clicking the{' '}
         <button className={'empty-pipeline-button'} onClick={onOpenCatalog}>
           <componentCatalogIcon.react
             className="component-catalog-icon"
@@ -64,8 +89,6 @@ export const EmptyPlatformSpecificPipeline: React.FC<IEmptyPlatformSpecificPipel
           />
         </button>{' '}
         button.
-        <br />
-        <br />
       </h3>
       <h4 className={HEADER_CLASS}>
         Refer to the
@@ -79,6 +102,8 @@ export const EmptyPlatformSpecificPipeline: React.FC<IEmptyPlatformSpecificPipel
         </a>
         for details.
       </h4>
+      <br />
+      <br />
       <h3 className={HEADER_CLASS}>
         Click{' '}
         <button className={'empty-pipeline-button'} onClick={onOpenSettings}>
@@ -89,8 +114,6 @@ export const EmptyPlatformSpecificPipeline: React.FC<IEmptyPlatformSpecificPipel
           />
         </button>{' '}
         to configure the pipeline editor.
-        <br />
-        <br />
       </h3>
     </div>
   );

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -1010,7 +1010,7 @@ const PipelineWrapper: React.FC<IProps> = ({
           leftPalette={true}
         >
           {type === undefined ? (
-            <EmptyGenericPipeline />
+            <EmptyGenericPipeline onOpenSettings={handleOpenSettings} />
           ) : (
             <EmptyPlatformSpecificPipeline
               onOpenCatalog={handleOpenCatalog}

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -526,9 +526,9 @@ const PipelineWrapper: React.FC<IProps> = ({
     };
   };
 
-  const handleDoubleClick = (data: any): void => {
+  const onDoubleClick = (data: any): void => {
     if (doubleClickBehavior) {
-      setPanelOpen(true);
+      onAction({ type: 'properties' });
       return;
     }
     for (let i = 0; i < data.selectedObjectIds.length; i++) {
@@ -1001,7 +1001,7 @@ const PipelineWrapper: React.FC<IProps> = ({
           pipeline={pipeline}
           onAction={onAction}
           onChange={onChange}
-          onDoubleClickNode={handleDoubleClick}
+          onDoubleClickNode={doubleClickBehavior ? undefined : onDoubleClick}
           onError={onError}
           onFileRequested={onFileRequested}
           onPropertiesUpdateRequested={onPropertiesUpdateRequested}

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -977,6 +977,10 @@ const PipelineWrapper: React.FC<IProps> = ({
     shell.activateById(`elyra-metadata:${COMPONENT_CATALOGS_SCHEMASPACE}`);
   };
 
+  const handleOpenSettings = (): void => {
+    commands.execute('settingeditor:open');
+  };
+
   return (
     <ThemeProvider theme={theme}>
       <Snackbar
@@ -1008,7 +1012,10 @@ const PipelineWrapper: React.FC<IProps> = ({
           {type === undefined ? (
             <EmptyGenericPipeline />
           ) : (
-            <EmptyPlatformSpecificPipeline onOpenCatalog={handleOpenCatalog} />
+            <EmptyPlatformSpecificPipeline
+              onOpenCatalog={handleOpenCatalog}
+              onOpenSettings={handleOpenSettings}
+            />
           )}
         </PipelineEditor>
       </Dropzone>

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -204,8 +204,8 @@ const PipelineWrapper: React.FC<IProps> = ({
     error: runtimesSchemaError
   } = useRuntimesSchema();
 
-  const doubleClickBehavior =
-    settings?.composite['doubleClickBehavior'] ?? true;
+  const doubleClickToOpenProperties =
+    settings?.composite['doubleClickToOpenProperties'] ?? true;
 
   const runtimeDisplayName = getDisplayName(runtimesSchema, type) ?? 'Generic';
 
@@ -527,10 +527,6 @@ const PipelineWrapper: React.FC<IProps> = ({
   };
 
   const onDoubleClick = (data: any): void => {
-    if (doubleClickBehavior) {
-      onAction({ type: 'properties' });
-      return;
-    }
     for (let i = 0; i < data.selectedObjectIds.length; i++) {
       const node = pipeline.pipelines[0].nodes.find(
         (node: any) => node.id === data.selectedObjectIds[i]
@@ -1001,7 +997,9 @@ const PipelineWrapper: React.FC<IProps> = ({
           pipeline={pipeline}
           onAction={onAction}
           onChange={onChange}
-          onDoubleClickNode={doubleClickBehavior ? undefined : onDoubleClick}
+          onDoubleClickNode={
+            doubleClickToOpenProperties ? undefined : onDoubleClick
+          }
           onError={onError}
           onFileRequested={onFileRequested}
           onPropertiesUpdateRequested={onPropertiesUpdateRequested}

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -48,10 +48,10 @@ import {
   DocumentWidget,
   Context
 } from '@jupyterlab/docregistry';
+import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 import 'carbon-components/css/carbon-components.min.css';
-
-import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 
 import { toArray } from '@lumino/algorithm';
 import { IDragEvent } from '@lumino/dragdrop';
@@ -144,6 +144,7 @@ class PipelineEditorWidget extends ReactWidget {
   commands: any;
   addFileToPipelineSignal: Signal<this, any>;
   context: Context;
+  settings: ISettingRegistry.ISettings;
 
   constructor(options: any) {
     super(options);
@@ -152,6 +153,7 @@ class PipelineEditorWidget extends ReactWidget {
     this.commands = options.commands;
     this.addFileToPipelineSignal = options.addFileToPipelineSignal;
     this.context = options.context;
+    this.settings = options.settings;
   }
 
   render(): any {
@@ -163,6 +165,7 @@ class PipelineEditorWidget extends ReactWidget {
         commands={this.commands}
         addFileToPipelineSignal={this.addFileToPipelineSignal}
         widgetId={this.parent?.id}
+        settings={this.settings}
       />
     );
   }
@@ -174,6 +177,7 @@ interface IProps {
   shell: ILabShell;
   commands: any;
   addFileToPipelineSignal: Signal<PipelineEditorWidget, any>;
+  settings?: ISettingRegistry.ISettings;
   widgetId?: string;
 }
 
@@ -183,6 +187,7 @@ const PipelineWrapper: React.FC<IProps> = ({
   shell,
   commands,
   addFileToPipelineSignal,
+  settings,
   widgetId
 }) => {
   const ref = useRef<any>(null);
@@ -198,6 +203,9 @@ const PipelineWrapper: React.FC<IProps> = ({
     data: runtimesSchema,
     error: runtimesSchemaError
   } = useRuntimesSchema();
+
+  const doubleClickBehavior =
+    settings?.composite['doubleClickBehavior'] ?? true;
 
   const runtimeDisplayName = getDisplayName(runtimesSchema, type) ?? 'Generic';
 
@@ -518,7 +526,11 @@ const PipelineWrapper: React.FC<IProps> = ({
     };
   };
 
-  const handleOpenFile = (data: any): void => {
+  const handleDoubleClick = (data: any): void => {
+    if (doubleClickBehavior) {
+      setPanelOpen(true);
+      return;
+    }
     for (let i = 0; i < data.selectedObjectIds.length; i++) {
       const node = pipeline.pipelines[0].nodes.find(
         (node: any) => node.id === data.selectedObjectIds[i]
@@ -989,7 +1001,7 @@ const PipelineWrapper: React.FC<IProps> = ({
           pipeline={pipeline}
           onAction={onAction}
           onChange={onChange}
-          onDoubleClickNode={handleOpenFile}
+          onDoubleClickNode={handleDoubleClick}
           onError={onError}
           onFileRequested={onFileRequested}
           onPropertiesUpdateRequested={onPropertiesUpdateRequested}
@@ -1011,6 +1023,7 @@ export class PipelineEditorFactory extends ABCWidgetFactory<DocumentWidget> {
   shell: ILabShell;
   commands: any;
   addFileToPipelineSignal: Signal<this, any>;
+  settings: ISettingRegistry.ISettings;
 
   constructor(options: any) {
     super(options);
@@ -1018,6 +1031,7 @@ export class PipelineEditorFactory extends ABCWidgetFactory<DocumentWidget> {
     this.shell = options.shell;
     this.commands = options.commands;
     this.addFileToPipelineSignal = new Signal<this, any>(this);
+    this.settings = options.settings;
   }
 
   protected createNewWidget(context: DocumentRegistry.Context): DocumentWidget {
@@ -1027,7 +1041,8 @@ export class PipelineEditorFactory extends ABCWidgetFactory<DocumentWidget> {
       commands: this.commands,
       browserFactory: this.browserFactory,
       context: context,
-      addFileToPipelineSignal: this.addFileToPipelineSignal
+      addFileToPipelineSignal: this.addFileToPipelineSignal,
+      settings: this.settings
     };
     const content = new PipelineEditorWidget(props);
 

--- a/packages/pipeline-editor/src/index.ts
+++ b/packages/pipeline-editor/src/index.ts
@@ -57,6 +57,7 @@ const PIPELINE_EDITOR = 'Pipeline Editor';
 const PIPELINE = 'pipeline';
 const PIPELINE_EDITOR_NAMESPACE = 'elyra-pipeline-editor-extension';
 const COMPONENT_CATALOGS_SCHEMASPACE = 'component-catalogs';
+const PLUGIN_ID = '@elyra/pipeline-editor-extension:plugin';
 
 const createRemoteIcon = async ({
   name,
@@ -101,10 +102,9 @@ const extension: JupyterFrontEndPlugin<void> = {
 
     // Fetch the initial state of the settings.
     const settings = await registry
-      .load('@elyra/pipeline-editor-extension:plugin')
+      .load(PLUGIN_ID)
       .catch(error => console.log(error));
 
-    console.log(settings);
     // Set up new widget Factory for .pipeline files
     const pipelineEditorFactory = new PipelineEditorFactory({
       name: PIPELINE_EDITOR,

--- a/packages/pipeline-editor/src/index.ts
+++ b/packages/pipeline-editor/src/index.ts
@@ -39,6 +39,7 @@ import { DocumentWidget } from '@jupyterlab/docregistry';
 import { IFileBrowserFactory } from '@jupyterlab/filebrowser';
 import { ILauncher } from '@jupyterlab/launcher';
 import { IMainMenu } from '@jupyterlab/mainmenu';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { addIcon, LabIcon } from '@jupyterlab/ui-components';
 
 import { PipelineEditorFactory, commandIDs } from './PipelineEditorWidget';
@@ -82,20 +83,28 @@ const extension: JupyterFrontEndPlugin<void> = {
     ILauncher,
     IFileBrowserFactory,
     ILayoutRestorer,
-    IMainMenu
+    IMainMenu,
+    ISettingRegistry
   ],
   optional: [IThemeManager],
-  activate: (
+  activate: async (
     app: JupyterFrontEnd,
     palette: ICommandPalette,
     launcher: ILauncher,
     browserFactory: IFileBrowserFactory,
     restorer: ILayoutRestorer,
     menu: IMainMenu,
+    registry: ISettingRegistry,
     themeManager?: IThemeManager
   ) => {
     console.log('Elyra - pipeline-editor extension is activated!');
 
+    // Fetch the initial state of the settings.
+    const settings = await registry
+      .load('@elyra/pipeline-editor-extension:plugin')
+      .catch(error => console.log(error));
+
+    console.log(settings);
     // Set up new widget Factory for .pipeline files
     const pipelineEditorFactory = new PipelineEditorFactory({
       name: PIPELINE_EDITOR,
@@ -104,7 +113,8 @@ const extension: JupyterFrontEndPlugin<void> = {
       shell: app.shell,
       commands: app.commands,
       browserFactory: browserFactory,
-      serviceManager: app.serviceManager
+      serviceManager: app.serviceManager,
+      settings: settings
     });
 
     // Add the default behavior of opening the widget for .pipeline files

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -801,7 +801,15 @@ a {
   text-align: center;
 }
 
-.component-catalog-icon {
+h3.empty-pipeline-header {
+  font-size: var(--jp-content-font-size5);
+}
+
+h4.empty-pipeline-header {
+  font-size: var(--jp-content-font-size3);
+}
+
+.empty-pipeline-icon {
   display: inline-block;
   vertical-align: middle;
 }
@@ -814,10 +822,14 @@ a {
   padding: 0;
   border: none;
   background: none;
-  color: #8897a2;
+  color: var(--jp-brand-color1);
 }
 
 .empty-pipeline-button:hover {
   background-color: var(--jp-layout-color2);
   cursor: pointer;
+}
+
+.empty-pipeline-button .jp-icon3[fill] {
+  fill: var(--jp-brand-color1);
 }

--- a/packages/pipeline-editor/style/index.css
+++ b/packages/pipeline-editor/style/index.css
@@ -806,7 +806,7 @@ a {
   vertical-align: middle;
 }
 
-.open-component-catalog-button {
+.empty-pipeline-button {
   display: inline-block;
   vertical-align: middle;
   pointer-events: auto;
@@ -817,7 +817,7 @@ a {
   color: #8897a2;
 }
 
-.open-component-catalog-button:hover {
+.empty-pipeline-button:hover {
   background-color: var(--jp-layout-color2);
   cursor: pointer;
 }


### PR DESCRIPTION
Adds a setting so users can customize the double click behavior for nodes in the pipeline editor. Double click can either open the file that the node represents or opens the properties pane for that node. Fixes part of #2275. Fixes #2470. Fixes #2017.

![image](https://user-images.githubusercontent.com/6673460/156264010-d19b2aa6-9243-4fd7-a579-0f7bfbb313d9.png)


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
