### PR TITLE
Convert bytes and bytearray types to string for Component definition attribute

### DIFF
--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -50,6 +50,9 @@ class EntryData(object):
     file_extension: str = None
 
     def __init__(self, definition: str, file_extension: Optional[str] = None, **kwargs):
+        if isinstance(definition, (bytes, bytearray)):
+            definition = definition.decode("utf-8")
+
         self.definition = definition
         self.file_extension = file_extension
 

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -27,6 +27,7 @@ from typing import Tuple
 
 from traitlets.config import LoggingConfigurable
 
+from elyra.pipeline.catalog_connector import CatalogEntry
 from elyra.pipeline.runtime_type import RuntimeProcessorType
 
 
@@ -351,9 +352,9 @@ class ComponentParser(LoggingConfigurable):  # ABC
         return self._file_types
 
     @abstractmethod
-    def parse(self, registry_entry: SimpleNamespace) -> Optional[List[Component]]:
+    def parse(self, catalog_entry: CatalogEntry) -> Optional[List[Component]]:
         """
-        Parse a component definition given in the registry entry and return
+        Parse a component definition given in the catalog entry and return
         a list of fully-qualified Component objects
         """
         raise NotImplementedError()

--- a/elyra/pipeline/component.py
+++ b/elyra/pipeline/component.py
@@ -27,7 +27,14 @@ from typing import Tuple
 
 from traitlets.config import LoggingConfigurable
 
-from elyra.pipeline.catalog_connector import CatalogEntry
+# Rather than importing only the CatalogEntry class needed in the Component parse
+# type hint below, the catalog_connector module must be imported in its
+# entirety in order to avoid a circular reference issue
+try:
+    from elyra.pipeline import catalog_connector
+except ImportError:
+    import sys
+    catalog_connector = sys.modules[__package__ + '.catalog_connector']
 from elyra.pipeline.runtime_type import RuntimeProcessorType
 
 
@@ -352,7 +359,7 @@ class ComponentParser(LoggingConfigurable):  # ABC
         return self._file_types
 
     @abstractmethod
-    def parse(self, catalog_entry: CatalogEntry) -> Optional[List[Component]]:
+    def parse(self, catalog_entry: 'catalog_connector.CatalogEntry') -> Optional[List[Component]]:
         """
         Parse a component definition given in the catalog entry and return
         a list of fully-qualified Component objects


### PR DESCRIPTION
Fixes #2598 

### What changes were proposed in this pull request?
Component definitions of types `bytes` or `bytearray` (instead of string) are explicitly converted to string types when passed to `EntryData` `__init__`. This prevents a  `TypeError` when later attempting to convert the definition to an appropriate json response using `json.dumps()`(which occurs when requesting the component definition using the new API endpoint).

We could also consider adding a try/except block in `pipeline/handlers.py` that returns the appropriate REST response code and message for any additional errors that might arise when accessing and converting the component `definition` attribute. In the interest of a 3.7.0 rc, however, this may be better saved for another PR as this might also require frontend modifications depending on how we would want to design things.

### How was this pull request tested?
Manually tested by creating an MLX catalog instance and confirming that the definition content opens appropriately.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
