### PR TITLE
Remove secret from airflow helm values

### DIFF
--- a/etc/kubernetes/airflow/helm/values.yaml
+++ b/etc/kubernetes/airflow/helm/values.yaml
@@ -39,7 +39,7 @@ airflow:
   ## GENERATE:
   ##   python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)"
   ##
-  fernetKey: "7T512UXSSmBOkpWimFHIVb8jK6lfmSAvx4mO6Arehnc="
+  fernetKey: "my-generated-fernetKey"
 
   ## environment variables for the web/scheduler/worker Pods (for airflow configs)
   ##


### PR DESCRIPTION
Running a scan to detect secrets persisted within the Elyra repository yielded several false positives, except one specifying a [Fernet Key](https://cryptography.io/en/latest/fernet/).  Since the preceding comment describes how to generate a key value, it's fairly clear the value that is there should be replaced when a user deploys Elyra via the helm chart.

This pull request replaces the value with `"my-generated-fernetKey"`, which _self-decribes_ what should be done, in conjunction with the preceding comment .  That comment is captured here:
```
  ## the fernet key used to encrypt the connections/variables in the database
  ##
  ## WARNING:
  ## - you MUST customise this value, otherwise the encryption will be somewhat pointless
  ##
  ## NOTE:
  ## - to prevent this value being stored in your values.yaml (and airflow-env ConfigMap),
  ##   consider using `airflow.extraEnv` to define it from a pre-created secret
  ##
  ## GENERATE:
  ##   python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)"
  ##
```
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
