### PR TITLE
Clean up tests that rely on component cache instances

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -48,8 +48,6 @@ def component_cache(jp_environ):
     """
     Initialize a component cache
     """
-    ComponentCache.clear_instance()
-
     # Create new instance and load the cache
     component_cache = ComponentCache.instance(emulate_server_app=True)
     component_cache.load()

--- a/elyra/pipeline/component_catalog.py
+++ b/elyra/pipeline/component_catalog.py
@@ -367,6 +367,7 @@ class ComponentCache(SingletonConfigurable):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
+        self._component_cache = {}
         self.is_server_process = ComponentCache._determine_server_process(**kwargs)
         self.manifest_dir = jupyter_runtime_dir()
         # Ensure queue attribute exists for non-server instances as well.

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -25,7 +25,6 @@ from elyra.metadata.metadata import Metadata
 from elyra.pipeline.catalog_connector import FilesystemComponentCatalogConnector
 from elyra.pipeline.catalog_connector import UrlComponentCatalogConnector
 from elyra.pipeline.component import Component
-from elyra.pipeline.component_catalog import ComponentCache
 from elyra.pipeline.kfp.processor_kfp import KfpPipelineProcessor
 from elyra.pipeline.parser import PipelineParser
 from elyra.pipeline.pipeline import GenericOperation
@@ -42,7 +41,6 @@ def processor(setup_factory_data):
 
 @pytest.fixture
 def pipeline():
-    ComponentCache.instance().wait_for_all_cache_tasks()
     pipeline_resource = _read_pipeline_resource("resources/sample_pipelines/pipeline_3_node_sample.json")
     return PipelineParser.parse(pipeline_resource)
 
@@ -273,7 +271,7 @@ def test_process_dictionary_value_function(processor):
     assert processor._process_dictionary_value(dict_as_str) == dict_as_str
 
 
-def test_processing_url_runtime_specific_component(monkeypatch, processor, sample_metadata, tmpdir):
+def test_processing_url_runtime_specific_component(monkeypatch, processor, component_cache, sample_metadata, tmpdir):
     # Define the appropriate reader for a URL-type component definition
     kfp_supported_file_types = [".yaml"]
     reader = UrlComponentCatalogConnector(kfp_supported_file_types)
@@ -304,7 +302,7 @@ def test_processing_url_runtime_specific_component(monkeypatch, processor, sampl
     )
 
     # Fabricate the component cache to include single filename-based component for testing
-    ComponentCache.instance()._component_cache[processor._type.name] = {
+    component_cache._component_cache[processor._type.name] = {
         "spoofed_catalog": {"components": {component_id: component}}
     }
 
@@ -350,7 +348,9 @@ def test_processing_url_runtime_specific_component(monkeypatch, processor, sampl
     assert pipeline_template["inputs"]["artifacts"][0]["raw"]["data"] == operation_params["text"]
 
 
-def test_processing_filename_runtime_specific_component(monkeypatch, processor, sample_metadata, tmpdir):
+def test_processing_filename_runtime_specific_component(
+    monkeypatch, processor, component_cache, sample_metadata, tmpdir
+):
     # Define the appropriate reader for a filesystem-type component definition
     kfp_supported_file_types = [".yaml"]
     reader = FilesystemComponentCatalogConnector(kfp_supported_file_types)
@@ -380,7 +380,7 @@ def test_processing_filename_runtime_specific_component(monkeypatch, processor, 
     )
 
     # Fabricate the component cache to include single filename-based component for testing
-    ComponentCache.instance()._component_cache[processor._type.name] = {
+    component_cache._component_cache[processor._type.name] = {
         "spoofed_catalog": {"components": {component_id: component}}
     }
 

--- a/elyra/tests/pipeline/test_validation.py
+++ b/elyra/tests/pipeline/test_validation.py
@@ -39,7 +39,7 @@ def load_pipeline():
 
 
 @pytest.fixture
-def validation_manager(setup_factory_data):
+def validation_manager(setup_factory_data, component_cache):
     root = os.path.realpath(os.path.join(os.getcwd(), os.path.dirname(__file__), "resources/validation_pipelines"))
     yield PipelineValidationManager.instance(root_dir=root)
     PipelineValidationManager.clear_instance()


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR cleans up some server tests that were previously using their 'own' instances of the `ComponentCache` singleton to use the existing `component_cache` fixture.

### How was this pull request tested?

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
