### PR TITLE
Move release template into elyra repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ test-dependencies:
 pytest:
 	pytest -v elyra
 
-test-server: install-server test-dependencies pytest # Run python unit tests
+test-server: test-dependencies pytest # Run python unit tests
 
 test-ui-unit: # Run frontend jest unit tests
 	yarn test:unit

--- a/create-release.py
+++ b/create-release.py
@@ -410,8 +410,8 @@ def prepare_extensions_release() -> None:
 
     extensions = {'elyra-code-snippet-extension':['code-snippet-extension', 'metadata-extension', 'theme-extension'],
                   'elyra-pipeline-editor-extension':['pipeline-editor-extension', 'metadata-extension', 'theme-extension'],
-                  'elyra-python-editor-extension':['metadata-extension', 'theme-extension'],
-                  'elyra-r-editor-extension':['metadata-extension', 'theme-extension']}
+                  'elyra-python-editor-extension':['python-editor-extension', 'metadata-extension', 'theme-extension'],
+                  'elyra-r-editor-extension':['r-editor-extension', 'metadata-extension', 'theme-extension']}
 
     for extension in extensions:
         extension_source_dir = os.path.join(config.work_dir, extension)

--- a/create-release.py
+++ b/create-release.py
@@ -35,8 +35,8 @@ config: SimpleNamespace
 
 VERSION_REG_EX = r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<pre_release>[a-z]+)(?P<build>\d+))?"
 
-DEFAULT_GIT_URL = 'git@github.com:elyra-ai/elyra.git'
-DEFAULT_GIT_BRANCH = ''
+DEFAULT_GIT_ORG = 'elyra-ai'
+DEFAULT_GIT_BRANCH = 'master'
 DEFAULT_BUILD_DIR = 'build/release'
 
 
@@ -276,7 +276,7 @@ def checkout_code() -> None:
     print(f'Creating working directory: {config.work_dir}')
     os.makedirs(config.work_dir)
     print(f'Cloning : {config.git_url} to {config.work_dir}')
-    check_run(['git', 'clone', config.git_url, '-b' if config.git_branch else '', config.git_branch], cwd=config.work_dir)
+    check_run(['git', 'clone', config.git_url, '-b', config.git_branch], cwd=config.work_dir)
     check_run(['git', 'config', 'user.name', config.git_user_name], cwd=config.source_dir)
     check_run(['git', 'config', 'user.email', config.git_user_email], cwd=config.source_dir)
 
@@ -608,8 +608,8 @@ def initialize_config(args=None) -> SimpleNamespace:
 
     configuration = {
         'goal': args.goal,
-        'git_url': DEFAULT_GIT_URL,
-        'git_branch': DEFAULT_GIT_BRANCH,
+        'git_url': f"git@github.com:{args.org or DEFAULT_GIT_ORG}/elyra.git",
+        'git_branch': args.branch or DEFAULT_GIT_BRANCH,
         'git_hash': 'HEAD',
         'git_user_name': check_output(['git', 'config', 'user.name']),
         'git_user_email': check_output(['git', 'config', 'user.email']),
@@ -639,10 +639,10 @@ def print_config() -> None:
     print("-----------------------------------------------------------------")
     print(f'Goal \t\t\t -> {config.goal}')
     print(f'Git URL \t\t -> {config.git_url}')
-    print(f'Git Branch \t -> {config.git_branch}')
+    print(f'Git Branch \t\t -> {config.git_branch}')
     print(f'Git reference \t\t -> {config.git_hash}')
     print(f'Git user \t\t -> {config.git_user_name}')
-    print(f'Git user emain \t\t -> {config.git_user_email}')
+    print(f'Git user email \t\t -> {config.git_user_email}')
     print(f'Work dir \t\t -> {config.work_dir}')
     print(f'Source dir \t\t -> {config.source_dir}')
     print(f'Old Version \t\t -> {config.old_version}')
@@ -700,6 +700,8 @@ def main(args=None):
     parser.add_argument('--dev-version', help='the new development version', type=str, required=False)
     parser.add_argument('--beta', help='the release beta number', type=str, required=False)
     parser.add_argument('--rc', help='the release candidate number', type=str, required=False)
+    parser.add_argument('--org', help='the github org or username to use', type=str, required=False)
+    parser.add_argument('--branch', help='the branch name to use', type=str, required=False)
     args = parser.parse_args()
 
     # can't use both rc and beta parameters

--- a/etc/templates/setup.py
+++ b/etc/templates/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018-2021 Elyra Authors
+# Copyright 2018-2022 Elyra Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/templates/setup.py
+++ b/etc/templates/setup.py
@@ -1,0 +1,62 @@
+#
+# Copyright 2018-2021 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+import sys
+from glob import glob
+from jupyter_packaging import get_data_files
+from setuptools import setup, find_packages
+
+long_desc = """
+            Elyra is a set of AI centric extensions to JupyterLab. It aims to help data scientists,
+            machine learning engineers and AI developer’s through the model development life cycle complexities.
+            """
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+setup_args = dict(
+    name="{{package-name}}",
+    version='{{version}}',
+    url="https://github.com/elyra-ai/elyra",
+    description="Elyra provides AI Centric extensions to JupyterLab",
+    long_description=long_desc,
+    author="Elyra Maintainers",
+    license="Apache License Version 2.0",
+    data_files=get_data_files([
+        {{data-files}}
+    ]),
+    packages=find_packages(),
+    install_requires=[
+        {{install-requires}}
+    ],
+    include_package_data=True,
+    classifiers=(
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
+        'Topic :: Software Development',
+        'Topic :: Software Development :: Libraries',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+    ),
+    entry_points={},
+)
+
+if __name__ == '__main__':
+    setup(**setup_args)

--- a/etc/templates/setup.py
+++ b/etc/templates/setup.py
@@ -50,10 +50,10 @@ setup_args = dict(
         'Topic :: Software Development',
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ),
     entry_points={},
 )


### PR DESCRIPTION
Move the setup.py template file used by the release script into
the elyra repo for easier editing. Also updates the release script
to fix some bugs now that the template is easier to edit.

List of changes:
- Moved setup.py template file from separate repo into elyra repo
- Added support for cloning a branch instead of master (for testing)
  - The release script now supports running with different forks and branches using the `--org` and `--branch` flags
- Fixed issue where r and python editor releases don't include the editor extension

Fixes #2508

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
