### PR TITLE
Metadata tag whitespace proposed solution

### DIFF
--- a/elyra/metadata/schemas/airflow.json
+++ b/elyra/metadata/schemas/airflow.json
@@ -178,7 +178,15 @@
         "tags": {
           "title": "Tags",
           "description": "Tags for categorizing Apache Airflow",
+          "uniqueItems": true,
           "type": "array",
+          "items": {
+            "allOf": [
+              { "minLength": 1 },
+              { "pattern": "^[^ \t]+" },
+              { "pattern": "[^ \t]+$" }
+            ]
+          },
           "uihints": {
             "field_type": "tags"
           }

--- a/elyra/metadata/schemas/code-snippet.json
+++ b/elyra/metadata/schemas/code-snippet.json
@@ -36,6 +36,14 @@
           "title": "Tags",
           "description": "Tags for categorizing snippets",
           "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "allOf": [
+              { "minLength": 1 },
+              { "pattern": "^[^ \t]+" },
+              { "pattern": "[^ \t]+$" }
+            ]
+          },
           "uihints": {
             "field_type": "tags"
           }

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -168,7 +168,15 @@
         "tags": {
           "title": "Tags",
           "description": "Tags for categorizing Kubeflow pipelines",
+          "uniqueItems": true,
           "type": "array",
+          "items": {
+            "allOf": [
+              { "minLength": 1 },
+              { "pattern": "^[^ \t]+" },
+              { "pattern": "[^ \t]+$" }
+            ]
+          },
           "uihints": {
             "field_type": "tags"
           }

--- a/elyra/metadata/schemas/metadata-test.json
+++ b/elyra/metadata/schemas/metadata-test.json
@@ -80,6 +80,16 @@
           "type": "string",
           "pattern": "^[a-z0-9][a-z0-9-.]*[a-z0-9]$"
         },
+        "string_complex_test": {
+          "title": "String Complex Test",
+          "description": "Property used to test strings with multiple restrictions",
+          "type": "string",
+          "allOf": [
+            { "minLength": 1 },
+            { "pattern": "^[^ \t]+" },
+            { "pattern": "[^ \t]+$" }
+          ]
+        },
         "enum_test": {
           "title": "Enum Test",
           "description": "Property used to test properties with enums",

--- a/elyra/metadata/schemas/runtime-image.json
+++ b/elyra/metadata/schemas/runtime-image.json
@@ -35,7 +35,15 @@
         "tags": {
           "title": "Tags",
           "description": "Tags for categorizing runtime images",
+          "uniqueItems": true,
           "type": "array",
+          "items": {
+            "allOf": [
+              { "minLength": 1 },
+              { "pattern": "^[^ \t]+" },
+              { "pattern": "[^ \t]+$" }
+            ]
+          },
           "uihints": {
             "field_type": "tags"
           }

--- a/elyra/tests/metadata/test_metadata.py
+++ b/elyra/tests/metadata/test_metadata.py
@@ -158,19 +158,22 @@ def test_manager_add_display_name(tests_manager, schemaspace_location):
         tests_manager.metadata_store.fetch_instances(metadata_name)
 
 
-@pytest.mark.parametrize("complex_string, valid", [
-    ("", False),
-    (" ", False),
-    (" starting-whitespace", False),
-    ("ending-whitespace ", False),
-    (" whitespace-both-ends ", False),
-    ("whitespace in between", True),
-    ("no-whitespace", True),
-])
+@pytest.mark.parametrize(
+    "complex_string, valid",
+    [
+        ("", False),
+        (" ", False),
+        (" starting-whitespace", False),
+        ("ending-whitespace ", False),
+        (" whitespace-both-ends ", False),
+        ("whitespace in between", True),
+        ("no-whitespace", True),
+    ],
+)
 def test_manager_complex_string_schema(tests_manager, schemaspace_location, complex_string, valid):
-    metadata_name = 'valid_metadata_instance'
+    metadata_name = "valid_metadata_instance"
     metadata_dict = {**valid_metadata_json}
-    metadata_dict['metadata']['string_complex_test'] = complex_string
+    metadata_dict["metadata"]["string_complex_test"] = complex_string
     metadata = Metadata.from_dict(METADATA_TEST_SCHEMASPACE_ID, metadata_dict)
 
     if not valid:
@@ -179,7 +182,7 @@ def test_manager_complex_string_schema(tests_manager, schemaspace_location, comp
 
     else:
         instance = tests_manager.create(metadata_name, metadata)
-        assert instance.metadata.get('string_complex_test') == complex_string
+        assert instance.metadata.get("string_complex_test") == complex_string
 
         # And finally, remove it.
         tests_manager.remove(metadata_name)


### PR DESCRIPTION
According to the issue referenced above there are problems with `whitespace only` and `empty` tags. In fact, upon looking into this issue there are some other concerns that we should look to address. The proposed solution in the schema will touch upon a couple of items:

1. Whitespace at the beginning of the line. A [regex](https://json-schema.org/understanding-json-schema/reference/regular_expressions.html#regular-expressions) was added following the allowed pattern options in a json schema to stop any number of whitespace characters after the beginning of a tag - `"^[^ \t]+"` - this can be read as "after the beginning of line, only allow non-whitespace characters for any length." This stop only whitespace as well because a first character whitespace will not be a non-whitespace character.  
2. Whitespace at the end of the line. Very similar to the above, `"[^ \t]+$"` was added to stop whitespace after a tag. This can be read as "Only allow non-whitespace characters of any length before ending the tag". Great! This will stop that extra space after a tag being allowed - something we do not want. 
3. [Minimum length tags](http://json-schema.org/understanding-json-schema/reference/string.html?highlight=minlength#id5) Following the linked item, we added an `item` parameter to stop 0 length tags. This is aimed to stop the empty tag situation.
4. [Unique items](https://json-schema.org/understanding-json-schema/reference/array.html?highlight=unique#uniqueness) While we're here, we should think. This seems to make sense logically, why should there be duplicated tags? Well, we stop this with a uniqueness boolean, but it is something to be discussed. I can imagine a situation where somebody is scripting tag creation and they are tagging something multiple times with "passed" or "correct" or "complete" or one of many other items indication some kind of finish. Then, they are just checking the count of the tags. Similarly, perhaps they are adding the tag "1" to on each round of run and are using that as a counter for their application. Would this not be valid. Should this be stopped? 

Anyway, below are examples of many use cases and their current outputs with the added code and it covers more than the expected behavior (linked in the issue and referenced below)! 

```
UI - The editor should discard/flag whitespace only tags.
CLI - Metadata service should validate whitespace/empty string tags. 
```

1. expected usage - allowed
![elyra-test-expected](https://user-images.githubusercontent.com/37085557/157288165-9dce322e-7e39-4578-94e2-626e37288716.png)
There is no effect on a traditional tag without whitespace 

2. whitespace in the middle of the tags - allowed
![elyra-test-whitepace-in-the-middle](https://user-images.githubusercontent.com/37085557/157288974-1e4d6f58-1a34-4655-ad9e-8f22834f5fe7.png)
There is no effect to tags that contain whitespace within the tags themselves

3. example used in issue description - not allowed
![elyra-example-from-issue](https://user-images.githubusercontent.com/37085557/157288256-a7c810a5-60f0-4b7c-b7ca-e6ccc28acca6.png)
The example tests with both an empty string tag `''` and an only whitespace tag `'    '`. Neither of these are allowed. And thankfully not when they're together either. We can look at the individual tags submitted below.

4. empty string tag
![elyra-empty-tag](https://user-images.githubusercontent.com/37085557/157289975-afdb5274-d020-4d48-a39f-780a2c72ec4e.png)
The tag stops the code snippet creation on validation due to the tag being too short. Great!

 
5. whitespace only tags - not allowed
![elyra-just-space](https://user-images.githubusercontent.com/37085557/157288289-cb7335a2-1421-4454-bca6-ff3537b536c6.png)
The tag stops the code snippet creation on validation due to a failure on the first pattern match. Great!

6. whitespace before the tag - not allowed
![elyra-test-begin-space](https://user-images.githubusercontent.com/37085557/157288313-1afe4fb9-160d-427a-99a1-f2aa369f94c9.png)
The tag stops the code snippet creation on validation due to a failure on the first pattern match. Great!

7. whitespace after the tag - not allowed
![elyra-test-end-space](https://user-images.githubusercontent.com/37085557/157288333-abee7d4a-50d9-4d25-b754-961d837f3bea.png)
The tag stops the code snippet creation on validation due to a failure on the second pattern match. Great!

8. whitespace before and after the tag - not allowed
![elyra-test-space-both-ends](https://user-images.githubusercontent.com/37085557/157288356-f7b65b5c-26b9-4f7b-83a2-18f351cafdeb.png)
The tag stops the code snippet creation on validation due to a failure on the first pattern match. Great!

9. duplicated tags - to discuss
![elyra-test-dup](https://user-images.githubusercontent.com/37085557/157288363-76510b0d-d422-4de4-82ed-be83d7a01c01.png)
The tag stops the code snippet creation on validation due to a failure on the uniqueness! Great! Or is it?

Fixes: #2019 