### PR TITLE
Improve argument handling in elyra-metadata

### DIFF
--- a/elyra/metadata/metadata_app_utils.py
+++ b/elyra/metadata/metadata_app_utils.py
@@ -639,7 +639,7 @@ class AppBase(object):
         print("Subcommands")
         print("-----------")
         print("Subcommands are launched as `elyra-metadata cmd [args]`. For information on")
-        print("using subcommand 'cmd', run: `elyra-metadata cmd -h`.")
+        print("using subcommand 'cmd', run: `elyra-metadata cmd -h` or `elyra-metadata cmd --help`.")
         print()
         for subcommand, desc in self.subcommands.items():
             print(subcommand)

--- a/elyra/tests/metadata/test_utils.py
+++ b/elyra/tests/metadata/test_utils.py
@@ -171,11 +171,11 @@ all_of_json = {
 }
 
 
-def create_json_file(location, file_name, content):
-    create_file(location, file_name, json.dumps(content))
+def create_json_file(location: Any, file_name: str, content: Dict) -> str:
+    return create_file(location, file_name, json.dumps(content))
 
 
-def create_file(location, file_name, content):
+def create_file(location: Any, file_name: str, content: str) -> str:
     try:
         os.makedirs(location)
     except OSError as e:
@@ -185,6 +185,7 @@ def create_file(location, file_name, content):
     resource = os.path.join(location, file_name)
     with open(resource, "w", encoding="utf-8") as f:
         f.write(content)
+    return resource
 
 
 def create_instance(metadata_store: MetadataStore, location: str, name: str, content: Any) -> str:


### PR DESCRIPTION
This pull request addresses two things.
1. It more gracefully handles the issue reported in #2640 in which object-value-handling options (i.e., `--file` and `--json`) do not include a file or JSON value (respectively).
2. It generally makes the equals operator (`=`) optional for options that take values, allowing for better parity with the `elyra-pipeline` CLI application.

One negative test, previously used to ensure the `--name` property was properly handled when there was no `equals` operator, has been repurposed since that is now a valid scenario.  In addition, tests specific to the `--file` and `--json` options have been added with 3 scenarios each: using an equals operator, no equals operator, and a missing value.  It also adjusts an existing test (`test_install_and_replace`) to not use the equals operator.

Resolves: #2640
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
