### PR TITLE
Use well-defined EntryData return values in Airflow catalog connectors

### DIFF
--- a/elyra/pipeline/airflow/package_catalog_connector/airflow_package_catalog_connector.py
+++ b/elyra/pipeline/airflow/package_catalog_connector/airflow_package_catalog_connector.py
@@ -28,13 +28,17 @@ import zipfile
 
 import requests
 
+from elyra.pipeline.catalog_connector import AirflowEntryData
 from elyra.pipeline.catalog_connector import ComponentCatalogConnector
+from elyra.pipeline.catalog_connector import EntryData
 
 
 class AirflowPackageCatalogConnector(ComponentCatalogConnector):
     """
     Provides access to operators that are defined in Apache Airflow wheel archives.
     """
+
+    REQUEST_TIMEOUT = 30
 
     def get_catalog_entries(self, catalog_metadata: Dict[str, Any]) -> List[Dict[str, Any]]:
 
@@ -76,9 +80,15 @@ class AirflowPackageCatalogConnector(ComponentCatalogConnector):
             self.log.debug(f'Downloading Apache Airflow package from \'{airflow_package_download_url}\' ...')
 
             # download archive; abort after 30 seconds
-            response = requests.get(airflow_package_download_url,
-                                    timeout=30,
-                                    allow_redirects=True)
+            try:
+                response = requests.get(airflow_package_download_url,
+                                        timeout=AirflowPackageCatalogConnector.REQUEST_TIMEOUT,
+                                        allow_redirects=True)
+            except Exception as ex:
+                self.log.error('Error. The Airflow package connector is not configured properly. '
+                               f'Download of \'{airflow_package_download_url}\' failed: '
+                               f'{ex}')
+                return operator_key_list
             if response.status_code != 200:
                 # download failed. Log error and abort processing
                 self.log.error('Error. The Airflow package connector is not configured properly. '
@@ -109,7 +119,7 @@ class AirflowPackageCatalogConnector(ComponentCatalogConnector):
             os.remove(archive)
 
             # Locate Python scripts that are stored in the 'airflow/operators' directory
-            python_scripts = [str(s) for s in self.tmp_archive_dir.glob('airflow/operators/*.py')]
+            python_scripts = [s for s in self.tmp_archive_dir.glob('airflow/operators/*.py')]
 
             #
             # Identify Python scripts that define classes that extend the
@@ -123,9 +133,9 @@ class AirflowPackageCatalogConnector(ComponentCatalogConnector):
             script_count = 0  # used for stats collection
             # process each Python script ...
             for script in python_scripts:
-                script_id = script[offset:]
-                if script_id == 'airflow/operators/__init__.py':
+                if script.name == '__init__.py':
                     continue
+                script_id = str(script)[offset:]
                 script_count += 1
                 self.log.debug(f'Parsing \'{script}\' ...')
                 with open(script, 'r') as source_code:
@@ -211,9 +221,9 @@ class AirflowPackageCatalogConnector(ComponentCatalogConnector):
 
         return operator_key_list
 
-    def read_catalog_entry(self,
-                           catalog_entry_data: Dict[str, Any],
-                           catalog_metadata: Dict[str, Any]) -> Optional[str]:
+    def get_entry_data(self,
+                       catalog_entry_data: Dict[str, Any],
+                       catalog_metadata: Dict[str, Any]) -> Optional[EntryData]:
         """
         Fetch the component that is identified by catalog_entry_data from
         the downloaded Apache Airflow package.
@@ -224,7 +234,7 @@ class AirflowPackageCatalogConnector(ComponentCatalogConnector):
                                  stored; in addition to catalog_entry_data, catalog_metadata may also be
                                  needed to read the component definition for certain types of catalogs
 
-        :returns: the content of the given catalog entry's definition in string form
+        :returns: An AirflowEntryData containing the definition and metadata, if found
         """
         operator_file_name = catalog_entry_data.get('file')
 
@@ -234,23 +244,29 @@ class AirflowPackageCatalogConnector(ComponentCatalogConnector):
                            ' downloaded Airflow package archive was not found.')
             return None
 
+        # Compose package name from operator_file_name, e.g.
+        # 'airflow/operators/papermill_operator.py' => 'airflow.operators.papermill_operator'
+        package = '.'.join(Path(operator_file_name).with_suffix('').parts)
+
         # load operator source using the provided key
         operator_source = self.tmp_archive_dir / operator_file_name
         self.log.debug(f'Reading operator source \'{operator_source}\' ...')
         try:
             with open(operator_source, 'r') as source:
-                return source.read()
+                return AirflowEntryData(definition=source.read(),
+                                        package_name=package)
         except Exception as ex:
             self.log.error(f'Error reading operator source \'{operator_source}\': {ex}')
 
         return None
 
-    def get_hash_keys(self) -> List[Any]:
+    @classmethod
+    def get_hash_keys(cls) -> List[Any]:
         """
         Instructs Elyra to use the specified keys to generate a unique
         hash value for item returned by get_catalog_entries
         :returns: a list of keys
-      """
+        """
         # Example key values:
         # - file: operators/bash_operator.py
         return ['file']

--- a/elyra/pipeline/airflow/provider_package_catalog_connector/airflow_provider_package_catalog_connector.py
+++ b/elyra/pipeline/airflow/provider_package_catalog_connector/airflow_provider_package_catalog_connector.py
@@ -146,7 +146,7 @@ class AirflowProviderPackageCatalogConnector(ComponentCatalogConnector):
                 return_dict = namespace['get_provider_info']()
             except KeyError:
                 # no method with this name is defined in get_provider_info.py
-                self.log.error('Error. Cannot \'invoke get_provider_info\' method '
+                self.log.error('Error. Cannot invoke \' get_provider_info\' method '
                                f'in \'{get_provider_info_file_location}\'.')
                 return operator_key_list
 
@@ -295,7 +295,7 @@ class AirflowProviderPackageCatalogConnector(ComponentCatalogConnector):
         :param catalog_metadata: the metadata associated with the catalog in which this catalog entry is
                                  stored; in addition to catalog_entry_data, catalog_metadata may also be
                                  needed to read the component definition for certain types of catalogs
-        :returns: A EntryData containing the definition and metadata, if found
+        :returns: An AirflowEntryData containing the definition and metadata, if found
         """
 
         operator_file_name = catalog_entry_data['file']

--- a/elyra/tests/pipeline/airflow/test_airflow_package_connector.py
+++ b/elyra/tests/pipeline/airflow/test_airflow_package_connector.py
@@ -1,0 +1,115 @@
+#
+# Copyright 2018-2022 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import io
+import zipfile
+
+from elyra.pipeline.airflow.package_catalog_connector.airflow_package_catalog_connector import AirflowPackageCatalogConnector  # noqa:E501
+from elyra.pipeline.catalog_connector import AirflowEntryData
+
+AIRFLOW_1_10_15_PKG_URL = 'https://files.pythonhosted.org/packages/f0/3a/'\
+                          'f5ce74b2bdbbe59c925bb3398ec0781b66a64b8a23e2f6adc7ab9f1005d9/'\
+                          'apache_airflow-1.10.15-py2.py3-none-any.whl'
+
+AIRFLOW_SUPPORTED_FILE_TYPES = [".py"]
+
+
+def test_empty_workdir():
+    """
+    Verify that the workdir isn't set by default. (The property is only set
+    after 'get_catalog_entries' was invoked.)
+    """
+    apc = AirflowPackageCatalogConnector(AIRFLOW_SUPPORTED_FILE_TYPES)
+    assert hasattr(apc, 'tmp_archive_dir') is False
+    apc.get_hash_keys()
+    assert hasattr(apc, 'tmp_archive_dir') is False
+    cd = apc.get_entry_data({'file': 'dummyfile'},
+                            {})
+    assert cd is None
+    assert hasattr(apc, 'tmp_archive_dir') is False
+
+
+def test_get_hash_keys():
+    """
+    Verify that `get_hash_keys` returns the expected hash key.
+    """
+    hk = AirflowPackageCatalogConnector.get_hash_keys()
+    assert len(hk) == 1
+    assert hk[0] == 'file'
+
+
+def test_invalid_download_input(requests_mock):
+    """
+    Test invalid input scenarios.
+    """
+    apc = AirflowPackageCatalogConnector(AIRFLOW_SUPPORTED_FILE_TYPES)
+
+    # Input is an invalid URL/host.
+    requests_mock.get('http://no.such.host/a-file', real_http=True)
+    ce = apc.get_catalog_entries({'airflow_package_download_url':
+                                  'http://no.such.host/a-file'})
+    assert len(ce) == 0
+
+    # Input is a valid URL but does not include a filename.
+    requests_mock.get('http://server.domain.com', text='a-file-content')
+    ce = apc.get_catalog_entries({'airflow_package_download_url':
+                                  'http://server.domain.com/'})
+    assert len(ce) == 0
+
+    # Input is a valid URL, but does not return a ZIP-compressed file.
+    requests_mock.get('http://server.domain.com/a-file', text='another-file-content')
+    ce = apc.get_catalog_entries({'airflow_package_download_url':
+                                  'http://server.domain.com/a-file'})
+    assert len(ce) == 0
+
+    # Input is a valid URL and a ZIP-compressed file, but is not an Airflow built distribution.
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, 'a', zipfile.ZIP_DEFLATED) as zip_file:
+        zip_file.writestr('dummy_file.txt', 'I am a dummy file, living in a ZIP archive.')
+    requests_mock.get('http://server.domain.com/a-zip-file', content=zip_buffer.getvalue())
+    ce = apc.get_catalog_entries({'airflow_package_download_url':
+                                  'http://server.domain.com/a-zip-file'})
+    assert len(ce) == 0
+
+# -----------------------------------
+# Long running test(s)
+# ----------------------------------
+
+
+def test_1_10_15_distribution():
+    """
+    Test connector using Apache Airflow 1.10.15 built distribution.
+    """
+    apc = AirflowPackageCatalogConnector(AIRFLOW_SUPPORTED_FILE_TYPES)
+    # get catalog entries for the specified distribution
+    ces = apc.get_catalog_entries({'airflow_package_download_url': AIRFLOW_1_10_15_PKG_URL})
+    # this distribution should contain 37 Python scripts with operator definitions
+    assert len(ces) == 37
+    # each entry must contain two keys
+    for entry in ces:
+        # built distribution package file name
+        assert entry.get('airflow_package') == 'apache_airflow-1.10.15-py2.py3-none-any.whl'
+        # a Python script
+        assert entry.get('file', '').endswith('.py')
+
+    # fetch and validate the first entry
+    ce = apc.get_entry_data({'file': ces[0]['file']},
+                            {})
+
+    assert ce is not None
+    assert isinstance(ce, AirflowEntryData)
+    assert ce.definition is not None
+    assert ce.package_name.startswith('airflow.operators.')

--- a/elyra/tests/pipeline/airflow/test_airflow_provider_package_connector.py
+++ b/elyra/tests/pipeline/airflow/test_airflow_provider_package_connector.py
@@ -1,0 +1,118 @@
+#
+# Copyright 2018-2022 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import io
+import zipfile
+
+from elyra.pipeline.airflow.provider_package_catalog_connector.airflow_provider_package_catalog_connector import AirflowProviderPackageCatalogConnector  # noqa:E501
+from elyra.pipeline.catalog_connector import AirflowEntryData
+
+HTTP_PROVIDER_PKG_URL = 'https://files.pythonhosted.org/packages/a1/08/'\
+                        '91653e9f394cbefe356ac07db809be7e69cc89b094379ad91d6cef3d2bc9/'\
+                        'apache_airflow_providers_http-2.0.2-py3-none-any.whl'
+
+AIRFLOW_SUPPORTED_FILE_TYPES = [".py"]
+
+
+def test_empty_workdir():
+    """
+    Verify that the workdir isn't set by default. (The property is only set
+    after 'get_catalog_entries' was invoked.)
+    """
+    appc = AirflowProviderPackageCatalogConnector(AIRFLOW_SUPPORTED_FILE_TYPES)
+    assert hasattr(appc, 'tmp_archive_dir') is False
+    appc.get_hash_keys()
+    assert hasattr(appc, 'tmp_archive_dir') is False
+    cd = appc.get_entry_data({'file': 'dummyfile'},
+                             {})
+    assert cd is None
+    assert hasattr(appc, 'tmp_archive_dir') is False
+
+
+def test_get_hash_keys():
+    """
+    Verify that `get_hash_keys` returns the expected hash key.
+    """
+    hk = AirflowProviderPackageCatalogConnector.get_hash_keys()
+    assert len(hk) == 2
+    assert hk[0] == 'provider'
+    assert hk[1] == 'file'
+
+
+def test_invalid_download_input(requests_mock):
+    """
+    Test invalid input scenarios.
+    """
+    appc = AirflowProviderPackageCatalogConnector(AIRFLOW_SUPPORTED_FILE_TYPES)
+
+    # Input is an invalid URL/host.
+    requests_mock.get('http://no.such.host/a-file', real_http=True)
+    ce = appc.get_catalog_entries({'airflow_provider_package_download_url':
+                                   'http://no.such.host/a-file'})
+    assert len(ce) == 0
+
+    # Input is a valid URL but does not include a filename.
+    requests_mock.get('http://server.domain.com', text='a-file-content')
+    ce = appc.get_catalog_entries({'airflow_provider_package_download_url':
+                                   'http://server.domain.com/'})
+    assert len(ce) == 0
+
+    # Input is a valid URL but but does not return a ZIP-compressed file.
+    requests_mock.get('http://server.domain.com/a-file', text='a-file-content')
+    ce = appc.get_catalog_entries({'airflow_provider_package_download_url':
+                                   'http://server.domain.com/a-file'})
+    assert len(ce) == 0
+
+    # Input is a valid URL and a ZIP-compressed file, but not a provider package
+    zip_buffer = io.BytesIO()
+    with zipfile.ZipFile(zip_buffer, 'a', zipfile.ZIP_DEFLATED) as zip_file:
+        zip_file.writestr('dummy_file.txt', 'I am a dummy file, living in a ZIP archive.')
+    requests_mock.get('http://server.domain.com/a-zip-file', content=zip_buffer.getvalue())
+    ce = appc.get_catalog_entries({'airflow_provider_package_download_url':
+                                   'http://server.domain.com/a-zip-file'})
+    assert len(ce) == 0
+
+
+# -----------------------------------
+# Long running test(s)
+# ----------------------------------
+
+
+def test_http_provider_package():
+    """
+    Test connector using HTTP provider package
+    """
+    appc = AirflowProviderPackageCatalogConnector(AIRFLOW_SUPPORTED_FILE_TYPES)
+    # get catalog entries for the specified provider package
+    ces = appc.get_catalog_entries({'airflow_provider_package_download_url': HTTP_PROVIDER_PKG_URL})
+    # this package should contain 1 Python scripts with operator definitions
+    assert len(ces) == 1
+    # each entry must contain three keys
+    for entry in ces:
+        # provider package file name
+        assert entry.get('provider_package') == 'apache_airflow_providers_http-2.0.2-py3-none-any.whl'
+        # provider name
+        assert entry.get('provider') == 'apache_airflow_providers_http'
+        # a Python script
+        assert entry.get('file', '').endswith('.py')
+
+    # fetch and validate the first entry
+    ce = appc.get_entry_data({'file': ces[0]['file']},
+                             {})
+    assert ce is not None
+    assert isinstance(ce, AirflowEntryData)
+    assert ce.definition is not None
+    assert ce.package_name == 'airflow.providers.http.operators.http'

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,4 +9,5 @@ pytest>=5.4.1
 pytest-console-scripts
 pytest-tornasync
 pytest_virtualenv
+requests-mock
 requests-unixsocket


### PR DESCRIPTION
This PR delivers the Airflow connector changes for https://github.com/elyra-ai/elyra/issues/2460.

Requires: https://github.com/elyra-ai/elyra/pull/2492
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?

- Adopt the server-side connector API changes
- Update connector tests

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?

- Added new automated tests for each connector

**Airflow package connector**
- Add Airflow 1.10.15 built distribution to the catalog ([instructions](https://github.com/elyra-ai/elyra/tree/master/elyra/pipeline/airflow/package_catalog_connector))
- Create an Airflow pipeline
- Add the `DummyOperator` to the pipeline (_do not_ use `SlackAPIPostOperator`, `BashOperator`, `EmailOperator`, `SimpleHttpOperator`, `SparkSqlOperator` or `SparkSubmitOperator`)
- Export the pipeline
- Review the exported DAG: make sure there is a valid `import` statement for the operator
   ![image](https://user-images.githubusercontent.com/13068832/154774187-15ee4a9a-bf53-477c-873a-fb6b4727aa92.png)
- Run the pipeline

**Airflow provider package connector**
- Add any Airflow 1.10.x compatible provider package to the catalog ([instructions](https://github.com/elyra-ai/elyra/tree/master/elyra/pipeline/airflow/provider_package_catalog_connector)) that is installed in the Airflow cluster
- Create an Airflow pipeline
- Add an operator from the provider package  to the pipeline 
- Export the pipeline
- Review the exported DAG: make sure there is a valid import statement for the operator
   ![image](https://user-images.githubusercontent.com/13068832/154985958-824a19a5-22fa-4fd0-9bd8-6933a8942318.png)
- Run the pipeline


<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
