### PR TITLE
Abort generic component processing when prereq download fails

### DIFF
--- a/elyra/airflow/operator.py
+++ b/elyra/airflow/operator.py
@@ -83,7 +83,7 @@ class BootscriptBuilder(object):
     @property
     def container_cmd(self):
 
-        common_curl_options = '--fail -H "Cache-Control: no-cache"'
+        common_curl_options = "--fail -H 'Cache-Control: no-cache'"
 
         self.arguments = [
             f"mkdir -p {self.container_work_dir} && cd {self.container_work_dir} && "

--- a/elyra/airflow/operator.py
+++ b/elyra/airflow/operator.py
@@ -82,10 +82,15 @@ class BootscriptBuilder(object):
 
     @property
     def container_cmd(self):
+
+        common_curl_options = '--fail -H "Cache-Control: no-cache"'
+
         self.arguments = [
             f"mkdir -p {self.container_work_dir} && cd {self.container_work_dir} && "
-            f"curl -H 'Cache-Control: no-cache' -L {ELYRA_BOOTSCRIPT_URL} --output bootstrapper.py && "
-            f"curl -H 'Cache-Control: no-cache' -L {ELYRA_REQUIREMENTS_URL} "
+            f"echo 'Downloading {ELYRA_BOOTSCRIPT_URL}' && "
+            f"curl {common_curl_options} -L {ELYRA_BOOTSCRIPT_URL} --output bootstrapper.py && "
+            f"echo 'Downloading {ELYRA_REQUIREMENTS_URL}' && "
+            f"curl {common_curl_options} -L {ELYRA_REQUIREMENTS_URL} "
             f"--output requirements-elyra.txt && "
             "python3 -m pip install packaging && "
             "python3 -m pip freeze > requirements-current.txt && "

--- a/elyra/kfp/operator.py
+++ b/elyra/kfp/operator.py
@@ -173,16 +173,21 @@ class ExecuteFileOp(ContainerOp):
             NOTE: Images being pulled must have python3 available on PATH and cURL utility
             """
 
+            common_curl_options = '--fail -H "Cache-Control: no-cache"'
+
             argument_list.append(
                 f"mkdir -p {self.container_work_dir} && cd {self.container_work_dir} && "
-                f'curl -H "Cache-Control: no-cache" -L {self.bootstrap_script_url} --output bootstrapper.py && '
-                f'curl -H "Cache-Control: no-cache" -L {self.requirements_url} --output requirements-elyra.txt && '
+                f"echo 'Downloading {self.bootstrap_script_url}' && "
+                f"curl {common_curl_options} -L {self.bootstrap_script_url} --output bootstrapper.py && "
+                f"echo 'Downloading {self.requirements_url}' && "
+                f"curl {common_curl_options} -L {self.requirements_url} --output requirements-elyra.txt && "
             )
 
             if self.emptydir_volume_size:
                 argument_list.append(
                     f"mkdir {self.container_python_dir_name} && cd {self.container_python_dir_name} && "
-                    f'curl -H "Cache-Control: no-cache" -L {self.python_pip_config_url} '
+                    f"echo 'Downloading {self.python_pip_config_url}' && "
+                    f"curl {common_curl_options} -L {self.python_pip_config_url} "
                     "--output pip.conf && cd .. &&"
                 )
 


### PR DESCRIPTION
Fixes https://github.com/elyra-ai/elyra/issues/2624
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->
Example output for KFP when the user assigned an invalid value to environment variable `ELYRA_REQUIREMENTS_URL`:

![image](https://user-images.githubusercontent.com/13068832/161607346-3e7c3e39-9ed5-491e-b3f5-ae2ac26d0260.png)

Example output for Airflow when the user assigned an invalid value to environment variable `ELYRA_REQUIREMENTS_URL`:

![image](https://user-images.githubusercontent.com/13068832/161619960-97a941fe-443b-4e13-b192-f18556a858c8.png)


### What changes were proposed in this pull request?
- When running generic nodes on KFP and Airflow, processing is aborted as soon as download of a prerequisite fails, preventing bootstrapper errors.
- Log file to be downloaded, to simplify troubleshooting

Note: https://curl.se/docs/manpage.html#-f does not identify a version in which the option was introduced, which makes me believe that using it does not introduce a new restriction for a more current curl installation.

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
Confirmed that the log out yields the expected results when the user misconfigures environment variables  `ELYRA_REQUIREMENTS_URL`, `ELYRA_PIP_CONFIG_URL`, `ELYRA_GITHUB_ORG`, or`ELYRA_GITHUB_BRANCH`.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
