### PR TITLE
Remove use of legacy resolver in builds and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ build-server: # Build backend
 	$(PYTHON) -m setup bdist_wheel sdist
 
 install-server-package:
-	$(PYTHON_PIP) install --upgrade --upgrade-strategy $(UPGRADE_STRATEGY) --use-deprecated=legacy-resolver "$(shell find dist -name "elyra-*-py3-none-any.whl")[kfp-tekton]"
+	$(PYTHON_PIP) install --upgrade --upgrade-strategy $(UPGRADE_STRATEGY) "$(shell find dist -name "elyra-*-py3-none-any.whl")[kfp-tekton]"
 
 install-server: build-dependencies lint-server build-server install-server-package ## Build and install backend
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ Elyra can be installed from PyPI:
 
 #### JupyterLab support
 
-**NOTE:** On November 2020, a new version of PIP (20.3) was released with a new, "2020" resolver. This resolver does not yet work with Elyra and might lead to errors in installation. In order to install Elyra, you need to either downgrade pip to version 20.2.4 `pip install --upgrade pip==20.2.4` or, in case you use pip 20.3 (or later), you need to add option `--use-deprecated legacy-resolver` to your pip install command.
-
 * [JupyterLab](https://github.com/jupyterlab/jupyterlab) 3.x is supported on **Elyra 2.0.0 and above**
 
   Install Elyra from PyPI ( Elyra >= 3.7.0 ):

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -33,7 +33,7 @@ make release
 
 # Updage dependencies and install Elyra wheel
 pip install --upgrade pip
-pip install --upgrade --use-deprecated=legacy-resolver tornado jupyter-core jupyter-server jupyterlab dist/*.whl
+pip install --upgrade tornado jupyter-core jupyter-server jupyterlab dist/*.whl
 
 mkdir -p binder-demo
 

--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -45,8 +45,6 @@ Prior to version 3.1, the `elyra` package included all dependencies. Subsequent 
 
 ### pip
 
-**NOTE:** On November 2020, a new version of PIP (20.3) was released with a new, "2020" resolver. This resolver does not yet work with Elyra and might lead to errors in installation. In order to install Elyra, you need to either downgrade pip to version 20.2.4 `pip install --upgrade pip==20.2.4` or, in case you use pip 20.3 (or later), you need to add option `--use-deprecated legacy-resolver` to your pip install command.
-
 If you use `pip`, install Elyra with:
 
 ```bash

--- a/etc/docker/elyra/Dockerfile
+++ b/etc/docker/elyra/Dockerfile
@@ -24,8 +24,7 @@ ARG TAG="dev"
 COPY requirements.txt .
 
 # Install Elyra and custom requirements
-RUN python3 -m pip install --quiet --no-cache-dir \
-    elyra[all]=="$TAG" \
+RUN python3 -m pip install --quiet --no-cache-dir elyra[all]=="$TAG" \
  && python3 -m pip install -r requirements.txt \   
  && rm -rf $HOME/.cache/yarn \
  && rm -rf /opt/conda/share/jupyter/lab/staging/node_modules \

--- a/etc/docker/elyra/Dockerfile
+++ b/etc/docker/elyra/Dockerfile
@@ -24,7 +24,7 @@ ARG TAG="dev"
 COPY requirements.txt .
 
 # Install Elyra and custom requirements
-RUN python3 -m pip install --quiet --no-cache-dir --use-deprecated=legacy-resolver \
+RUN python3 -m pip install --quiet --no-cache-dir \
     elyra[all]=="$TAG" \
  && python3 -m pip install -r requirements.txt \   
  && rm -rf $HOME/.cache/yarn \

--- a/etc/docker/kubeflow/Dockerfile
+++ b/etc/docker/kubeflow/Dockerfile
@@ -24,7 +24,7 @@ ARG TAG="dev"
 # Install Elyra
 # - with KFP Tekton support ('kfp-tekton')
 # - with component examples ('kfp-examples')
-RUN python -m pip install --quiet --no-cache-dir --use-deprecated=legacy-resolver \
+RUN python -m pip install --quiet --no-cache-dir \
     elyra[kfp-tekton,kfp-examples]=="$TAG" \
     && rm -rf $HOME/.cache/yarn \
     && rm -rf /opt/conda/share/jupyter/lab/staging/node_modules

--- a/etc/docker/kubeflow/Dockerfile
+++ b/etc/docker/kubeflow/Dockerfile
@@ -24,8 +24,7 @@ ARG TAG="dev"
 # Install Elyra
 # - with KFP Tekton support ('kfp-tekton')
 # - with component examples ('kfp-examples')
-RUN python -m pip install --quiet --no-cache-dir \
-    elyra[kfp-tekton,kfp-examples]=="$TAG" \
+RUN python -m pip install --quiet --no-cache-dir elyra[kfp-tekton,kfp-examples]=="$TAG" \
     && rm -rf $HOME/.cache/yarn \
     && rm -rf /opt/conda/share/jupyter/lab/staging/node_modules
 


### PR DESCRIPTION
with Elyra 3.7 the latest version of pip can be used for installation, see #2648 
