### PR TITLE
Support key-value type list properties in a more generic way

### DIFF
--- a/elyra/pipeline/handlers.py
+++ b/elyra/pipeline/handlers.py
@@ -207,7 +207,9 @@ class PipelinePropertiesHandler(HttpErrorMixin, APIHandler):
             raise web.HTTPError(400, f"Invalid runtime type '{runtime_type}'")
 
         # Get pipeline properties json
-        pipeline_properties_json = PipelineDefinition.get_pipeline_properties_from_template()
+        pipeline_properties_json = PipelineDefinition.get_canvas_properties_from_template(
+            package_name="templates/pipeline", template_name="pipeline_properties_template.jinja2"
+        )
 
         self.set_status(200)
         self.set_header("Content-Type", "application/json")

--- a/elyra/pipeline/handlers.py
+++ b/elyra/pipeline/handlers.py
@@ -21,8 +21,6 @@ import mimetypes
 from typing import List
 from typing import Optional
 
-from jinja2 import Environment
-from jinja2 import PackageLoader
 from jupyter_server.base.handlers import APIHandler
 from jupyter_server.utils import url_path_join
 from tornado import web
@@ -34,6 +32,7 @@ from elyra.pipeline.component import Component
 from elyra.pipeline.component_catalog import ComponentCache
 from elyra.pipeline.component_catalog import RefreshInProgressError
 from elyra.pipeline.parser import PipelineParser
+from elyra.pipeline.pipeline_definition import PipelineDefinition
 from elyra.pipeline.processor import PipelineProcessorManager
 from elyra.pipeline.processor import PipelineProcessorRegistry
 from elyra.pipeline.runtime_type import RuntimeProcessorType
@@ -208,9 +207,7 @@ class PipelinePropertiesHandler(HttpErrorMixin, APIHandler):
             raise web.HTTPError(400, f"Invalid runtime type '{runtime_type}'")
 
         # Get pipeline properties json
-        jinja_loader = PackageLoader("elyra", "templates/pipeline")
-        template = Environment(loader=jinja_loader).get_template("pipeline_properties_template.jinja2")
-        pipeline_properties_json = json.loads(template.render())
+        pipeline_properties_json = PipelineDefinition.get_pipeline_properties_from_template()
 
         self.set_status(200)
         self.set_header("Content-Type", "application/json")

--- a/elyra/pipeline/local/processor_local.py
+++ b/elyra/pipeline/local/processor_local.py
@@ -142,7 +142,7 @@ class OperationProcessor(ABC):
     @staticmethod
     def _collect_envs(operation: GenericOperation, elyra_run_name: str) -> Dict:
         envs = os.environ.copy()  # Make sure this process's env is "available" in the kernel subprocess
-        envs.update(operation.env_vars_as_dict())
+        envs.update(operation.env_vars.to_dict())
         envs["ELYRA_RUNTIME_ENV"] = "local"  # Special case
         envs["ELYRA_RUN_NAME"] = elyra_run_name
         return envs

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -447,24 +447,25 @@ class KeyValueList(list):
             kv_dict[key] = value
         return kv_dict
 
-    def dict_to_kv_list(self, kv_dict: Dict) -> "KeyValueList":
+    @classmethod
+    def from_dict(cls, kv_dict: Dict) -> "KeyValueList":
         """
         Convert a set of key-value pairs stored in a dictionary to
         a KeyValueList of strings with the defined separator.
         """
-        str_list = [f"{key}{self._key_value_separator}{value}" for key, value in kv_dict.items()]
+        str_list = [f"{key}{cls._key_value_separator}{value}" for key, value in kv_dict.items()]
         return KeyValueList(str_list)
 
-    def merge_kv_pairs(self, primary_list: "KeyValueList") -> "KeyValueList":
+    @classmethod
+    def merge(cls, primary: "KeyValueList", secondary: "KeyValueList") -> "KeyValueList":
         """
         Merge two key-value pair lists, preferring the values given in the
-        primary_list in the case of a matching key between the two lists.
+        primary parameter in the case of a matching key between the two lists.
         """
-        primary_dict = primary_list.to_dict()
-        secondary_dict = self.to_dict()
+        primary_dict = primary.to_dict()
+        secondary_dict = secondary.to_dict()
 
-        merged_list = self.dict_to_kv_list({**secondary_dict, **primary_dict})
-        return KeyValueList(merged_list)
+        return KeyValueList.from_dict({**secondary_dict, **primary_dict})
 
     @staticmethod
     def log_message(msg: str, logger: Optional[Logger] = None, level: Optional[int] = logging.DEBUG):

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -22,6 +22,8 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
+from elyra.pipeline.pipeline_constants import ENV_VARIABLES
+
 # TODO: Make pipeline version available more widely
 # as today is only available on the pipeline editor
 PIPELINE_CURRENT_VERSION = 7
@@ -290,11 +292,7 @@ class GenericOperation(Operation):
 
     @property
     def env_vars(self) -> Optional["KeyValueList"]:
-        return self._component_params.get("env_vars")
-
-    @property
-    def volume_mounts(self) -> Optional["KeyValueList"]:
-        return self._component_params.get("mounted_volumes")
+        return self._component_params.get(ENV_VARIABLES)
 
     @property
     def cpu(self) -> Optional[str]:

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -448,13 +448,13 @@ class KeyValueList(list):
             if not key:
                 KeyValueList.log_message(f"Skipping inclusion of property '{kv}': no key found", logger, logging.WARN)
                 continue
+            if isinstance(value, str):
+                value = value.strip()
             if not value:
                 KeyValueList.log_message(
                     f"Skipping inclusion of property '{key}': no value specified", logger, logging.DEBUG
                 )
                 continue
-            if isinstance(value, str):
-                value = value.strip()
 
             kv_dict[key] = value
         return kv_dict

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -421,7 +421,7 @@ class KeyValueList(list):
         Properties consisting of key/value pairs are stored in a list of separated
         strings, while most processing steps require a dictionary - so we must convert.
         If no key/value pairs are specified, an empty dictionary is returned, otherwise
-        pairs are converted to dictionary entries and returned.
+        pairs are converted to dictionary entries, stripped of whitespace, and returned.
         """
         kv_dict = {}
         for kv in self:
@@ -435,14 +435,18 @@ class KeyValueList(list):
                 )
 
             key, value = kv.split(self._key_value_separator, 1)
-            if not key.strip():
+
+            key = key.strip()
+            if not key:
                 KeyValueList.log_message(f"Skipping inclusion of property '{kv}': no key found", logger, logging.WARN)
                 continue
             if not value:
                 KeyValueList.log_message(
-                    f"Skipping inclusion of property '{key}': no value specified", logger, logging.INFO
+                    f"Skipping inclusion of property '{key}': no value specified", logger, logging.DEBUG
                 )
                 continue
+            if isinstance(value, str):
+                value = value.strip()
 
             kv_dict[key] = value
         return kv_dict

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -418,7 +418,7 @@ class KeyValueList(list):
 
     def to_dict(self, logger: Optional[Logger] = None) -> Dict[str, str]:
         """
-        Properties consisting of key/value pairs are stored in a list of separated
+        Properties consisting of key-value pairs are stored in a list of separated
         strings, while most processing steps require a dictionary - so we must convert.
         If no key/value pairs are specified, an empty dictionary is returned, otherwise
         pairs are converted to dictionary entries, stripped of whitespace, and returned.

--- a/elyra/pipeline/pipeline_constants.py
+++ b/elyra/pipeline/pipeline_constants.py
@@ -17,3 +17,4 @@
 PIPELINE_DEFAULTS = "pipeline_defaults"
 RUNTIME_IMAGE = "runtime_image"
 ENV_VARIABLES = "env_vars"
+KEY_VALUE_SEPARATOR = "="

--- a/elyra/pipeline/pipeline_constants.py
+++ b/elyra/pipeline/pipeline_constants.py
@@ -17,4 +17,3 @@
 PIPELINE_DEFAULTS = "pipeline_defaults"
 RUNTIME_IMAGE = "runtime_image"
 ENV_VARIABLES = "env_vars"
-KEY_VALUE_SEPARATOR = "="

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -584,31 +584,23 @@ class RuntimePipelineProcessor(PipelineProcessor):
 
     def _get_volume_mounts(self, operation: Operation) -> Optional[Dict[str, str]]:
         """
-        Parses the mounted volume strings specified in the Operation into a key value pair of
-        <MOUNT PATH>: <PVC NAME>
+        Loops through an Operation mounted volumes to re-format path and remove
+        invalid PVC names.
+
         :param operation: the operation to check for volume mounts
-        :return:
+        :return: dictionary of mount path to valid PVC names
         """
-        volume_mounts = operation.component_params.get(MOUNTED_VOLUMES)
-        if operation.component_params.get(MOUNTED_VOLUMES):
-            volume_mounts = {}
-            for entry in operation.component_params[MOUNTED_VOLUMES]:
-                # TODO: Replace hack (input formatted as "<mount_point>=<pvc_name>") once the
-                # pipeline object makes the parameter available as a dictionary
-                s = entry.split("=")
-                # make sure the input is valid
-                if len(s) != 2:
-                    self.log.warning(f"Ignoring invalid volume mount entry '{entry}': a PVC name is required.")
-                    continue
-                s[0] = f"/{s[0].strip().strip('/')}"  # result should be formatted as "/mount/path"
-                s[1] = s[1].strip()
-                # ensure the PVC name is syntactically a valid Kubernetes resource name
-                if not is_valid_kubernetes_resource_name(s[1]):
-                    self.log.warning(
-                        f"Ignoring invalid volume mount entry '{entry}': the PVC name '{s[1]}'"
-                        "is not a valid Kubernetes resource name."
-                    )
-                    continue
-                volume_mounts[s[0]] = s[1]
-                # end hack
-        return volume_mounts
+        volume_mounts_valid = {}
+        volume_mounts = operation.component_params.get(MOUNTED_VOLUMES).to_dict()
+        for mount_path, pvc_name in volume_mounts.items():
+            # Ensure the PVC name is syntactically a valid Kubernetes resource name
+            if not is_valid_kubernetes_resource_name(pvc_name):
+                self.log.warning(
+                    f"Ignoring invalid volume mount entry '{mount_path}': the PVC "
+                    f"name '{pvc_name}' is not a valid Kubernetes resource name."
+                )
+                continue
+
+            formatted_mount_path = f"/{mount_path.strip('/')}"
+            volume_mounts_valid[formatted_mount_path] = pvc_name
+        return volume_mounts_valid

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -591,16 +591,17 @@ class RuntimePipelineProcessor(PipelineProcessor):
         :return: dictionary of mount path to valid PVC names
         """
         volume_mounts_valid = {}
-        volume_mounts = operation.component_params.get(MOUNTED_VOLUMES).to_dict()
-        for mount_path, pvc_name in volume_mounts.items():
-            # Ensure the PVC name is syntactically a valid Kubernetes resource name
-            if not is_valid_kubernetes_resource_name(pvc_name):
-                self.log.warning(
-                    f"Ignoring invalid volume mount entry '{mount_path}': the PVC "
-                    f"name '{pvc_name}' is not a valid Kubernetes resource name."
-                )
-                continue
+        if operation.component_params.get(MOUNTED_VOLUMES):
+            volume_mounts = operation.component_params.get(MOUNTED_VOLUMES).to_dict()
+            for mount_path, pvc_name in volume_mounts.items():
+                # Ensure the PVC name is syntactically a valid Kubernetes resource name
+                if not is_valid_kubernetes_resource_name(pvc_name):
+                    self.log.warning(
+                        f"Ignoring invalid volume mount entry '{mount_path}': the PVC "
+                        f"name '{pvc_name}' is not a valid Kubernetes resource name."
+                    )
+                    continue
 
-            formatted_mount_path = f"/{mount_path.strip('/')}"
-            volume_mounts_valid[formatted_mount_path] = pvc_name
+                formatted_mount_path = f"/{mount_path.strip('/')}"
+                volume_mounts_valid[formatted_mount_path] = pvc_name
         return volume_mounts_valid

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -488,7 +488,7 @@ class RuntimePipelineProcessor(PipelineProcessor):
         :return: dictionary containing environment name/value pairs
         """
 
-        envs: Dict = operation.env_vars_as_dict(logger=self.log)
+        envs: Dict = operation.env_vars.to_dict(logger=self.log)
         envs["ELYRA_RUNTIME_ENV"] = self.name
 
         # set environment variables for Minio/S3 access, in the following order of precedence:

--- a/elyra/templates/components/generic_properties_template.jinja2
+++ b/elyra/templates/components/generic_properties_template.jinja2
@@ -181,7 +181,8 @@
           },
           "data": {
             "placeholder": "env_var=VALUE",
-            "canRefresh": true
+            "canRefresh": true,
+            "keyValueEntries": true
           }
         },
         {

--- a/elyra/templates/pipeline/pipeline_properties_template.jinja2
+++ b/elyra/templates/pipeline/pipeline_properties_template.jinja2
@@ -111,7 +111,8 @@
           "placement": "on_panel"
         },
         "data": {
-          "placeholder": "/mount/path=pvc-name"
+          "placeholder": "/mount/path=pvc-name",
+          "keyValueEntries": true
         }
       }
     ],

--- a/elyra/templates/pipeline/pipeline_properties_template.jinja2
+++ b/elyra/templates/pipeline/pipeline_properties_template.jinja2
@@ -74,7 +74,8 @@
           "placement": "on_panel"
         },
         "data": {
-          "placeholder": "env_var=VALUE"
+          "placeholder": "env_var=VALUE",
+          "keyValueEntries": true
         }
       }
     ],

--- a/elyra/tests/pipeline/airflow/test_processor_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_processor_airflow.py
@@ -439,7 +439,7 @@ def test_collect_envs(processor):
     assert envs["AWS_SECRET_ACCESS_KEY"] == "secret"
     assert envs["ELYRA_ENABLE_PIPELINE_INFO"] == "True"
     assert "ELYRA_WRITABLE_CONTAINER_DIR" not in envs
-    assert envs["USER_EMPTY_VALUE"] == "  "
+    assert envs["USER_EMPTY_VALUE"] == ""
     assert envs["USER_TWO_EQUALS"] == "KEY=value"
     assert "USER_NO_VALUE" not in envs
 
@@ -451,7 +451,7 @@ def test_collect_envs(processor):
     assert "AWS_SECRET_ACCESS_KEY" not in envs
     assert envs["ELYRA_ENABLE_PIPELINE_INFO"] == "True"
     assert "ELYRA_WRITABLE_CONTAINER_DIR" not in envs
-    assert envs["USER_EMPTY_VALUE"] == "  "
+    assert envs["USER_EMPTY_VALUE"] == ""
     assert envs["USER_TWO_EQUALS"] == "KEY=value"
     assert "USER_NO_VALUE" not in envs
 

--- a/elyra/tests/pipeline/airflow/test_processor_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_processor_airflow.py
@@ -441,7 +441,7 @@ def test_collect_envs(processor):
     assert envs["AWS_SECRET_ACCESS_KEY"] == "secret"
     assert envs["ELYRA_ENABLE_PIPELINE_INFO"] == "True"
     assert "ELYRA_WRITABLE_CONTAINER_DIR" not in envs
-    assert envs["USER_EMPTY_VALUE"] == ""
+    assert "USER_EMPTY_VALUE" not in envs
     assert envs["USER_TWO_EQUALS"] == "KEY=value"
     assert "USER_NO_VALUE" not in envs
 
@@ -453,7 +453,7 @@ def test_collect_envs(processor):
     assert "AWS_SECRET_ACCESS_KEY" not in envs
     assert envs["ELYRA_ENABLE_PIPELINE_INFO"] == "True"
     assert "ELYRA_WRITABLE_CONTAINER_DIR" not in envs
-    assert envs["USER_EMPTY_VALUE"] == ""
+    assert "USER_EMPTY_VALUE" not in envs
     assert envs["USER_TWO_EQUALS"] == "KEY=value"
     assert "USER_NO_VALUE" not in envs
 

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -184,7 +184,7 @@ def test_collect_envs(processor):
     assert envs["AWS_SECRET_ACCESS_KEY"] == "secret"
     assert envs["ELYRA_ENABLE_PIPELINE_INFO"] == "True"
     assert envs["ELYRA_WRITABLE_CONTAINER_DIR"] == "/tmp"
-    assert envs["USER_EMPTY_VALUE"] == "  "
+    assert envs["USER_EMPTY_VALUE"] == ""
     assert envs["USER_TWO_EQUALS"] == "KEY=value"
     assert "USER_NO_VALUE" not in envs
 
@@ -196,7 +196,7 @@ def test_collect_envs(processor):
     assert "AWS_SECRET_ACCESS_KEY" not in envs
     assert envs["ELYRA_ENABLE_PIPELINE_INFO"] == "True"
     assert envs["ELYRA_WRITABLE_CONTAINER_DIR"] == "/tmp"
-    assert envs["USER_EMPTY_VALUE"] == "  "
+    assert envs["USER_EMPTY_VALUE"] == ""
     assert envs["USER_TWO_EQUALS"] == "KEY=value"
     assert "USER_NO_VALUE" not in envs
 

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -184,7 +184,7 @@ def test_collect_envs(processor):
     assert envs["AWS_SECRET_ACCESS_KEY"] == "secret"
     assert envs["ELYRA_ENABLE_PIPELINE_INFO"] == "True"
     assert envs["ELYRA_WRITABLE_CONTAINER_DIR"] == "/tmp"
-    assert envs["USER_EMPTY_VALUE"] == ""
+    assert "USER_EMPTY_VALUE" not in envs
     assert envs["USER_TWO_EQUALS"] == "KEY=value"
     assert "USER_NO_VALUE" not in envs
 
@@ -196,7 +196,7 @@ def test_collect_envs(processor):
     assert "AWS_SECRET_ACCESS_KEY" not in envs
     assert envs["ELYRA_ENABLE_PIPELINE_INFO"] == "True"
     assert envs["ELYRA_WRITABLE_CONTAINER_DIR"] == "/tmp"
-    assert envs["USER_EMPTY_VALUE"] == ""
+    assert "USER_EMPTY_VALUE" not in envs
     assert envs["USER_TWO_EQUALS"] == "KEY=value"
     assert "USER_NO_VALUE" not in envs
 

--- a/elyra/tests/pipeline/local/test_pipeline_processor_local.py
+++ b/elyra/tests/pipeline/local/test_pipeline_processor_local.py
@@ -74,7 +74,7 @@ def test_pipeline_get_envs():
 
     for op in pipeline.operations.values():
         assert isinstance(op, GenericOperation)
-        op_envs = op.env_vars_as_dict()
+        op_envs = op.env_vars.to_dict()
         assert op_envs["OP_NAME"] == op.name
 
 

--- a/elyra/tests/pipeline/resources/properties.json
+++ b/elyra/tests/pipeline/resources/properties.json
@@ -181,7 +181,8 @@
         },
         "data": {
           "placeholder": "env_var=VALUE",
-          "canRefresh": true
+          "canRefresh": true,
+          "keyValueEntries": true
         }
       },
       {

--- a/elyra/tests/pipeline/resources/sample_pipelines/pipeline_valid_with_pipeline_default.json
+++ b/elyra/tests/pipeline/resources/sample_pipelines/pipeline_valid_with_pipeline_default.json
@@ -20,7 +20,8 @@
               "env_vars": ["var1=var1", "var2=var2", "var3="],
               "include_subdirectories": false,
               "dependencies": ["a.txt", "b.txt", "c.txt"],
-              "outputs": ["d.txt", "e.txt", "f.txt"]
+              "outputs": ["d.txt", "e.txt", "f.txt"],
+              "kv_test_property": ["var1 =var1", "var3=  "]
             },
             "ui_data": {
               "label": "{{label}}",
@@ -39,7 +40,12 @@
           "name": "{{name}}",
           "pipeline_defaults": {
             "runtime_image": "{{ default_image }}",
-            "env_vars": ["var1=var_one", "var2=var_two", "var3=var_three"]
+            "env_vars": ["var1=var_one", "var2=var_two", "var3=var_three"],
+            "kv_test_property": [
+              "var1=var_one  ",
+              "var2=var2",
+              "var3  =var_three"
+            ]
           },
           "runtime": "{{runtime description}}"
         },

--- a/elyra/tests/pipeline/test_pipeline_constructor.py
+++ b/elyra/tests/pipeline/test_pipeline_constructor.py
@@ -361,7 +361,7 @@ def test_env_list_to_dict_function():
         component_params=component_parameters,
     )
 
-    assert test_operation.env_vars_as_dict() == env_variables_dict
+    assert test_operation.env_vars.to_dict() == env_variables_dict
 
 
 def test_validate_resource_values():

--- a/elyra/tests/pipeline/test_pipeline_constructor.py
+++ b/elyra/tests/pipeline/test_pipeline_constructor.py
@@ -346,7 +346,7 @@ def test_env_list_to_dict_function():
         "TWO_EQUALS=KEY=value",
         "==",
     ]
-    env_variables_dict = {"KEY": "value", "KEY2": "value2", "EMPTY_VALUE": "", "TWO_EQUALS": "KEY=value"}
+    env_variables_dict = {"KEY": "value", "KEY2": "value2", "TWO_EQUALS": "KEY=value"}
 
     component_parameters = {
         "filename": "elyra/pipeline/tests/resources/archive/test.ipynb",

--- a/elyra/tests/pipeline/test_pipeline_constructor.py
+++ b/elyra/tests/pipeline/test_pipeline_constructor.py
@@ -346,7 +346,7 @@ def test_env_list_to_dict_function():
         "TWO_EQUALS=KEY=value",
         "==",
     ]
-    env_variables_dict = {"KEY": "value", "KEY2": "value2", "EMPTY_VALUE": "  ", "TWO_EQUALS": "KEY=value"}
+    env_variables_dict = {"KEY": "value", "KEY2": "value2", "EMPTY_VALUE": "", "TWO_EQUALS": "KEY=value"}
 
     component_parameters = {
         "filename": "elyra/pipeline/tests/resources/archive/test.ipynb",

--- a/elyra/tests/pipeline/test_pipeline_definition.py
+++ b/elyra/tests/pipeline/test_pipeline_definition.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from unittest import mock
+
 import pytest
 
 from elyra.pipeline import pipeline_constants
@@ -110,12 +112,45 @@ def test_env_dict_to_list():
     assert KeyValueList.from_dict(test_dict) == test_list_correct
 
 
-def test_propagate_pipeline_default_properties():
-    env_list_correct = ["var1=var1", "var2=var2", "var3=var_three"]
+def test_convert_kv_properties(monkeypatch):
+    kv_test_property_name = "kv_test_property"
     pipeline_json = _read_pipeline_resource("resources/sample_pipelines/pipeline_valid_with_pipeline_default.json")
+
+    # Mock get_kv_properties() to ensure the "kv_test_property" variable is included in the list
+    mock_kv_property_list = [pipeline_constants.ENV_VARIABLES, kv_test_property_name]
+    monkeypatch.setattr(PipelineDefinition, "get_kv_properties", mock.Mock(return_value=mock_kv_property_list))
+
+    pipeline_definition = PipelineDefinition(pipeline_definition=pipeline_json)
+
+    node = pipeline_definition.primary_pipeline.nodes.pop()
+    pipeline_defaults = pipeline_definition.primary_pipeline.get_property(pipeline_constants.PIPELINE_DEFAULTS)
+
+    for kv_property in mock_kv_property_list:
+        assert isinstance(node.get_component_parameter(kv_property), KeyValueList)
+        assert isinstance(pipeline_defaults[kv_property], KeyValueList)
+
+    # Ensure a non-list property is not converted to a KeyValueList
+    assert not isinstance(
+        pipeline_definition.primary_pipeline.get_property(pipeline_constants.RUNTIME_IMAGE), KeyValueList
+    )
+
+    # Ensure plain list property is not converted to a KeyValueList
+    assert not isinstance(node.get_component_parameter("outputs"), KeyValueList)
+
+
+def test_propagate_pipeline_default_properties(monkeypatch):
+    kv_list_correct = ["var1=var1", "var2=var2", "var3=var_three"]
+    kv_test_property_name = "kv_test_property"
+    pipeline_json = _read_pipeline_resource("resources/sample_pipelines/pipeline_valid_with_pipeline_default.json")
+
+    # Mock get_kv_properties() to ensure the "kv_test_property" variable is included in the list
+    mock_kv_property_list = [pipeline_constants.ENV_VARIABLES, kv_test_property_name]
+    monkeypatch.setattr(PipelineDefinition, "get_kv_properties", mock.Mock(return_value=mock_kv_property_list))
+
     pipeline_definition = PipelineDefinition(pipeline_definition=pipeline_json)
     node = pipeline_definition.primary_pipeline.nodes.pop()
-    assert node.get_component_parameter(pipeline_constants.ENV_VARIABLES) == env_list_correct
+    assert node.get_component_parameter(pipeline_constants.ENV_VARIABLES) == kv_list_correct
+    assert node.get_component_parameter(kv_test_property_name) == kv_list_correct
 
 
 def _check_pipeline_correct_pipeline_name():

--- a/elyra/tests/pipeline/test_pipeline_definition.py
+++ b/elyra/tests/pipeline/test_pipeline_definition.py
@@ -109,7 +109,7 @@ def test_envs_to_dict():
 def test_env_dict_to_list():
     test_dict = {"TEST": "one", "TEST_TWO": "two", "TEST_FOUR": "1"}
     test_list_correct = ["TEST=one", "TEST_TWO=two", "TEST_FOUR=1"]
-    assert KeyValueList.dict_to_kv_list(test_dict) == test_list_correct
+    assert KeyValueList().dict_to_kv_list(test_dict) == test_list_correct
 
 
 def test_propagate_pipeline_default_properties():

--- a/elyra/tests/pipeline/test_pipeline_definition.py
+++ b/elyra/tests/pipeline/test_pipeline_definition.py
@@ -23,9 +23,7 @@ from elyra.tests.pipeline.util import _read_pipeline_resource
 
 @pytest.fixture
 def mock_pipeline_property_propagation(monkeypatch):
-    # Mock coerce_kv_pair_properties and propagate_pipeline_default_properties
-    # to avoid premature error messages
-    monkeypatch.setattr(PipelineDefinition, "coerce_kv_pair_properties", lambda x: True)
+    # Mock propagate_pipeline_default_properties to skip propagation
     monkeypatch.setattr(PipelineDefinition, "propagate_pipeline_default_properties", lambda x: True)
 
 
@@ -101,7 +99,7 @@ def test_updates_to_nodes_updates_pipeline_definition():
 
 
 def test_envs_to_dict():
-    test_list = ["TEST=one", "TEST_TWO=two", "TEST_THREE=", "TEST_FOUR=1", "TEST_FIVE=fi=ve"]
+    test_list = ["TEST= one", "TEST_TWO=two ", "TEST_THREE =", " TEST_FOUR=1", "TEST_FIVE = fi=ve "]
     test_dict_correct = {"TEST": "one", "TEST_TWO": "two", "TEST_FOUR": "1", "TEST_FIVE": "fi=ve"}
     assert KeyValueList(test_list).to_dict() == test_dict_correct
 

--- a/elyra/tests/pipeline/test_pipeline_definition.py
+++ b/elyra/tests/pipeline/test_pipeline_definition.py
@@ -109,7 +109,7 @@ def test_envs_to_dict():
 def test_env_dict_to_list():
     test_dict = {"TEST": "one", "TEST_TWO": "two", "TEST_FOUR": "1"}
     test_list_correct = ["TEST=one", "TEST_TWO=two", "TEST_FOUR=1"]
-    assert KeyValueList().dict_to_kv_list(test_dict) == test_list_correct
+    assert KeyValueList.from_dict(test_dict) == test_list_correct
 
 
 def test_propagate_pipeline_default_properties():


### PR DESCRIPTION
Fixes #2678 

Supports #2675

### What changes were proposed in this pull request?
First, key-value type properties are identified in the canvas JSON with the addition of a key `keyValueEntries` in the `data` stanza. 

The `list` built-in type is extended in this PR in a class called `KeyValueList`. Key-value pair properties will have values of this type. The `KeyValueList` type has various methods that perform conversion of a list of character-separated key-value pairs (e.g. `"key=value"`) to a dictionary and vice-versa. Node and pipeline key-value list properties identified with the `keyValueEntries` metadata mentioned above have their values converted ASAP, during the construction of the `PipelineDefinition` object. A new function `coerce_kv_pair_properties` is added that takes place before default property propagation that makes this conversion from `list` to `KeyValueList` so that later functions dealing with the processing of these values will succeed.

This allows for the removal of some duplicate code and explicit references to env_vars.

### How was this pull request tested?
A new test case (`test_convert_kv_properties`) was added to ensure all key-value props are converted to `KeyValueList` types.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
