### PR TITLE
Add a refresh button the header of Metadata Widget

### DIFF
--- a/packages/metadata-common/src/MetadataHeaderButtons.tsx
+++ b/packages/metadata-common/src/MetadataHeaderButtons.tsx
@@ -15,7 +15,7 @@
  */
 
 import { IDictionary } from '@elyra/services';
-import { addIcon } from '@jupyterlab/ui-components';
+import { addIcon, refreshIcon } from '@jupyterlab/ui-components';
 import {
   Box,
   ButtonGroup,
@@ -32,19 +32,20 @@ import React from 'react';
 export const METADATA_HEADER_BUTTON_CLASS = 'elyra-metadataHeader-button';
 export const METADATA_HEADER_POPPER_CLASS = 'elyra-metadataHeader-popper';
 
-export interface IAddMetadataButtonProps {
+export interface IMetadataHeaderButtonsProps {
   schemas?: IDictionary<any>[];
   addMetadata: (schema: string, titleContext?: string) => void;
   titleContext?: string;
   appendToTitle?: boolean;
+  refreshMetadata: () => void;
 }
 
 const StyledButton = styled(Button)({
   minWidth: 'auto'
 });
 
-export const AddMetadataButton = (
-  props: IAddMetadataButtonProps
+export const MetadataHeaderButtons = (
+  props: IMetadataHeaderButtonsProps
 ): React.ReactElement => {
   const [open, setOpen] = React.useState(false);
   const anchorRef = React.useRef<HTMLDivElement>(null);
@@ -76,6 +77,17 @@ export const AddMetadataButton = (
   return (
     <Box>
       <ButtonGroup ref={anchorRef} variant="text">
+        <StyledButton
+          size="small"
+          className={METADATA_HEADER_BUTTON_CLASS}
+          onClick={(): void => {
+            props.refreshMetadata();
+            setOpen(false);
+          }}
+          title="Refresh list"
+        >
+          <refreshIcon.react tag="span" elementPosition="center" width="16px" />
+        </StyledButton>
         <StyledButton
           size="small"
           className={METADATA_HEADER_BUTTON_CLASS}

--- a/packages/metadata-common/src/MetadataWidget.tsx
+++ b/packages/metadata-common/src/MetadataWidget.tsx
@@ -37,9 +37,9 @@ import { Signal } from '@lumino/signaling';
 
 import React from 'react';
 
-import { AddMetadataButton } from './AddMetadataButton';
 import { FilterTools } from './FilterTools';
 import { MetadataCommonService } from './MetadataCommonService';
+import { MetadataHeaderButtons } from './MetadataHeaderButtons';
 
 /**
  * The CSS class added to metadata widgets.
@@ -462,11 +462,12 @@ export class MetadataWidget extends ReactWidget {
               />
               <p> {this.props.display_name} </p>
             </div>
-            <AddMetadataButton
+            <MetadataHeaderButtons
               schemas={this.schemas}
               addMetadata={this.addMetadata}
               titleContext={this.titleContext}
               appendToTitle={this.props.appendToTitle}
+              refreshMetadata={this.updateMetadata}
             />
           </header>
           <UseSignal signal={this.renderSignal} initialArgs={[]}>

--- a/packages/metadata-common/src/index.ts
+++ b/packages/metadata-common/src/index.ts
@@ -18,5 +18,5 @@ import '../style/index.css';
 
 export * from './MetadataEditor';
 export * from './MetadataWidget';
-export * from './AddMetadataButton';
+export * from './MetadataHeaderButtons';
 export * from './MetadataCommonService';

--- a/packages/metadata-common/style/index.css
+++ b/packages/metadata-common/style/index.css
@@ -45,6 +45,10 @@
   cursor: pointer;
 }
 
+.elyra-metadataHeader-button.MuiButtonGroup-groupedTextHorizontal:not(:last-child) {
+  border-right: none;
+}
+
 .elyra-metadataHeader [fill] {
   fill: var(--jp-ui-font-color1);
 }
@@ -119,7 +123,7 @@
 .elyra-metadataEditor
   .elyra-metadataEditor-arrayInput
   li:not(.elyra-metadataEditor-arrayItemEditor)
-  .elyra-MuiInputBase-formControl {
+  .elyra-elyra-metadataHeaderMuiInputBase-formControl {
   background-color: var(--jp-border-color3);
 }
 


### PR DESCRIPTION
This adds a button to the header of the Metadata Widget that allows
a user to manually refresh the list of metadata. This is helpful for
both users who use the both the CLI and UI simultaneously.

The refresh does not have any side effects, meaning no action is performed if the refreshed list contains a new instance, an updated instance, or a 'deleted' instance.

Fixes #2504

<img width="346" alt="Screen Shot 2022-03-03 at 3 10 28 PM" src="https://user-images.githubusercontent.com/13952758/156653451-a18349a5-7b3e-41a3-af5d-8b840061d2f1.png">

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
