### PR TITLE
Remove dependency on ipython_genutils

### DIFF
--- a/elyra/metadata/metadata.py
+++ b/elyra/metadata/metadata.py
@@ -19,7 +19,7 @@ from typing import Any
 from typing import Type
 from typing import TypeVar
 
-from ipython_genutils.importstring import import_item
+from traitlets.utils.importstring import import_item
 
 from elyra.metadata.schema import SchemaManager
 


### PR DESCRIPTION
The Jupyter ecosystem has recently removed the use of the `ipython_genutils` module across various repos.  This pull request does the same here.  The only functionality we were using from it is the ability to import a module using its _dotted name_ (e.g., "elyra.pipeline.local.processor_local.LocalPipelineProcessor").  This functionality is used in the metadata service to _hydrate_ metadata class overrides.

The `import_item` function will reside in `elyra.util.import_item.py` and includes a corresponding test in the `util` tests directory. Because we had been (erroneously) resolving this dependency (via the installation of another dependency) there is no actual dependency to remove.

cf: https://github.com/elyra-ai/elyra/pull/2709#issuecomment-1118170815

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
