### PR TITLE
Prepend baseUrl to icon source

### DIFF
--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -60,6 +60,7 @@
     "@jupyterlab/mainmenu": "^3.4.0",
     "@jupyterlab/notebook": "^3.4.0",
     "@jupyterlab/outputarea": "^3.4.0",
+    "@jupyterlab/services": "^6.4.0",
     "@jupyterlab/ui-components": "^3.4.0",
     "@lumino/algorithm": "^1.3.3",
     "@lumino/coreutils": "^1.5.6",

--- a/packages/pipeline-editor/src/pipeline-hooks.ts
+++ b/packages/pipeline-editor/src/pipeline-hooks.ts
@@ -16,6 +16,8 @@
 
 import { MetadataService, RequestHandler } from '@elyra/services';
 import { pyIcon, rIcon } from '@elyra/ui-components';
+import { URLExt } from '@jupyterlab/coreutils';
+import { ServerConnection } from '@jupyterlab/services';
 import { notebookIcon } from '@jupyterlab/ui-components';
 import produce from 'immer';
 import useSWR from 'swr';
@@ -211,7 +213,10 @@ export const componentFetcher = async (type: string): Promise<any> => {
       category.node_types?.[0]?.runtime_type ?? 'LOCAL';
 
     const type = types.find((t: any) => t.id === category_runtime_type);
-    const defaultIcon = `/${type?.icon}`;
+    const defaultIcon = URLExt.join(
+      ServerConnection.makeSettings().baseUrl,
+      type?.icon || ''
+    );
 
     category.image = defaultIcon;
 


### PR DESCRIPTION
Currently we only prepend `/` to the icon path when using icons
hosted on the server. This causes the icons to not be found when
the server has base_url set in in it's config.

To address this I've prepended baseUrl to the icon path instead as
we also do when making API calls to the server.

Note: base_url is used in the server config json, but baseUrl is used when
accessing the python and js objects

base_url can be configured by including the following when running `jupyter lab`:

` --ServerApp.base_url="/foo"`

Fixes #2723

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
