### PR TITLE
Relax component YAML validation requirements for certain fields

### DIFF
--- a/elyra/pipeline/kfp/kfp_component_utils.py
+++ b/elyra/pipeline/kfp/kfp_component_utils.py
@@ -19,7 +19,7 @@ component_yaml_schema = {
             "type": "string"
         },
         "description": {
-            "type": "string"
+            "type": ["string", "null"]
         },
         "inputs": {
             "type": "array",
@@ -30,13 +30,13 @@ component_yaml_schema = {
                         "type": "string"
                     },
                     "description": {
-                        "type": "string"
+                        "type": ["string", "null"]
                     },
                     "type": {
-                        "type": "string"
+                        "type": ["string", "null"]
                     },
                     "optional": {
-                        "type": "boolean"
+                        "type": ["boolean", "null"]
                     }
                 }
             },
@@ -51,13 +51,13 @@ component_yaml_schema = {
                         "type": "string"
                     },
                     "description": {
-                        "type": "string"
+                        "type": ["string", "null"]
                     },
                     "type": {
-                        "type": "string"
+                        "type": ["string", "null"]
                     },
                     "optional": {
-                        "type": "boolean"
+                        "type": ["boolean", "null"]
                     }
                 }
             },
@@ -75,27 +75,13 @@ component_yaml_schema = {
                         "command": {
                             "type": "array",
                             "items": {
-                                "OneOf": [
-                                    {
-                                        "type": "string"
-                                    },
-                                    {
-                                        "type": "object"
-                                    }
-                                ]
+                                "type": ["string", "object"]
                             }
                         },
                         "args": {
                             "type": "array",
                             "items": {
-                                "OneOf": [
-                                    {
-                                        "type": "string"
-                                    },
-                                    {
-                                        "type": "object"
-                                    }
-                                ]
+                                "type": ["string", "object"]
                             }
                         }
                     }

--- a/elyra/tests/pipeline/resources/components/kfp_test_operator.yaml
+++ b/elyra/tests/pipeline/resources/components/kfp_test_operator.yaml
@@ -1,7 +1,7 @@
 name: Test Operator
 description: 'This component description contains an unescaped " character'
 inputs:
-- {name: test_string_no_default, description: 'The test command description', type: String}
+- {name: test_string_no_default, description: , type: String}
 - {name: test_string_default_value, description: 'The test command description', type: String, default: 'default'}
 - {name: test_string_default_empty, description: 'The test command description', type: String, default: ''}
 - {name: test_bool_default, description: 'The test command description', type: Bool}


### PR DESCRIPTION
Some component YAML files do not contain values for all their keys, e.g.:
```
name: Test Component
description:
inputs:
- {name: test_string_no_default, description: , type: String}
...
```

The simple component YAML validation functionality was listing this as invalid since the 'description' property is `null`/`None`. We want to relax this validation, as these fields should not be explicitly required for our purposes.

### What changes were proposed in this pull request?
This PR relaxes the requirements that certain fields be of a certain data type, if present. These fields can now be either `null`/`None` or their corresponding data type. Note that this does not mean that these fields are required - it only means that if the key is present, the value is still optional. More specifically, these fields are component 'description', input/output property 'description', input/output property 'type', and input/output property 'optional' flag. Note that input/output property 'default value' is not listed in the validation criteria because it is not a required field and its data type can be any type, so there is nothing to validate.

### How was this pull request tested?
The `kfp_test_operator.yaml` file was edited to have a `null`/`None` value for one of the input property descriptions in order to cover this case (tests are passing anyway indicating that this property having a null value still passes validation).
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
