### PR TITLE
Remove hacking dependency, capture version snapshot prior to CI testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,8 @@ jobs:
         run: |
           make install-server
           make test-dependencies
+      - name: Version Snapshot
+        run: pip freeze
       - name: Test
         run: make pytest
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ enable-extensions = G
 # References:
 # https://flake8.readthedocs.io/en/latest/user/configuration.html
 # https://flake8.readthedocs.io/en/latest/user/error-codes.html
-# https://docs.openstack.org/hacking/latest/user/hacking.html
 ignore =
     # Import formatting
     E4,

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,8 +1,5 @@
 elyra-examples-kfp-catalog
-flake8>=3.5.0
-flake8-import-order>=0.18.1
 git-python
-hacking
 importlib-resources
 pytest>=5.4.1
 pytest-console-scripts


### PR DESCRIPTION
This pull request removes `hacking` from the set of test dependencies, as it was found to side-affect linting in server dev environments that were not seen during CI (see #2670 for details) and its absence doesn't appear to break anything.

This change includes two other changes:
1. The redundant lint-related dependencies have been removed from `test_requirements.txt` as they're already included in `lint_requirements.txt`.
2. A `Version Snapshot` action has been added in the `test-server` job after dependencies have been installed and prior to running server tests.  This equivalent information was inadvertently removed in #1671.

### How was this pull request tested?
1. Per #2670, a new conda env was created.  
2. Then the branch for PR #2656 was pulled (which contains the lining issue that surfaces using older `flake8` versions)
3. `make lint-server` - passes
4. `make clean install` - passes
5. `make test-dependencies lint-server` - passes (it was this `lint-server` that failed with `hacking` in place).

Resolves: #2670
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
