### PR TITLE
Fix error handling when replace used w/o schemaspace

### DIFF
--- a/docs/source/recipes/deploying-kubeflow-locally-for-dev.md
+++ b/docs/source/recipes/deploying-kubeflow-locally-for-dev.md
@@ -92,7 +92,7 @@ These endpoints will be used to configure your Elyra metadata runtime with the
 command below:
 
 ```bash
-elyra-metadata install runtimes --replace=true \
+elyra-metadata install runtimes \
        --schema_name=kfp \
        --name=kfp-local \
        --display_name="Kubeflow Pipeline (local)" \

--- a/elyra/metadata/storage.py
+++ b/elyra/metadata/storage.py
@@ -196,6 +196,8 @@ class FileMetadataStore(MetadataStore):
         If name is provided, the single instance will be returned in a list of one item.
         """
         if not self.schemaspace_exists():  # schemaspace doesn't exist - return empty list
+            if name:  # If we're looking for a single metadata and we're looking for a specific instance, raise
+                raise MetadataNotFoundError(self.schemaspace, name)
             return []
 
         resources = {}

--- a/elyra/tests/metadata/test_metadata_app.py
+++ b/elyra/tests/metadata/test_metadata_app.py
@@ -184,6 +184,14 @@ def test_install_and_replace(script_runner, mock_data_dir):
     if os.path.exists(expected_file):
         os.remove(expected_file)
 
+    # Attempt replace before schemaspace exists and ensure appropriate error message
+    ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_SCHEMASPACE, '--schema_name=metadata-test',
+                            '--name=test-metadata_42_valid-name', '--display_name=display_name',
+                            '--required_test=required_value', '--replace')
+    assert ret.success is False
+    assert "No such instance named 'test-metadata_42_valid-name' was found in the metadata-tests schemaspace." \
+           in ret.stdout
+
     ret = script_runner.run('elyra-metadata', 'install', METADATA_TEST_SCHEMASPACE, '--schema_name=metadata-test',
                             '--name=test-metadata_42_valid-name', '--display_name=display_name',
                             '--required_test=required_value', '--number_default_test=24')


### PR DESCRIPTION
The recipe for [deploying Kubeflow pipelines locally](https://elyra.readthedocs.io/en/stable/recipes/deploying-kubeflow-locally-for-dev.html) erroneously lists the `elyra-metadata` command used to create an initial runtime configuration with a `--replace=true` option.  (This is erroneous on two counts: 1) replace is meant to be used when an instance already exists, and 2) `--replace` is a _flag_ that doesn't take values.  Turns out values of _flag_ options are ignored.)

Under normal circumstances, when other runtime instances exist and `--replace` is used to _create_ an initial instance, the user will receive the message (using the command from the docs):
```
The following exception occurred saving metadata instance for schema 'kfp': No such instance named 'kfp-local' was found in the runtimes schemaspace.
```
However, prior to these changes, the user gets the error:
```
The following exception occurred saving metadata instance for schema 'kfp': list index out of range
```
This is due to how the metadata service handles retrievals when the schemaspace doesn't exist - it just returns an empty list.  However, since this is a request for a specific instance and not _all_ instances, we should issue a similar "No such instance" message.

This PR detects this situation and raises a `MetadataNotFound` exception (i.e., "No such instance").  It also removes the erroneous `--replace` flag from the documentation, and extends the metadata test to check for this particular scenario.


Resolves: #2539 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
