### PR TITLE
Add unit tests for script editor package

### DIFF
--- a/docs/source/developer_guide/contributing.md
+++ b/docs/source/developer_guide/contributing.md
@@ -102,12 +102,8 @@ Then, in the `package.json`, add the following under `'scripts'`:
 ```
 And the following under `'dev_dependencies'`:
 ```
-"@jupyterlab/testutils": "^1.0.0",
-"@types/enzyme": "^3.10.5",
-"@types/enzyme-adapter-react-16": "^1.0.6",
+"@jupyterlab/testutils": "3.3.0",
 "@types/jest": "^23.3.11",
-"enzyme": "^3.11.0",
-"enzyme-adapter-react-16": "^1.15.3",
 "install": "^0.13.0",
 "jest": "^24.7.1",
 "jest-raw-loader": "^1.0.1",

--- a/docs/source/developer_guide/contributing.md
+++ b/docs/source/developer_guide/contributing.md
@@ -87,7 +87,7 @@ Refer to the [cypress API](https://docs.cypress.io/api/api/table-of-contents.htm
 New integration tests can be added to `tests/integration`. 
 
 #### UI Unit tests
-To run all of the unit tests, use `make test-ui-unit` from the root directory. To run the unit tests for a specific Elyra package, simply run `jest` from that package's directory (under `packages/`). For writing tests, `jest` has a watch mode option: just run `jest --watch`. 
+To run all of the unit tests, use `make test-ui-unit` from the root directory. To run the unit tests for a specific Elyra package, simply run `jest` or `npm run test` from that package's directory (under `packages/`). To turn on the watch mode just run `jest --watch` or `npm run test --watch`.
 
 Elyra's unit tests test the various classes and objects used by Elyra extensions. Refer to the [jest API](https://jestjs.io/docs/en/getting-started) for more details. 
 

--- a/docs/source/developer_guide/contributing.md
+++ b/docs/source/developer_guide/contributing.md
@@ -104,7 +104,6 @@ And the following under `'dev_dependencies'`:
 ```
 "@jupyterlab/testutils": "3.3.0",
 "@types/jest": "^23.3.11",
-"install": "^0.13.0",
 "jest": "^24.7.1",
 "jest-raw-loader": "^1.0.1",
 "ts-jest": "^24.0.2",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "eslint-plugin-react": "^7.18.3",
     "eslint-plugin-react-hooks": "^4.1.2",
     "husky": "^2.3.0",
-    "install": "^0.13.0",
     "jest": "^26.6.3",
     "jest-raw-loader": "^1.0.1",
     "lerna": "^3.16.4",

--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -88,7 +88,6 @@
     "@types/react-intl": "^3.0.0",
     "@types/uuid": "^3.4.7",
     "cheerio": "^1.0.0-rc.3",
-    "install": "^0.13.0",
     "jest": "^24.7.1",
     "jest-raw-loader": "^1.0.1",
     "rimraf": "^3.0.2",

--- a/packages/script-editor/jest.config.js
+++ b/packages/script-editor/jest.config.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2018-2022 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* global module, require */
+module.exports = require('../../testutils/jest.config');

--- a/packages/script-editor/package.json
+++ b/packages/script-editor/package.json
@@ -30,7 +30,9 @@
     "prepare": "npm run build",
     "watch": "tsc -w",
     "lab:install": "jupyter labextension link --no-build",
-    "lab:uninstall": "jupyter labextension unlink --no-build"
+    "lab:uninstall": "jupyter labextension unlink --no-build",
+    "test": "jest",
+    "build:test": "tsc --build tsconfig.test.json"
   },
   "dependencies": {
     "@jupyterlab/apputils": "^3.3.0",
@@ -50,7 +52,13 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "rimraf": "^3.0.2",
-    "typescript": "~4.1.3"
+    "typescript": "~4.1.3",
+    "@jupyterlab/testutils": "3.3.0",
+    "@types/jest": "^23.3.11",
+    "install": "^0.13.0",
+    "jest": "^24.7.1",
+    "jest-raw-loader": "^1.0.1",
+    "ts-jest": "^24.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/script-editor/package.json
+++ b/packages/script-editor/package.json
@@ -55,7 +55,6 @@
     "typescript": "~4.1.3",
     "@jupyterlab/testutils": "3.3.0",
     "@types/jest": "^23.3.11",
-    "install": "^0.13.0",
     "jest": "^24.7.1",
     "jest-raw-loader": "^1.0.1",
     "ts-jest": "^24.0.2"

--- a/packages/script-editor/src/test/script-editor.spec.ts
+++ b/packages/script-editor/src/test/script-editor.spec.ts
@@ -17,8 +17,10 @@
 import { JupyterServer } from '@jupyterlab/testutils';
 
 import { ScriptEditorController } from '../ScriptEditorController';
+import { ScriptRunner } from '../ScriptRunner';
 
 const server = new JupyterServer();
+const language = 'python';
 
 beforeAll(async () => {
   jest.setTimeout(20000);
@@ -34,7 +36,6 @@ describe('@elyra/script-editor', () => {
     describe('#getKernelSpecs', () => {
       it('should get Python kernel specs', async () => {
         const controller = new ScriptEditorController();
-        const language = 'python';
         const kernelSpecs = await controller.getKernelSpecsByLanguage(language);
         for (const [key, value] of Object.entries(
           kernelSpecs?.kernelspecs ?? []
@@ -42,6 +43,18 @@ describe('@elyra/script-editor', () => {
           expect(key).toContain(language);
           expect(value?.language).toContain(language);
         }
+      });
+    });
+  });
+
+  describe('KernelManager', () => {
+    describe('#startSession', () => {
+      it('should start a kernel session', async () => {
+        const dummyFunc = (x: boolean) => console.log(x);
+        const runner = new ScriptRunner(dummyFunc);
+        const session = await runner.startSession(language, 'test.py');
+        expect(session.id).toBeTruthy();
+        expect(session.id).toEqual(runner.sessionConnection?.id);
       });
     });
   });

--- a/packages/script-editor/src/test/script-editor.spec.ts
+++ b/packages/script-editor/src/test/script-editor.spec.ts
@@ -17,11 +17,11 @@
 import { JupyterServer } from '@jupyterlab/testutils';
 
 import { ScriptEditorController } from '../ScriptEditorController';
-jest.setTimeout(3 * 60 * 1000);
 
 const server = new JupyterServer();
 
 beforeAll(async () => {
+  jest.setTimeout(20000);
   await server.start();
 });
 
@@ -39,7 +39,6 @@ describe('@elyra/script-editor', () => {
         for (const [key, value] of Object.entries(
           kernelSpecs?.kernelspecs ?? []
         )) {
-          // console.log(`${key}: ${value}`);
           expect(key).toContain(language);
           expect(value?.language).toContain(language);
         }

--- a/packages/script-editor/src/test/script-editor.spec.ts
+++ b/packages/script-editor/src/test/script-editor.spec.ts
@@ -50,13 +50,14 @@ describe('@elyra/script-editor', () => {
   describe('KernelManager', () => {
     describe('#startSession', () => {
       let runner: ScriptRunner;
+      const testPath = 'test.py';
 
       beforeEach(() => {
         runner = new ScriptRunner((x: boolean): void => console.log(x));
       });
 
       it('should start a kernel session', async () => {
-        const session = await runner.startSession(language, 'test.py');
+        const session = await runner.startSession(language, testPath);
         expect(session.id).toEqual(runner.sessionConnection?.id);
         expect(runner.sessionConnection?.kernel?.connectionStatus).toEqual(
           'connecting'
@@ -69,6 +70,19 @@ describe('@elyra/script-editor', () => {
         await runner.shutdownSession();
         expect(runner.sessionConnection).toBeNull();
       });
+
+      // Test should run script
+      it('should run script', async () => {
+        const code = 'print("Test")';
+        await runner.startSession(language, 'test.py');
+        const kernelMsg = async (msg: any): Promise<void> => {
+          msg.output && expect(msg.output).toEqual('Test');
+        };
+        await runner.runScript(language, testPath, code, kernelMsg);
+        await runner.shutdownSession();
+      });
+
+      // Test should receive error message when running a broken script
     });
   });
 });

--- a/packages/script-editor/src/test/script-editor.spec.ts
+++ b/packages/script-editor/src/test/script-editor.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018-2022 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JupyterServer } from '@jupyterlab/testutils';
+
+import { ScriptEditorController } from '../ScriptEditorController';
+jest.setTimeout(3 * 60 * 1000);
+
+const server = new JupyterServer();
+
+beforeAll(async () => {
+  await server.start();
+});
+
+afterAll(async () => {
+  await server.shutdown();
+});
+
+describe('@elyra/script-editor', () => {
+  describe('ScriptEditorController', () => {
+    describe('#getKernelSpecs', () => {
+      it('should get Python kernel specs', async () => {
+        const controller = new ScriptEditorController();
+        const language = 'python';
+        const kernelSpecs = await controller.getKernelSpecsByLanguage(language);
+        for (const [key, value] of Object.entries(
+          kernelSpecs?.kernelspecs ?? []
+        )) {
+          // console.log(`${key}: ${value}`);
+          expect(key).toContain(language);
+          expect(value?.language).toContain(language);
+        }
+      });
+    });
+  });
+});

--- a/packages/script-editor/src/test/script-editor.spec.ts
+++ b/packages/script-editor/src/test/script-editor.spec.ts
@@ -49,12 +49,25 @@ describe('@elyra/script-editor', () => {
 
   describe('KernelManager', () => {
     describe('#startSession', () => {
+      let runner: ScriptRunner;
+
+      beforeEach(() => {
+        runner = new ScriptRunner((x: boolean): void => console.log(x));
+      });
+
       it('should start a kernel session', async () => {
-        const dummyFunc = (x: boolean): void => console.log(x);
-        const runner = new ScriptRunner(dummyFunc);
         const session = await runner.startSession(language, 'test.py');
-        expect(session.id).toBeTruthy();
         expect(session.id).toEqual(runner.sessionConnection?.id);
+        expect(runner.sessionConnection?.kernel?.connectionStatus).toEqual(
+          'connecting'
+        );
+        runner.shutdownSession();
+      });
+
+      it('should shut down a kernel session', async () => {
+        await runner.startSession(language, 'test.py');
+        await runner.shutdownSession();
+        expect(runner.sessionConnection).toBeNull();
       });
     });
   });

--- a/packages/script-editor/src/test/script-editor.spec.ts
+++ b/packages/script-editor/src/test/script-editor.spec.ts
@@ -18,12 +18,12 @@ import { JupyterServer } from '@jupyterlab/testutils';
 
 import { ScriptEditorController } from '../ScriptEditorController';
 import { ScriptRunner } from '../ScriptRunner';
+jest.setTimeout(3 * 60 * 1000);
 
 const server = new JupyterServer();
 const language = 'python';
 
 beforeAll(async () => {
-  jest.setTimeout(20000);
   await server.start();
 });
 

--- a/packages/script-editor/src/test/script-editor.spec.ts
+++ b/packages/script-editor/src/test/script-editor.spec.ts
@@ -50,7 +50,7 @@ describe('@elyra/script-editor', () => {
   describe('KernelManager', () => {
     describe('#startSession', () => {
       it('should start a kernel session', async () => {
-        const dummyFunc = (x: boolean) => console.log(x);
+        const dummyFunc = (x: boolean): void => console.log(x);
         const runner = new ScriptRunner(dummyFunc);
         const session = await runner.startSession(language, 'test.py');
         expect(session.id).toBeTruthy();

--- a/packages/script-editor/src/test/script-editor.spec.ts
+++ b/packages/script-editor/src/test/script-editor.spec.ts
@@ -78,19 +78,19 @@ describe('@elyra/script-editor', () => {
 
       it('should run script', async () => {
         const code = 'print("Test")';
-        const kernelMsgFn = async (msg: any): Promise<void> =>
-          msg.output && expect(msg.output).toMatch(/test/i);
+        const testCallback = async (kernelMsg: any): Promise<void> =>
+          kernelMsg.output && expect(kernelMsg.output).toMatch(/test/i);
         expect(kernelName).not.toBe('');
-        await runner.runScript(kernelName, testPath, code, kernelMsgFn);
+        await runner.runScript(kernelName, testPath, code, testCallback);
         await runner.shutdownSession();
       });
 
       it('should receive error message when running a broken script', async () => {
         const code = 'print(Broken Test)';
-        const kernelMsgFn = async (msg: any): Promise<void> =>
-          msg.error && expect(msg.error.type).toMatch(/error/i);
+        const testCallback = async (kernelMsg: any): Promise<void> =>
+          kernelMsg.error && expect(kernelMsg.error.type).toMatch(/error/i);
         expect(kernelName).not.toBe('');
-        await runner.runScript(kernelName, testPath, code, kernelMsgFn);
+        await runner.runScript(kernelName, testPath, code, testCallback);
         await runner.shutdownSession();
       });
     });

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -48,7 +48,6 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/react-intl": "^3.0.0",
-    "install": "^0.13.0",
     "jest": "^24.7.1",
     "jest-raw-loader": "^1.0.1",
     "rimraf": "^3.0.2",

--- a/packages/services/src/test/services.spec.ts
+++ b/packages/services/src/test/services.spec.ts
@@ -18,6 +18,7 @@ import { JupyterServer } from '@jupyterlab/testutils';
 
 import { MetadataService } from '../metadata';
 import { RequestHandler } from '../requests';
+jest.setTimeout(3 * 60 * 1000);
 
 const server = new JupyterServer();
 
@@ -32,7 +33,6 @@ const codeSnippetMetadata = {
 };
 
 beforeAll(async () => {
-  jest.setTimeout(20000);
   await server.start();
 });
 

--- a/packages/services/src/test/services.spec.ts
+++ b/packages/services/src/test/services.spec.ts
@@ -18,7 +18,6 @@ import { JupyterServer } from '@jupyterlab/testutils';
 
 import { MetadataService } from '../metadata';
 import { RequestHandler } from '../requests';
-jest.setTimeout(3 * 60 * 1000);
 
 const server = new JupyterServer();
 
@@ -33,6 +32,7 @@ const codeSnippetMetadata = {
 };
 
 beforeAll(async () => {
+  jest.setTimeout(20000);
   await server.start();
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10909,11 +10909,6 @@ inquirer@^7.0.0, inquirer@^7.1.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
-install@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/install/-/install-0.13.0.tgz#6af6e9da9dd0987de2ab420f78e60d9c17260776"
-  integrity sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==
-
 internal-ip@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907"


### PR DESCRIPTION
Addresses Script Editor unit tests listed as subtasks in #2453

### What changes were proposed in this pull request?
- Add unit test for ScriptController (get kernels)
- Add unit tests for KernelManager (session connection, kernel messages, code output/error)
- Update documentation (remove references to enzyme dependency, update testutils version, add npm command)

### How was this pull request tested?
Ran `npm run test packages/script-editor/src/test/script-editor.spec.ts
`
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
