### PR TITLE
Support use of mounted volumes in Kubeflow Pipelines runtime

### DIFF
--- a/elyra/pipeline/pipeline_constants.py
+++ b/elyra/pipeline/pipeline_constants.py
@@ -17,3 +17,4 @@
 PIPELINE_DEFAULTS = "pipeline_defaults"
 RUNTIME_IMAGE = "runtime_image"
 ENV_VARIABLES = "env_vars"
+MOUNTED_VOLUMES = "mounted_volumes"

--- a/elyra/templates/components/generic_properties_template.jinja2
+++ b/elyra/templates/components/generic_properties_template.jinja2
@@ -9,7 +9,8 @@
       "elyra_outputs": [],
       "elyra_env_vars": [],
       "elyra_dependencies": [],
-      "elyra_include_subdirectories": false
+      "elyra_include_subdirectories": false,
+      "elyra_mounted_volumes": []
     },
     "parameters": [
       {
@@ -41,6 +42,9 @@
       },
       {
         "id": "elyra_outputs"
+      },
+      {
+        "id": "elyra_mounted_volumes"
       }
     ],
     "uihints": {
@@ -198,7 +202,22 @@
           "data": {
             "placeholder": "*.csv"
           }
-        }
+        },
+        {
+          "parameter_ref": "elyra_mounted_volumes",
+          "control": "custom",
+          "custom_control_id": "StringArrayControl",
+          "label": {
+            "default": "Data Volumes"
+          },
+          "description": {
+           "default": "Volumes to be mounted in this node. The specified Persistent Volume Claims must exist in the Kubeflow Pipelines user namespace or this node will not run.",
+           "placement": "on_panel"
+          },
+          "data": {
+            "placeholder": "/mount/path=pvc-name"
+          }
+        }        
       ],
       "group_info": [
         {
@@ -244,6 +263,11 @@
               "id": "elyra_outputs",
               "type": "controls",
               "parameter_refs": ["elyra_outputs"]
+            },
+            {
+              "id": "elyra_mounted_volumes",
+              "type": "controls",
+              "parameter_refs": ["elyra_mounted_volumes"]
             }
           ]
         }

--- a/elyra/templates/pipeline/pipeline_properties_template.jinja2
+++ b/elyra/templates/pipeline/pipeline_properties_template.jinja2
@@ -4,7 +4,8 @@
     "runtime": "",
     "description": "",
     "elyra_runtime_image": null,
-    "elyra_env_vars": []
+    "elyra_env_vars": [],
+    "elyra_mounted_volumes": []
   },
   "parameters": [
     {
@@ -21,6 +22,9 @@
     },
     {
       "id": "elyra_env_vars"
+    },
+    {
+      "id": "elyra_mounted_volumes"
     }
   ],
   "uihints": {
@@ -76,6 +80,21 @@
         "data": {
           "placeholder": "env_var=VALUE"
         }
+      },
+      {
+        "parameter_ref": "elyra_mounted_volumes",
+        "control": "custom",
+        "custom_control_id": "StringArrayControl",
+        "label": {
+          "default": "Data Volumes"
+        },
+        "description": {
+          "default": "Volumes to be mounted in all nodes. The specified Persistent Volume Claims must exist in the Kubeflow Pipelines user namespace or the pipeline will not run.",
+          "placement": "on_panel"
+        },
+        "data": {
+          "placeholder": "/mount/path=pvc-name"
+        }
       }
     ],
     "group_info": [
@@ -119,6 +138,11 @@
             "id": "elyra_env_vars",
             "type": "controls",
             "parameter_refs": ["elyra_env_vars"]
+          },
+          {
+            "id": "elyra_mounted_volumes",
+            "type": "controls",
+            "parameter_refs": ["elyra_mounted_volumes"]
           }
         ]
       }

--- a/elyra/tests/pipeline/resources/properties.json
+++ b/elyra/tests/pipeline/resources/properties.json
@@ -6,6 +6,7 @@
     "elyra_cpu": null,
     "elyra_gpu": null,
     "elyra_memory": null,
+    "elyra_mounted_volumes": [],
     "elyra_outputs": [],
     "elyra_env_vars": [],
     "elyra_dependencies": [],
@@ -41,6 +42,9 @@
     },
     {
       "id": "elyra_outputs"
+    },
+    {
+      "id": "elyra_mounted_volumes"
     }
   ],
   "uihints": {
@@ -198,6 +202,21 @@
         "data": {
           "placeholder": "*.csv"
         }
+      },
+      {
+        "parameter_ref": "elyra_mounted_volumes",
+        "control": "custom",
+        "custom_control_id": "StringArrayControl",
+        "label": {
+          "default": "Data Volumes"
+        },
+        "description": {
+          "default": "Volumes to be mounted in this node. The specified Persistent Volume Claims must exist in the Kubeflow Pipelines user namespace or this node will not run.",
+          "placement": "on_panel"
+        },
+        "data": {
+          "placeholder": "/mount/path=pvc-name"
+        }
       }
     ],
     "group_info": [
@@ -244,6 +263,11 @@
             "id": "elyra_outputs",
             "type": "controls",
             "parameter_refs": ["elyra_outputs"]
+          },
+          {
+            "id": "elyra_mounted_volumes",
+            "type": "controls",
+            "parameter_refs": ["elyra_mounted_volumes"]
           }
         ]
       }

--- a/elyra/tests/pipeline/test_handlers.py
+++ b/elyra/tests/pipeline/test_handlers.py
@@ -200,5 +200,5 @@ async def test_get_pipeline_properties_definition(jp_fetch):
             {"id": "description"},
             {"id": "elyra_runtime_image"},
             {"id": "elyra_env_vars"},
-            {'id': 'elyra_mounted_volumes'},
+            {"id": "elyra_mounted_volumes"},
         ]

--- a/elyra/tests/pipeline/test_handlers.py
+++ b/elyra/tests/pipeline/test_handlers.py
@@ -200,4 +200,5 @@ async def test_get_pipeline_properties_definition(jp_fetch):
             {"id": "description"},
             {"id": "elyra_runtime_image"},
             {"id": "elyra_env_vars"},
+            {'id': 'elyra_mounted_volumes'},
         ]

--- a/elyra/tests/util/test_kubernetes.py
+++ b/elyra/tests/util/test_kubernetes.py
@@ -1,0 +1,61 @@
+#
+# Copyright 2018-2022 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from elyra.util.kubernetes import is_valid_kubernetes_resource_name
+
+
+def test_is_valid_kubernetes_resource_name_invalid_input():
+    """
+    Verify that is_valid_kubernetes_resource_name detects whether or
+    not a given string is a valid Kubernetes resource name:
+        - contains no more than 253 characters
+        - contain only lowercase alphanumeric characters, '-' or '.'
+        - start with an alphanumeric character
+        - end with an alphanumeric character
+    """
+    # test length violations
+    assert not is_valid_kubernetes_resource_name(name=None)  # Too short
+    assert not is_valid_kubernetes_resource_name(name="")  # Too short
+    assert not is_valid_kubernetes_resource_name(name="a" * 254)  # Too long
+    # test first character violations (not alphanum or lowercase)
+    assert not is_valid_kubernetes_resource_name(name="-a")
+    assert not is_valid_kubernetes_resource_name(name=".b")
+    assert not is_valid_kubernetes_resource_name(name=" c")
+    assert not is_valid_kubernetes_resource_name(name="Dave")
+    # test last character violations (not alphanum or lowercase)
+    assert not is_valid_kubernetes_resource_name(name="a-")
+    assert not is_valid_kubernetes_resource_name(name="b.")
+    assert not is_valid_kubernetes_resource_name(name="c ")
+    assert not is_valid_kubernetes_resource_name(name="sw33T")
+    # test middle characters violations
+    assert not is_valid_kubernetes_resource_name(name="aBBa")
+    assert not is_valid_kubernetes_resource_name(name="b  b")
+
+
+def test_is_valid_kubernetes_resource_name_valid_input():
+    """
+    Verify that is_valid_kubernetes_resource_name detects whether or
+    not a given string is a valid Kubernetes resource name:
+        - contains no more than 253 characters
+        - contain only lowercase alphanumeric characters, '-' or '.'
+        - start with an alphanumeric character
+        - end with an alphanumeric character
+    """
+    # test valid names
+    assert is_valid_kubernetes_resource_name(name="l0l")
+    assert is_valid_kubernetes_resource_name(name="l-l")
+    assert is_valid_kubernetes_resource_name(name="l.l")
+    assert is_valid_kubernetes_resource_name(name="4-you")
+    assert is_valid_kubernetes_resource_name(name="you.2")

--- a/elyra/util/kubernetes.py
+++ b/elyra/util/kubernetes.py
@@ -1,0 +1,39 @@
+#
+# Copyright 2018-2022 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def is_valid_kubernetes_resource_name(name: str) -> bool:
+    """
+    Returns a truthy value indicating whether name meets the kubernetes
+    naming constraints, as outlined in
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+    This implementation is based on https://tools.ietf.org/html/rfc1123:
+    - contains no more than 253 characters
+    - contain only lowercase alphanumeric characters, '-' or '.'
+    - start with an alphanumeric character
+    - end with an alphanumeric character
+    """
+    if name is None or (len(name) == 0) or (len(name) > 253) or not name[0].isalnum() or not name[-1].isalnum():
+        return False
+    for char in name:
+        if char.isdigit():
+            pass
+        elif char.isalpha():
+            if not char.islower():
+                return False
+        elif char not in ["-", "."]:
+            return False
+    return True

--- a/tests/snapshots/pipeline-editor-tests/matches-complex-pipeline-snapshot.1.snap
+++ b/tests/snapshots/pipeline-editor-tests/matches-complex-pipeline-snapshot.1.snap
@@ -26,6 +26,7 @@ Object {
               ],
               "filename": "producer.ipynb",
               "include_subdirectories": false,
+              "mounted_volumes": Array [],
               "outputs": Array [
                 "output-1.csv",
                 "output-2.csv",
@@ -133,6 +134,7 @@ Object {
               "env_vars": Array [],
               "filename": "../scripts/setup.py",
               "include_subdirectories": false,
+              "mounted_volumes": Array [],
               "outputs": Array [],
               "runtime_image": "continuumio/anaconda3:2021.11",
             },
@@ -184,6 +186,7 @@ Object {
               "env_vars": Array [],
               "filename": "create-source-files.py",
               "include_subdirectories": false,
+              "mounted_volumes": Array [],
               "outputs": Array [
                 "input-1.csv",
                 "input-2.csv",
@@ -238,6 +241,7 @@ Object {
               "env_vars": Array [],
               "filename": "producer-script.py",
               "include_subdirectories": false,
+              "mounted_volumes": Array [],
               "outputs": Array [
                 "output-3.csv",
                 "output-4.csv",

--- a/tests/snapshots/pipeline-editor-tests/matches-complex-pipeline-snapshot.1.snap
+++ b/tests/snapshots/pipeline-editor-tests/matches-complex-pipeline-snapshot.1.snap
@@ -81,6 +81,7 @@ Object {
               "env_vars": Array [],
               "filename": "consumer.ipynb",
               "include_subdirectories": false,
+              "mounted_volumes": Array [],
               "outputs": Array [],
               "runtime_image": "continuumio/anaconda3:2021.11",
             },

--- a/tests/snapshots/pipeline-editor-tests/matches-simple-pipeline-snapshot.1.snap
+++ b/tests/snapshots/pipeline-editor-tests/matches-simple-pipeline-snapshot.1.snap
@@ -27,6 +27,7 @@ Object {
               ],
               "filename": "helloworld.ipynb",
               "include_subdirectories": false,
+              "mounted_volumes": Array [],
               "outputs": Array [],
             },
             "label": "",


### PR DESCRIPTION
Add [data] volume mount support for generic components:
- Persistent Volume Claim (PVC) - based data volume mounts can be defined as pipeline defaults

    ![image](https://user-images.githubusercontent.com/13068832/164338091-fb7eb6f5-e149-41f9-9eff-c0680d0dc449.png)
  - The current UI implementation requires volume mounts to be defined as `/mount/path=<pvc-name>`, where `/mount/path` represents the path where the _existing_ `pvc-name` PVC will be mounted.
  - The specified PVCs must exist in the users' Kubeflow Pipelines namespace or the pipeline will not run because the pods will time out. 
  - The pipeline editor only validates that `<pvc-name>` is a valid Kubernetes resource name. If the specified name is invalid, a warning message is logged and the volume mount ignored.
  - The `/mount/path` must represent a valid Unix path.
  - Whether or not the volume mount works at runtime as expected depends on the PVC resource definition in the Kubernetes cluster. 

 - Data volume mounts can also be defined for each generic node. 
   - The constraints listed for pipeline defaults also apply to node-level volume mounts.
   - Node-level volume mounts override pipeline default volume mounts. In the example below the node-level volume mount `/mnt/vol1=my-pvc` takes precedence over the pipeline default volume mount `/mnt/vol1=my-other-pvc`.
   
    ![image](https://user-images.githubusercontent.com/13068832/164339626-013ad659-2483-4fe5-9f44-8c174e53c91d.png)

Volume mount information is displayed in the node-preview on the canvas:
   
   ![image](https://user-images.githubusercontent.com/13068832/164340495-54893ae1-e1d1-4e54-841a-bb3dd1ce7e55.png)



Volume mount information  is displayed in Kubeflow Central Dashboard:
     ![image](https://user-images.githubusercontent.com/13068832/164340339-83066c0f-e9a2-4087-9540-e7d190c1b308.png)


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/master/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/master/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
- Add support for  [data] volume mounts to pipeline defaults
- Add support [data] volume mounts to generic nodes (KFP)
- Update relevant documentation (TODO)
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
- Manual testing
- Added new unit tests for `kubernetes` utility class
- Reviewed output of `make docs`
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
