### PR TITLE
Update documentation URLs in schema definitions

### DIFF
--- a/create-release.py
+++ b/create-release.py
@@ -160,6 +160,50 @@ def update_version_to_release() -> None:
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
+        # update documentation references in schema definitions
+        # located in elyra/metadata/schemas/
+        sed(
+            _source("elyra/metadata/schemas/url-catalog.json"),
+            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
+        )
+
+        sed(
+            _source("elyra/metadata/schemas/local-directory-catalog.json"),
+            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
+        )
+
+        sed(
+            _source("elyra/metadata/schemas/local-file-catalog.json"),
+            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
+        )
+
+        sed(
+            _source("elyra/metadata/schemas/airflow.json"),
+            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
+        )
+
+        sed(
+            _source("elyra/metadata/schemas/kfp.json"),
+            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
+        )
+
+        sed(
+            _source("elyra/metadata/schemas/code-snippet.json"),
+            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
+        )
+
+        sed(
+            _source("elyra/metadata/schemas/runtime-image.json"),
+            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
+        )
+
         check_run(
             ["lerna", "version", new_npm_version, "--no-git-tag-version", "--no-push", "--yes", "--exact"],
             cwd=config.source_dir,

--- a/elyra/metadata/schemas/local-directory-catalog.json
+++ b/elyra/metadata/schemas/local-directory-catalog.json
@@ -9,7 +9,7 @@
   "metadata_class_name": "elyra.pipeline.component_metadata.DirectoryCatalogMetadata",
   "uihints": {
     "icon": "",
-    "reference_url": "https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html#directory-component-catalog"
+    "reference_url": "https://elyra.readthedocs.io/en/latest/user_guide/pipeline-components.html#directory-component-catalog"
   },
   "properties": {
     "schema_name": {

--- a/elyra/metadata/schemas/local-directory-catalog.json
+++ b/elyra/metadata/schemas/local-directory-catalog.json
@@ -9,7 +9,7 @@
   "metadata_class_name": "elyra.pipeline.component_metadata.DirectoryCatalogMetadata",
   "uihints": {
     "icon": "",
-    "reference_url": "https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html"
+    "reference_url": "https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html#directory-component-catalog"
   },
   "properties": {
     "schema_name": {

--- a/elyra/metadata/schemas/local-file-catalog.json
+++ b/elyra/metadata/schemas/local-file-catalog.json
@@ -9,7 +9,7 @@
   "metadata_class_name": "elyra.pipeline.component_metadata.FilenameCatalogMetadata",
   "uihints": {
     "icon": "",
-    "reference_url": "https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html#filesystem-component-catalog"
+    "reference_url": "https://elyra.readthedocs.io/en/latest/user_guide/pipeline-components.html#filesystem-component-catalog"
   },
   "properties": {
     "schema_name": {

--- a/elyra/metadata/schemas/local-file-catalog.json
+++ b/elyra/metadata/schemas/local-file-catalog.json
@@ -9,7 +9,7 @@
   "metadata_class_name": "elyra.pipeline.component_metadata.FilenameCatalogMetadata",
   "uihints": {
     "icon": "",
-    "reference_url": "https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html"
+    "reference_url": "https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html#filesystem-component-catalog"
   },
   "properties": {
     "schema_name": {

--- a/elyra/metadata/schemas/url-catalog.json
+++ b/elyra/metadata/schemas/url-catalog.json
@@ -9,7 +9,7 @@
   "metadata_class_name": "elyra.pipeline.component_metadata.UrlCatalogMetadata",
   "uihints": {
     "icon": "",
-    "reference_url": "https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html#url-component-catalog"
+    "reference_url": "https://elyra.readthedocs.io/en/latest/user_guide/pipeline-components.html#url-component-catalog"
   },
   "properties": {
     "schema_name": {

--- a/elyra/metadata/schemas/url-catalog.json
+++ b/elyra/metadata/schemas/url-catalog.json
@@ -9,7 +9,7 @@
   "metadata_class_name": "elyra.pipeline.component_metadata.UrlCatalogMetadata",
   "uihints": {
     "icon": "",
-    "reference_url": "https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html"
+    "reference_url": "https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html#url-component-catalog"
   },
   "properties": {
     "schema_name": {


### PR DESCRIPTION
- The reference URLs for some of the built-in catalog connectors point to the wrong documentation location:

   ![image](https://user-images.githubusercontent.com/13068832/163057232-871961e9-513a-44f5-8c3e-9ec1662bf1e9.png)

- Reference URLs in schema definitions should be pinned to a specific version during release

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
- Update the connector URLs to point to the appropriate section.
- Update release script to pin reference URLs to a specific release (like it is/should be done everywhere else)
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
- Verified links for the impacted catalog types
- Also confirmed that the reference URLs are correct for the other built-in types
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
