### PR TITLE
Update built-in catalog connectors to use new connector API

### DIFF
--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -23,7 +23,6 @@ import pytest
 
 from elyra.metadata.metadata import Metadata
 from elyra.pipeline.catalog_connector import CatalogEntry
-from elyra.pipeline.catalog_connector import EntryData
 from elyra.pipeline.catalog_connector import FilesystemComponentCatalogConnector
 from elyra.pipeline.catalog_connector import UrlComponentCatalogConnector
 from elyra.pipeline.component import ComponentParser
@@ -176,7 +175,6 @@ def test_parse_airflow_component_file():
     # Read contents of given path
     path = _get_resource_path('airflow_test_operator.py')
     catalog_entry_data = {"path": path}
-    definition = reader.read_catalog_entry(catalog_entry_data, {})
 
     # Construct a catalog instance
     catalog_type = "local-file-catalog"
@@ -189,7 +187,7 @@ def test_parse_airflow_component_file():
     )
 
     # Build the catalog entry data structures required for parsing
-    entry_data = EntryData(definition)
+    entry_data = reader.get_entry_data(catalog_entry_data, {})
     catalog_entry = CatalogEntry(entry_data, catalog_entry_data, catalog_instance, ['path'])
 
     # Parse the component entry
@@ -359,7 +357,6 @@ def test_parse_airflow_component_url():
     # Read contents of given path
     url = 'https://raw.githubusercontent.com/apache/airflow/1.10.15/airflow/operators/bash_operator.py'  # noqa: E501
     catalog_entry_data = {"url": url}
-    definition = reader.read_catalog_entry(catalog_entry_data, {})
 
     # Construct a catalog instance
     catalog_type = "url-catalog"
@@ -372,7 +369,7 @@ def test_parse_airflow_component_url():
     )
 
     # Build the catalog entry data structures required for parsing
-    entry_data = EntryData(definition)
+    entry_data = reader.get_entry_data(catalog_entry_data, {})
     catalog_entry = CatalogEntry(entry_data, catalog_entry_data, catalog_instance, ['url'])
 
     # Parse the component entry
@@ -404,7 +401,6 @@ def test_parse_airflow_component_file_no_inputs():
     # Read contents of given path
     path = _get_resource_path('airflow_test_operator_no_inputs.py')
     catalog_entry_data = {"path": path}
-    definition = reader.read_catalog_entry(catalog_entry_data, {})
 
     # Construct a catalog instance
     catalog_type = "local-file-catalog"
@@ -417,7 +413,7 @@ def test_parse_airflow_component_file_no_inputs():
     )
 
     # Build the catalog entry data structures required for parsing
-    entry_data = EntryData(definition)
+    entry_data = reader.get_entry_data(catalog_entry_data, {})
     catalog_entry = CatalogEntry(entry_data, catalog_entry_data, catalog_instance, ['path'])
 
     # Parse the component entry
@@ -455,5 +451,5 @@ async def test_parse_components_invalid_url(invalid_url):
     reader = UrlComponentCatalogConnector(airflow_supported_file_types)
 
     # Get path to an invalid component definition file and read contents
-    component_definition = reader.read_catalog_entry({"url": invalid_url}, {})
-    assert component_definition is None
+    entry_data = reader.get_entry_data({"url": invalid_url}, {})
+    assert entry_data is None

--- a/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
@@ -22,7 +22,6 @@ import pytest
 
 from elyra.metadata.metadata import Metadata
 from elyra.pipeline.catalog_connector import CatalogEntry
-from elyra.pipeline.catalog_connector import EntryData
 from elyra.pipeline.catalog_connector import FilesystemComponentCatalogConnector
 from elyra.pipeline.catalog_connector import UrlComponentCatalogConnector
 from elyra.pipeline.component_catalog import ComponentCache
@@ -169,7 +168,6 @@ def test_parse_kfp_component_file():
     # Read contents of given path
     path = _get_resource_path('kfp_test_operator.yaml')
     catalog_entry_data = {"path": path}
-    definition = reader.read_catalog_entry(catalog_entry_data, {})
 
     # Construct a catalog instance
     catalog_type = "local-file-catalog"
@@ -182,7 +180,7 @@ def test_parse_kfp_component_file():
     )
 
     # Build the catalog entry data structures required for parsing
-    entry_data = EntryData(definition)
+    entry_data = reader.get_entry_data(catalog_entry_data, {})
     catalog_entry = CatalogEntry(entry_data, catalog_entry_data, catalog_instance, ['path'])
 
     # Parse the component entry
@@ -282,7 +280,6 @@ def test_parse_kfp_component_url():
     # Read contents of given path
     url = 'https://raw.githubusercontent.com/kubeflow/pipelines/1.4.1/components/notebooks/Run_notebook_using_papermill/component.yaml'  # noqa: E501
     catalog_entry_data = {"url": url}
-    definition = reader.read_catalog_entry(catalog_entry_data, {})
 
     # Construct a catalog instance
     catalog_type = "url-catalog"
@@ -295,7 +292,7 @@ def test_parse_kfp_component_url():
     )
 
     # Build the catalog entry data structures required for parsing
-    entry_data = EntryData(definition)
+    entry_data = reader.get_entry_data(catalog_entry_data, {})
     catalog_entry = CatalogEntry(entry_data, catalog_entry_data, catalog_instance, ['url'])
 
     # Parse the component entry
@@ -325,7 +322,6 @@ def test_parse_kfp_component_file_no_inputs():
     # Read contents of given path
     path = _get_resource_path('kfp_test_operator_no_inputs.yaml')
     catalog_entry_data = {"path": path}
-    definition = reader.read_catalog_entry(catalog_entry_data, {})
 
     # Construct a catalog instance
     catalog_type = "local-file-catalog"
@@ -338,7 +334,7 @@ def test_parse_kfp_component_file_no_inputs():
     )
 
     # Build the catalog entry data structures required for parsing
-    entry_data = EntryData(definition)
+    entry_data = reader.get_entry_data(catalog_entry_data, {})
     catalog_entry = CatalogEntry(entry_data, catalog_entry_data, catalog_instance, ['path'])
 
     # Parse the component entry
@@ -376,8 +372,8 @@ async def test_parse_components_invalid_file():
 
     # Get path to an invalid component definition file and read contents
     path = _get_resource_path('kfp_test_operator_invalid.yaml')
-    component_definition = reader.read_catalog_entry({"path": path}, {})
-    assert component_definition is None
+    entry_data = reader.get_entry_data({"path": path}, {})
+    assert entry_data is None
 
 
 async def test_parse_components_additional_metatypes():
@@ -388,7 +384,6 @@ async def test_parse_components_additional_metatypes():
     # Read contents of given path
     url = 'https://raw.githubusercontent.com/kubeflow/pipelines/1.4.1/components/keras/Train_classifier/from_CSV/component.yaml'  # noqa: E501
     catalog_entry_data = {"url": url}
-    definition = reader.read_catalog_entry(catalog_entry_data, {})
 
     # Construct a catalog instance
     catalog_type = "url-catalog"
@@ -401,7 +396,7 @@ async def test_parse_components_additional_metatypes():
     )
 
     # Build the catalog entry data structures required for parsing
-    entry_data = EntryData(definition)
+    entry_data = reader.get_entry_data(catalog_entry_data, {})
     catalog_entry = CatalogEntry(entry_data, {"url": url}, catalog_instance, ['url'])
 
     # Parse the component entry

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -287,7 +287,8 @@ def test_processing_url_runtime_specific_component(monkeypatch, processor, sampl
 
     # Read contents of given path -- read_component_definition() returns a
     # a dictionary of component definition content indexed by path
-    component_definition = reader.read_catalog_entry({"url": url}, {})
+    entry_data = reader.get_entry_data({"url": url}, {})
+    component_definition = entry_data.definition
 
     # Instantiate a url-based component
     component_id = 'url-catalog:7f0546b6135c'
@@ -365,7 +366,8 @@ def test_processing_filename_runtime_specific_component(monkeypatch, processor, 
 
     # Read contents of given path -- read_component_definition() returns a
     # a dictionary of component definition content indexed by path
-    component_definition = reader.read_catalog_entry({"path": absolute_path}, {})
+    entry_data = reader.get_entry_data({"path": absolute_path}, {})
+    component_definition = entry_data.definition
 
     # Instantiate a file-based component
     component_id = "elyra-kfp-examples-catalog:a08014f9252f"


### PR DESCRIPTION
Closes #2512

### What changes were proposed in this pull request?
Changes the `read_catalog_entry` function to a `get_entry_data` function for the built-in catalog connector types in order to bring it in line with the changes from #2492. The built-in connectors currently return a generic `EntryData` object, but there is an opportunity to create runtime-type-specific objects according to the runtime type of the catalog being parsed (although any `AirflowEntryData` objects will not include the `package_name` field so differentiating may not be strictly necessary). 

### How was this pull request tested?
Tests have been updated.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
