### PR TITLE
Support emissary as workflow executor for KFP with Argo

### DIFF
--- a/docs/source/user_guide/best-practices-custom-pipeline-components.md
+++ b/docs/source/user_guide/best-practices-custom-pipeline-components.md
@@ -27,6 +27,7 @@ limitations under the License.
 - [Python function-based components](https://www.kubeflow.org/docs/components/pipelines/sdk/python-function-components/) are not supported.
 - The [component specification](https://www.kubeflow.org/docs/components/pipelines/sdk/v2/component-development/#creating-a-component-specification) must be accessible to the Visual Pipeline Editor and can be stored locally or remotely. Refer to the 
 [Managing pipeline components topic](pipeline-components.html#managing-pipeline-components) for details.
+- If Kubeflow Pipelines is [configured with Argo as workflow engine and emissary executor as workflow executor](https://www.kubeflow.org/docs/components/pipelines/installation/choose-executor/#emissary-executor), the component specifiction must [meet the stated requirement](https://www.kubeflow.org/docs/components/pipelines/installation/choose-executor/#migrate-pipeline-components-to-run-on-emissary-executor). If Elyra detects a component that does not meet the requirement, a warning is logged.
 
 #### Best practices
 

--- a/elyra/pipeline/kfp/component_parser_kfp.py
+++ b/elyra/pipeline/kfp/component_parser_kfp.py
@@ -185,6 +185,15 @@ class KfpComponentParser(ComponentParser):
         try:
             # Validate against component YAML schema
             validate(instance=results, schema=component_yaml_schema)
+            # If the component definition does not define a container command, log a warning.
+            # See https://www.kubeflow.org/docs/components/pipelines/installation/choose-executor/#emissary-executor
+            if results.get("implementation", {}).get("container", {}).get("command") is None:
+                self.log.warning(
+                    f"Component '{results['name']}' does not define a container command. "
+                    "It might fail execution on Kubeflow Pipelines installations that are "
+                    "configured to use Argo as workflow engine and emissary "
+                    "executor as workflow executor."
+                )
         except ValidationError as ve:
             self.log.warning(
                 f"Invalid format of YAML definition for component with identifying information: "


### PR DESCRIPTION
Closes https://github.com/elyra-ai/elyra/issues/2243
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
- Update best practices topic for custom KFP components
- Extend KFP component parser to determine whether a component _might_ fail, depending on how KFP is configured
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
- Reviewed output of `make docs`
- Added a KFP component definition via a catalog that does not include a container command (warning message is displayed in log)
- Created a pipeline that uses the component and ran it KFP with Argo/docker: run completes successfully
-  Created a pipeline that uses the component and ran it KFP with Argo/emissary: run fails, as expected
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
