### PR TITLE
Address Metadata UI inconsistencies

### DIFF
--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -23,7 +23,11 @@ import {
   JupyterFrontEndPlugin,
   ILabStatus
 } from '@jupyterlab/application';
-import { IThemeManager, ICommandPalette } from '@jupyterlab/apputils';
+import {
+  IThemeManager,
+  ICommandPalette,
+  MainAreaWidget
+} from '@jupyterlab/apputils';
 import { IEditorServices } from '@jupyterlab/codeeditor';
 import { textEditorIcon, LabIcon } from '@jupyterlab/ui-components';
 
@@ -94,7 +98,8 @@ const extension: JupyterFrontEndPlugin<void> = {
       metadataEditorWidget.title.icon = textEditorIcon;
       metadataEditorWidget.addClass(METADATA_EDITOR_ID);
       metadataEditorWidget.titleContext = args.titleContext;
-      app.shell.add(metadataEditorWidget, 'main');
+      const main = new MainAreaWidget({ content: metadataEditorWidget });
+      app.shell.add(main, 'main');
     };
 
     app.commands.addCommand(`${METADATA_EDITOR_ID}:open`, {

--- a/packages/pipeline-editor/src/index.ts
+++ b/packages/pipeline-editor/src/index.ts
@@ -361,6 +361,9 @@ const extension: JupyterFrontEndPlugin<void> = {
     runtimeImagesWidget.title.icon = containerIcon;
     runtimeImagesWidget.title.caption = 'Runtime Images';
 
+    restorer.add(runtimeImagesWidget, runtimeImagesWidgetID);
+    app.shell.add(runtimeImagesWidget, 'left', { rank: 951 });
+
     const componentCatalogWidget = new MetadataWidget({
       app,
       themeManager,
@@ -374,8 +377,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     componentCatalogWidget.title.icon = componentCatalogIcon;
     componentCatalogWidget.title.caption = 'Component Catalogs';
 
-    restorer.add(runtimeImagesWidget, runtimeImagesWidgetID);
-    app.shell.add(runtimeImagesWidget, 'left', { rank: 951 });
+    restorer.add(componentCatalogWidget, componentCatalogWidgetID);
     app.shell.add(componentCatalogWidget, 'left', { rank: 961 });
   }
 };

--- a/tests/integration/codesnippet.ts
+++ b/tests/integration/codesnippet.ts
@@ -42,9 +42,9 @@ describe('Code Snippet tests', () => {
     createInvalidCodeSnippet(snippetName);
 
     // Metadata editor should not close
-    cy.get(
-      'li.lm-TabBar-tab[data-id="elyra-metadata-editor:code-snippets:code-snippet:new"]'
-    ).should('be.visible');
+    cy.get('.lm-TabBar-tabLabel')
+      .contains('New Code Snippet')
+      .should('be.visible');
 
     // Fields marked as required should be highlighted
     cy.get(
@@ -57,9 +57,9 @@ describe('Code Snippet tests', () => {
     createValidCodeSnippet(snippetName);
 
     // Metadata editor tab should not be visible
-    cy.get(
-      'li.lm-TabBar-tab[data-id="elyra-metadata-editor:code-snippets:code-snippet:new"]'
-    ).should('not.exist');
+    cy.get('.lm-TabBar-tabLabel')
+      .contains('New Code Snippet')
+      .should('not.exist');
 
     // Check new code snippet is displayed
     getSnippetByName(snippetName);
@@ -85,9 +85,9 @@ describe('Code Snippet tests', () => {
     cy.get('.elyra-metadataEditor-form-display_name').type('{enter}');
 
     // Metadata editor tab should not be visible
-    cy.get(
-      'li.lm-TabBar-tab[data-id="elyra-metadata-editor:code-snippets:code-snippet:new"]'
-    ).should('not.exist');
+    cy.get('.lm-TabBar-tabLabel')
+      .contains('New Code Snippet')
+      .should('not.exist');
 
     // Check new code snippet is displayed
     getSnippetByName(snippetName);


### PR DESCRIPTION
Adds the Component Catalogs Widget to the restorer so it will show
on page refresh like the other default metadata tabs.

Also wraps the Metadata Editor in a MainArea Widget to match other
widgets in the main area.

Screenshots (before and after):
 ![Screen Shot 2022-03-14 at 2 49 04 PM](https://user-images.githubusercontent.com/13952758/158250321-9189defe-4d40-4703-84ad-4b5ddf1cfcdc.png)
![Screen Shot 2022-03-14 at 2 52 50 PM](https://user-images.githubusercontent.com/13952758/158250324-ba8afee0-fcb0-4a9a-926e-5627813d931e.png)

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
