### PR TITLE
Add restoration to CodeViewer

### DIFF
--- a/packages/code-viewer/src/CodeViewerWidget.ts
+++ b/packages/code-viewer/src/CodeViewerWidget.ts
@@ -19,20 +19,16 @@ import { StackedLayout, Widget } from '@lumino/widgets';
 
 export class CodeViewerWidget extends Widget {
   /**
-   * Construct a new text viewer widget.
+   * Construct a new code viewer widget.
    */
   constructor(options: CodeViewerWidget.IOptions) {
     super();
+    this.model = options.model;
 
-    this.model = new CodeEditor.Model({
-      value: options.content,
-      mimeType: options.mimeType
-    });
-
-    const editorWidget = (this.editorWidget = new CodeEditorWrapper({
+    const editorWidget = new CodeEditorWrapper({
       factory: options.factory,
-      model: this.model
-    }));
+      model: options.model
+    });
     this.editor = editorWidget.editor;
     this.editor.setOption('readOnly', true);
 
@@ -40,19 +36,46 @@ export class CodeViewerWidget extends Widget {
     layout.addWidget(editorWidget);
   }
 
-  private editorWidget: CodeEditorWrapper;
-  public model: CodeEditor.IModel;
-  public editor: CodeEditor.IEditor;
+  static getCodeViewer(
+    options: CodeViewerWidget.INoModelOptions
+  ): CodeViewerWidget {
+    const model = new CodeEditor.Model({
+      value: options.content,
+      mimeType: options.mimeType
+    });
+    return new CodeViewerWidget({ factory: options.factory, model });
+  }
+
+  getContent = (): string => this.model.value.text;
+  getMimeType = (): string => this.model.mimeType;
+
+  model: CodeEditor.IModel;
+  editor: CodeEditor.IEditor;
 }
 
 /**
- * The namespace for text viewer widget.
+ * The namespace for code viewer widget.
  */
 export namespace CodeViewerWidget {
   /**
-   * The options used to create an text viewer widget.
+   * The options used to create an code viewer widget.
    */
   export interface IOptions {
+    /**
+     * A code editor factory.
+     */
+    factory: CodeEditor.Factory;
+
+    /**
+     * The content model for the viewer.
+     */
+    model: CodeEditor.Model;
+  }
+
+  /**
+   * The options used to create an code viewer widget without a model.
+   */
+  export interface INoModelOptions {
     /**
      * A code editor factory.
      */


### PR DESCRIPTION
Adds support for restoration to the Code Viewer along with various
other improvements discovered while submitting this feature to core
jupyterlab in https://github.com/jupyterlab/jupyterlab/pull/12365


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
