### PR TITLE
Fix new `test_get_volume_mounts` test to use `KeyValueList` type

### DIFF
--- a/elyra/tests/pipeline/test_processor_base.py
+++ b/elyra/tests/pipeline/test_processor_base.py
@@ -18,7 +18,7 @@ import os
 import pytest
 
 from elyra.pipeline.parser import PipelineParser
-from elyra.pipeline.pipeline import GenericOperation
+from elyra.pipeline.pipeline import GenericOperation, KeyValueList
 from elyra.pipeline.processor import RuntimePipelineProcessor
 from elyra.tests.pipeline.test_pipeline_parser import _read_pipeline_resource
 
@@ -49,11 +49,12 @@ def sample_metadata():
 
 
 def test_get_volume_mounts(runtime_processor):
+    mounted_volumes = KeyValueList(["/mount/test=rwx-test-claim", "/mount/test_two=second-claim"])
     component_parameters = {
         "filename": "pipelines_test_file",
         "env_vars": [],
         "runtime_image": "tensorflow/tensorflow:latest",
-        "mounted_volumes": ["/mount/test=rwx-test-claim", "/mount/test_two=second-claim"],
+        "mounted_volumes": mounted_volumes,
     }
     test_operation = GenericOperation(
         id="this-is-a-test-id",

--- a/elyra/tests/pipeline/test_processor_base.py
+++ b/elyra/tests/pipeline/test_processor_base.py
@@ -18,7 +18,8 @@ import os
 import pytest
 
 from elyra.pipeline.parser import PipelineParser
-from elyra.pipeline.pipeline import GenericOperation, KeyValueList
+from elyra.pipeline.pipeline import GenericOperation
+from elyra.pipeline.pipeline import KeyValueList
 from elyra.pipeline.processor import RuntimePipelineProcessor
 from elyra.tests.pipeline.test_pipeline_parser import _read_pipeline_resource
 


### PR DESCRIPTION
Fixes failing tests on master.

### What changes were proposed in this pull request?
A new test added in #2680 was failing when merged after #2679. The latter PR adds functionality that converts properties identified as key-value list properties to the `KeyValueList` type (rather than built-in `list`) during property propagation in `pipeline_definition.py`. The former PR is calling `_get_volume_mounts` directly, bypassing the conversion that would otherwise happen in during propagation. This PR changes that test to manually convert the volume mounts list to the `KeyValueList` type in order to test the `_get_volume_mounts` function as expected.


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
