### PR TITLE
Fix broken links to documentation

### DIFF
--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -284,7 +284,7 @@ def pipeline():
     Run Elyra pipelines in your local environment or submit them to an external service,
     such as Kubeflow Pipelines or Apache Airflow.
 
-    Find more information at: https://elyra.readthedocs.io/en/v3.7.0rc0/
+    Find more information at: https://elyra.readthedocs.io/en/latest/
     """
     pass
 

--- a/packages/pipeline-editor/src/EmptyPipelineContent.tsx
+++ b/packages/pipeline-editor/src/EmptyPipelineContent.tsx
@@ -70,7 +70,7 @@ export const EmptyPlatformSpecificPipeline: React.FC<IEmptyPlatformSpecificPipel
   // Note: the URL is rewritten by the release script by replacing `latest` with a
   // specific version number, e.g. https://.../en/v3.6.0/user_guide/pi...
   const customComponentsHelpTopicURL =
-    'https://elyra.readthedocs.io/en/v3.7.0rc0/user_guide/pipeline-components.html';
+    'https://elyra.readthedocs.io/en/latest/user_guide/pipeline-components.html';
 
   return (
     <div>

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -532,7 +532,7 @@ const PipelineWrapper: React.FC<IProps> = ({
               <br />
               <br />
               <a
-                href="https://elyra.readthedocs.io/en/v3.7.0rc0/user_guide/best-practices-custom-pipeline-components.html#troubleshooting-missing-pipeline-components"
+                href="https://elyra.readthedocs.io/en/latest/user_guide/best-practices-custom-pipeline-components.html#troubleshooting-missing-pipeline-components"
                 target="_blank"
                 rel="noreferrer"
               >

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -380,7 +380,7 @@ const PipelineWrapper: React.FC<IProps> = ({
                       enabled in your environment. Complete the setup
                       instructions in{' '}
                       <a
-                        href="https://elyra.readthedocs.io/en/v3.7.0rc0/user_guide/pipeline-components.html#example-custom-components"
+                        href="https://elyra.readthedocs.io/en/latest/user_guide/pipeline-components.html#example-custom-components"
                         target="_blank"
                         rel="noreferrer"
                       >


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update links to documentation leading to 404 - change references from `v3.7.0rc0` to `latest`

### How was this pull request tested?
All updated links access correct documentation.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
