### PR TITLE
Add ComponentCache load to relevant pipeline app commands

### DIFF
--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -292,12 +292,12 @@ def validate(pipeline_path, runtime_config='local'):
 
     print_banner("Elyra Pipeline Validation")
 
-    _build_component_cache()
-
     runtime = _get_runtime_schema_name(runtime_config)
 
     pipeline_definition = \
         _preprocess_pipeline(pipeline_path, runtime=runtime, runtime_config=runtime_config)
+
+    _build_component_cache()
 
     try:
         _validate_pipeline_definition(pipeline_definition)
@@ -353,8 +353,6 @@ def submit(json_option, pipeline_path, runtime_config_name,
 
     print_banner("Elyra Pipeline Submission")
 
-    _build_component_cache()
-
     runtime_config = _get_runtime_config(runtime_config_name)
 
     runtime_schema = runtime_config.schema_name
@@ -363,6 +361,8 @@ def submit(json_option, pipeline_path, runtime_config_name,
         _preprocess_pipeline(pipeline_path,
                              runtime=runtime_schema,
                              runtime_config=runtime_config_name)
+
+    _build_component_cache()
 
     try:
         _validate_pipeline_definition(pipeline_definition)
@@ -587,8 +587,6 @@ def export(pipeline_path, runtime_config, output, overwrite):
     click.echo()
     print_banner("Elyra pipeline export")
 
-    _build_component_cache()
-
     rtc = _get_runtime_config(runtime_config)
     runtime_schema = rtc.schema_name
     runtime_type = rtc.metadata.get('runtime_type')
@@ -648,6 +646,8 @@ def export(pipeline_path, runtime_config, output, overwrite):
     if output_file.exists() and not overwrite:
         raise click.ClickException(f"Output file '{str(output_file)}' exists and "
                                    "option '--overwrite' was not specified.")
+
+    _build_component_cache()
 
     # validate the pipeline
     try:

--- a/elyra/pipeline/component_catalog.py
+++ b/elyra/pipeline/component_catalog.py
@@ -597,6 +597,10 @@ class ComponentCache(SingletonConfigurable):
         return ComponentCache._generic_components.get(component_id)
 
     @staticmethod
+    def get_generic_component_ops() -> List[str]:
+        return [component.op for component in ComponentCache.get_generic_components()]
+
+    @staticmethod
     def load_jinja_template(template_name: str) -> Template:
         """
         Loads the jinja template of the given name from the
@@ -647,7 +651,7 @@ class ComponentCache(SingletonConfigurable):
         If component_id is one of the generic set, generic template is rendered,
         otherwise, the  runtime-specific property template is rendered
         """
-        if component.id in ('notebook', 'python-script', 'r-script'):
+        if ComponentCache.get_generic_component(component.id) is not None:
             template = ComponentCache.load_jinja_template('generic_properties_template.jinja2')
         else:
             template = ComponentCache.load_jinja_template('canvas_properties_template.jinja2')

--- a/elyra/pipeline/validation.py
+++ b/elyra/pipeline/validation.py
@@ -285,6 +285,17 @@ class PipelineValidationManager(SingletonConfigurable):
                 # Checks pipeline node types are compatible with the runtime selected
                 for sub_pipeline in pipeline_definition.pipelines:
                     for node in sub_pipeline.nodes:
+                        if node.op not in ComponentCache.get_generic_component_ops() and pipeline_runtime == "local":
+                            response.add_message(severity=ValidationSeverity.Error,
+                                                 message_type="invalidNodeType",
+                                                 message="This pipeline contains at least one runtime-specific "
+                                                         "component, but pipeline runtime is 'local'. Specify a "
+                                                         "runtime config or remove runtime-specific components "
+                                                         "from the pipeline",
+                                                 data={"nodeID": node.id,
+                                                       "nodeOpName": node.op,
+                                                       "pipelineId": sub_pipeline.id})
+                            break
                         if node.type == "execution_node" and node.op not in supported_ops:
                             response.add_message(severity=ValidationSeverity.Error,
                                                  message_type="invalidNodeType",

--- a/elyra/tests/cli/test_pipeline_app.py
+++ b/elyra/tests/cli/test_pipeline_app.py
@@ -268,6 +268,19 @@ def test_validate_with_missing_kfp_component(jp_environ, kubeflow_pipelines_runt
         assert "[Error][Calculate data hash] - This component was not found in the catalog." in result.output
         assert result.exit_code != 0
 
+
+def test_validate_with_no_runtime_config():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        pipeline_file_path = Path(__file__).parent / 'resources' / 'pipelines' / 'kfp_3_node_custom.pipeline'
+        result = runner.invoke(pipeline, ['validate', str(pipeline_file_path)])
+
+        assert "Validating pipeline..." in result.output
+        assert "[Error] - This pipeline contains at least one runtime-specific component, " \
+               "but pipeline runtime is 'local'" in result.output
+        assert result.exit_code != 0
+
+
 # ------------------------------------------------------------------
 # tests for 'submit' command
 # ------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2609 
Fixes #2612 

### What changes were proposed in this pull request?
This PR adds a load of the components in the component cache for pipeline app tools that need it (`submit`, `export`, and `validate`). Note that this will cause some slowdown for these commands because the cache load must be fully complete before moving on to the relevant task (this is true whether or not that task requires the access of any custom components). The cache load does not happen if the pipeline runtime type is determined to be Generic because, in that case, there should not be any custom components present (validation will still catch this issue appropriately if it is encountered).

<img width="594" alt="Screen Shot 2022-03-29 at 5 51 47 PM" src="https://user-images.githubusercontent.com/31816267/160719579-a9ec8fe3-342e-4bd3-888d-2d9b3c9a8baa.png">

In reviewing this PR, the bug described in #2612 was uncovered. This PR also addresses this issue by adding a new case during pipeline node validation. This new case checks for custom component(s) in a pipeline determined to be of runtime 'local' and issues an error message if a custom component is found.

```
 [Error] - This pipeline contains at least one runtime-specific component, but pipeline runtime is 'local'. Specify a runtime config or remove runtime-specific components from the pipeline 
```

### How was this pull request tested?
Some pipeline app tests are also slowed down by this change when run individually, but execution time for all tests isn't noticeably affected.

A test case was added to `test_pipeline_app.py` that checks for the case where a runtime-specific pipeline is submitted for validation with no runtime-config given. The error mentioned in the above section will be raised in this case.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
