### PR TITLE
Replace remaining ComponentCache instance with fixture in processor test

### DIFF
--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -430,7 +430,7 @@ def test_processing_filename_runtime_specific_component(
     assert pipeline_template["container"]["command"][3] == operation_params["url"]
 
 
-def test_cc_pipeline_component_no_input(monkeypatch, processor, sample_metadata, tmpdir):
+def test_cc_pipeline_component_no_input(monkeypatch, processor, component_cache, sample_metadata, tmpdir):
     """
     Verifies that cc_pipeline can handle KFP component definitions that don't
     include any inputs
@@ -464,7 +464,7 @@ def test_cc_pipeline_component_no_input(monkeypatch, processor, sample_metadata,
     )
 
     # Fabricate the component cache to include single filename-based component for testing
-    ComponentCache.instance()._component_cache[processor._type.name] = {
+    component_cache._component_cache[processor._type.name] = {
         "spoofed_catalog": {"components": {component_id: component}}
     }
 


### PR DESCRIPTION
Fixes master lint


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
