### PR TITLE
Update Launcher to work with other languages

### DIFF
--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -23,6 +23,7 @@ import {
 import { ICommandPalette, MainAreaWidget } from '@jupyterlab/apputils';
 import { ILauncher, LauncherModel } from '@jupyterlab/launcher';
 import { IMainMenu } from '@jupyterlab/mainmenu';
+import { ITranslator } from '@jupyterlab/translation';
 import { launcherIcon } from '@jupyterlab/ui-components';
 
 import { toArray } from '@lumino/algorithm';
@@ -47,11 +48,12 @@ const CommandIDs = {
 const extension: JupyterFrontEndPlugin<ILauncher> = {
   id: ELYRA_THEME_NAMESPACE,
   autoStart: true,
-  requires: [ILabShell, IMainMenu],
+  requires: [ITranslator, ILabShell, IMainMenu],
   optional: [ICommandPalette],
   provides: ILauncher,
   activate: (
     app: JupyterFrontEnd,
+    translator: ITranslator,
     labShell: ILabShell,
     mainMenu: IMainMenu,
     palette: ICommandPalette | null
@@ -79,10 +81,11 @@ const extension: JupyterFrontEndPlugin<ILauncher> = {
 
     // Use custom Elyra launcher
     const { commands } = app;
+    const trans = translator.load('jupyterlab');
     const model = new LauncherModel();
 
     commands.addCommand(CommandIDs.create, {
-      label: 'New Launcher',
+      label: trans.__('New Launcher'),
       execute: (args: any) => {
         const cwd = args['cwd'] ? String(args['cwd']) : '';
         const id = `launcher-${Private.id++}`;
@@ -90,11 +93,17 @@ const extension: JupyterFrontEndPlugin<ILauncher> = {
           labShell.add(item, 'main', { ref: id });
         };
 
-        const launcher = new Launcher({ model, cwd, callback, commands });
+        const launcher = new Launcher({
+          model,
+          cwd,
+          callback,
+          commands,
+          translator
+        });
 
         launcher.model = model;
         launcher.title.icon = launcherIcon;
-        launcher.title.label = 'Launcher';
+        launcher.title.label = trans.__('Launcher');
 
         const main = new MainAreaWidget({ content: launcher });
 
@@ -114,7 +123,10 @@ const extension: JupyterFrontEndPlugin<ILauncher> = {
     });
 
     if (palette) {
-      palette.addItem({ command: CommandIDs.create, category: 'Launcher' });
+      palette.addItem({
+        command: CommandIDs.create,
+        category: trans.__('Launcher')
+      });
     }
 
     commands.addCommand(CommandIDs.openHelp, {

--- a/packages/theme/src/launcher.tsx
+++ b/packages/theme/src/launcher.tsx
@@ -20,6 +20,7 @@ import {
   Launcher as JupyterlabLauncher,
   ILauncher
 } from '@jupyterlab/launcher';
+import { TranslationBundle } from '@jupyterlab/translation';
 import { LabIcon } from '@jupyterlab/ui-components';
 
 import { each } from '@lumino/algorithm';
@@ -30,7 +31,6 @@ import * as React from 'react';
  * The known categories of launcher items and their default ordering.
  */
 const ELYRA_CATEGORY = 'Elyra';
-const KNOWN_CATEGORIES = ['Notebook', 'Console', ELYRA_CATEGORY, 'Other'];
 
 export class Launcher extends JupyterlabLauncher {
   /**
@@ -38,6 +38,7 @@ export class Launcher extends JupyterlabLauncher {
    */
   constructor(options: ILauncher.IOptions) {
     super(options);
+    this._translator = this.translator.load('jupyterlab');
   }
 
   private replaceCategoryIcon(
@@ -83,9 +84,16 @@ export class Launcher extends JupyterlabLauncher {
 
     const categories: React.ReactElement<any>[] = [];
 
+    const knownCategories = [
+      this._translator.__('Notebook'),
+      this._translator.__('Console'),
+      ELYRA_CATEGORY,
+      this._translator.__('Other')
+    ];
+
     // Assemble the final ordered list of categories
-    // based on KNOWN_CATEGORIES.
-    each(KNOWN_CATEGORIES, (category, index) => {
+    // based on knownCategories.
+    each(knownCategories, (category, index) => {
       React.Children.forEach(launcherCategories, cat => {
         if (cat.key === category) {
           if (cat.key === ELYRA_CATEGORY) {
@@ -108,4 +116,6 @@ export class Launcher extends JupyterlabLauncher {
       </div>
     );
   }
+
+  private _translator: TranslationBundle;
 }


### PR DESCRIPTION
Our override of the Launcher does not currently use the translation
service. This was causing the launcher to break when using languages
other than english. This fixes that bug.

This PR DOES NOT add translation for Elyra though, that should be
done in a larger follow up issue.

Fixes #2597

Screenshot of the launcher using the CN translation referenced in the issue:
<img width="1285" alt="Screen Shot 2022-03-30 at 1 57 43 PM" src="https://user-images.githubusercontent.com/13952758/160913499-6124a1b6-d346-4a33-95e4-eb94e92207b6.png">

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
