### PR TITLE
Publish latest-tagged images when building releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,9 @@ PYTHON_PIP=$(PYTHON) -m pip
 
 TAG:=dev
 ELYRA_IMAGE=elyra/elyra:$(TAG)
+ELYRA_IMAGE_LATEST=elyra/elyra:latest
 KF_NOTEBOOK_IMAGE=elyra/kf-notebook:$(TAG)
+KF_NOTEBOOK_IMAGE_LATEST=elyra/kf-notebook:latest
 
 # Contains the set of commands required to be used by elyra
 REQUIRED_RUNTIME_IMAGE_COMMANDS?="curl python3"
@@ -233,6 +235,13 @@ publish-elyra-image: elyra-image # Publish Elyra stand-alone container image
 	# this is a privileged operation; a `docker login` might be required
 	docker push docker.io/$(ELYRA_IMAGE)
 	docker push quay.io/$(ELYRA_IMAGE)
+	# If we're building a release, tag latest and push
+	if [ "$(TAG)" != "dev" ]; then \
+		docker tag docker.io/$(ELYRA_IMAGE) docker.io/$(ELYRA_IMAGE_LATEST); \
+		docker push docker.io/$(ELYRA_IMAGE_LATEST); \
+		docker tag quay.io/$(ELYRA_IMAGE) quay.io/$(ELYRA_IMAGE_LATEST); \
+		docker push quay.io/$(ELYRA_IMAGE_LATEST); \
+	fi
 
 kf-notebook-image: # Build elyra image for use with Kubeflow Notebook Server
 	@mkdir -p build/docker-kubeflow
@@ -259,6 +268,13 @@ publish-kf-notebook-image: kf-notebook-image # Publish elyra image for use with 
 	# this is a privileged operation; a `docker login` might be required
 	docker push docker.io/$(KF_NOTEBOOK_IMAGE)
 	docker push quay.io/$(KF_NOTEBOOK_IMAGE)
+	# If we're building a release, tag latest and push
+	if [ "$(TAG)" != "dev" ]; then \
+		docker tag docker.io/$(KF_NOTEBOOK_IMAGE) docker.io/$(KF_NOTEBOOK_IMAGE_LATEST); \
+		docker push docker.io/$(KF_NOTEBOOK_IMAGE_LATEST); \
+		docker tag quay.io/$(KF_NOTEBOOK_IMAGE) quay.io/$(KF_NOTEBOOK_IMAGE_LATEST); \
+		docker push quay.io/$(KF_NOTEBOOK_IMAGE_LATEST); \
+	fi
 
 container-images: elyra-image kf-notebook-image ## Build all container images
 	docker images $(ELYRA_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -235,8 +235,8 @@ publish-elyra-image: elyra-image # Publish Elyra stand-alone container image
 	# this is a privileged operation; a `docker login` might be required
 	docker push docker.io/$(ELYRA_IMAGE)
 	docker push quay.io/$(ELYRA_IMAGE)
-	# If we're building a release, tag latest and push
-	if [ "$(TAG)" != "dev" ]; then \
+	# If we're building a release from master, tag latest and push
+	if [ "$(TAG)" != "dev" -a "$(shell git branch --show-current)" == "master" ]; then \
 		docker tag docker.io/$(ELYRA_IMAGE) docker.io/$(ELYRA_IMAGE_LATEST); \
 		docker push docker.io/$(ELYRA_IMAGE_LATEST); \
 		docker tag quay.io/$(ELYRA_IMAGE) quay.io/$(ELYRA_IMAGE_LATEST); \
@@ -268,8 +268,8 @@ publish-kf-notebook-image: kf-notebook-image # Publish elyra image for use with 
 	# this is a privileged operation; a `docker login` might be required
 	docker push docker.io/$(KF_NOTEBOOK_IMAGE)
 	docker push quay.io/$(KF_NOTEBOOK_IMAGE)
-	# If we're building a release, tag latest and push
-	if [ "$(TAG)" != "dev" ]; then \
+	# If we're building a release from master, tag latest and push
+	if [ "$(TAG)" != "dev" -a "$(shell git branch --show-current)" == "master" ]; then \
 		docker tag docker.io/$(KF_NOTEBOOK_IMAGE) docker.io/$(KF_NOTEBOOK_IMAGE_LATEST); \
 		docker push docker.io/$(KF_NOTEBOOK_IMAGE_LATEST); \
 		docker tag quay.io/$(KF_NOTEBOOK_IMAGE) quay.io/$(KF_NOTEBOOK_IMAGE_LATEST); \


### PR DESCRIPTION
### What changes were proposed in this pull request?
When using the `Makefile` targets to build and publish images for each release, we were not equating the built images with a `latest` tag.  As a result, this needed to be a manual step that, often, fell through the cracks.  This pull request applies the `latest` tag to the corresponding image _when releases are being built_ (i.e., when the `Makefile` variable `TAG` does not equal `"dev"`), and pushes those tagged images to the respective registry.

### How was this pull request tested?
This was tested by temporarily prefixing the `docker push` commands with `echo` since I didn't want to update any hash values relative to the images already present.  This test ensured that the `if [ "$(TAG)" != "dev" ];` statement was executed correctly.   I also used `make -n publish-container-images` and `make -n TAG=3.7.0 publish-container-images` to visually see the results - which only echos the logic flow although one can't really ensure the `if` statement is properly executed (thus the echo-based test).

Resolves: #2659

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
