### PR TITLE
CLI: Add support for '--include-invalid' option to list/export commands

### DIFF
--- a/elyra/metadata/metadata_app.py
+++ b/elyra/metadata/metadata_app.py
@@ -65,12 +65,18 @@ class SchemaspaceList(SchemaspaceBase):
     json_flag = Flag("--json", name='json',
                      description='List complete instances as JSON', default_value=False)
 
+    # deprecated: remove this flag in 4.0
     valid_only_flag = Flag("--valid-only", name='valid-only',
-                           description='Only list valid instances (default includes invalid instances)',
+                           description='[Deprecated] Only list valid instances (default includes invalid instances).'
+                           'This option will be removed in Elyra v4.0.',
                            default_value=False)
 
+    include_invalid_flag = Flag("--include-invalid", name='include-invalid',
+                                description='Include invalid instances.',
+                                default_value=False)
+
     # 'List' flags
-    options = [json_flag, valid_only_flag]
+    options = [json_flag, valid_only_flag, include_invalid_flag]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -79,7 +85,19 @@ class SchemaspaceList(SchemaspaceBase):
     def start(self):
         super().start()  # process options
 
-        include_invalid = not self.valid_only_flag.value
+        # TODO: remove this check in 4.0
+        if self.valid_only_flag.value is True and self.include_invalid_flag.value is True:
+            print(f"ERROR. Options '{self.valid_only_flag.cli_option}' and '{self.include_invalid_flag.cli_option}'"
+                  " are mutually exclusive.")
+            self.exit(1)
+
+        # 3.7 behavior: include invalid, unless explicitly excluded
+        include_invalid = True
+        if self.valid_only_flag.value:
+            include_invalid = False
+        # TODO 4.0+ behavior:  include invalid, if explicitly requested
+        # include_invalid = self.include_invalid_flag.value
+
         try:
             metadata_instances = self.metadata_manager.get_all(include_invalid=include_invalid)
         except MetadataNotFoundError:
@@ -91,11 +109,11 @@ class SchemaspaceList(SchemaspaceBase):
             print(metadata_instances)
         else:
             if not metadata_instances:
-                print("No metadata instances found for {}".format(self.schemaspace))
+                print(f"No metadata instances found for {self.schemaspace}")
                 return
 
             validity_clause = "includes invalid" if include_invalid else "valid only"
-            print("Available metadata instances for {} ({}):".format(self.schemaspace, validity_clause))
+            print(f"Available metadata instances for {self.schemaspace} ({validity_clause}):")
 
             sorted_instances = sorted(metadata_instances, key=lambda inst: (inst.schema_name, inst.name))
             # pad to width of longest instance
@@ -108,16 +126,18 @@ class SchemaspaceList(SchemaspaceBase):
                 max_resource_len = max(len(instance.resource), max_resource_len)
 
             print()
-            print("%s   %s  %s  " % ('Schema'.ljust(max_schema_name_len),
-                                     'Instance'.ljust(max_name_len),
-                                     'Resource'.ljust(max_resource_len)))
-            print("%s   %s  %s  " % ('------'.ljust(max_schema_name_len),
-                                     '--------'.ljust(max_name_len),
-                                     '--------'.ljust(max_resource_len)))
+            print(f"{'Schema'.ljust(max_schema_name_len)}   "
+                  f"{'Instance'.ljust(max_name_len)}  "
+                  f"{'Resource'.ljust(max_resource_len)}  ")
+            print(f"{'------'.ljust(max_schema_name_len)}   "
+                  f"{'--------'.ljust(max_name_len)}  "
+                  f"{'--------'.ljust(max_resource_len)}  ")
+
             for instance in sorted_instances:
                 invalid = ""
                 if instance.reason and len(instance.reason) > 0:
-                    invalid = "**INVALID** ({})".format(instance.reason)
+                    invalid = f"**INVALID** ({instance.reason})"
+                # print()
                 print("%s   %s  %s  %s" % (instance.schema_name.ljust(max_schema_name_len),
                                            instance.name.ljust(max_name_len),
                                            instance.resource.ljust(max_resource_len),
@@ -385,9 +405,15 @@ class SchemaspaceExport(SchemaspaceBase):
                                    description='The schema name of the metadata instances to export',
                                    required=False)
 
+    # deprecated: remove this flag in 4.0
     valid_only_flag = Flag("--valid-only", name='valid-only',
-                           description='Only export valid instances (default includes invalid instances)',
+                           description='[Deprecated] Only export valid instances (default includes invalid instances).'
+                           'This option will be removed in Elyra v4.0.',
                            default_value=False)
+
+    include_invalid_flag = Flag("--include-invalid", name='include-invalid',
+                                description='Include invalid instances.',
+                                default_value=False)
 
     clean_flag = Flag("--clean", name='clean',
                       description='Clear out contents of the export directory',
@@ -398,7 +424,7 @@ class SchemaspaceExport(SchemaspaceBase):
                                  required=True)
 
     # 'Export' flags
-    options: List[Option] = [schema_name_option, valid_only_flag, clean_flag, directory_option]
+    options: List[Option] = [schema_name_option, valid_only_flag, include_invalid_flag, clean_flag, directory_option]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -415,7 +441,18 @@ class SchemaspaceExport(SchemaspaceBase):
                       f"the schema name must be one of {schema_list}")
                 self.exit(1)
 
-        include_invalid = not self.valid_only_flag.value
+        if self.valid_only_flag.value is True and self.include_invalid_flag.value is True:
+            print(f"ERROR. Options '{self.valid_only_flag.cli_option}' and '{self.include_invalid_flag.cli_option}'"
+                  " are mutually exclusive.")
+            self.exit(1)
+
+        # 3.7 behavior: include invalid, unless explicitly excluded
+        include_invalid = True
+        if self.valid_only_flag.value:
+            include_invalid = False
+        # TODO 4.0+ behavior:  include invalid, if explicitly requested
+        # include_invalid = self.include_invalid_flag.value
+
         directory = self.directory_option.value
         clean = self.clean_flag.value
 


### PR DESCRIPTION
Addresses the first stage of https://github.com/elyra-ai/elyra/issues/2562, which introduces a new `--include-invalid` option for the `elyra-metadata list` and `elyra-metadata export` commands.
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
- Marked `--valid-only` option for the `elyra-metadata list` and `elyra-metadata export` commands as deprecated (to be removed in version 4.0)
- Add new `--include-invalid` option for the `elyra-metadata list` and `elyra-metadata export` commands. Prior to version 4.0 this option is a no-op.
- Updated the documentation 
- Follow-up is required in version 4.0 to remove the deprecated code
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
- Added/ updated unit test cases
- Reviewed the out put of `make docs`
- Ran manual tests using CLI
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
