### PR TITLE
Fix processing of node properties for pipeline app commands

### DIFF
--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -537,9 +537,7 @@ def describe(json_option, pipeline_path):
             describe_dict["component_dependencies"].add(node.component_source)
         # collect information of mounted volumes
         for mounted_volume in node.get_component_parameter(pipeline_constants.MOUNTED_VOLUMES, []):
-            temp_mount_value = mounted_volume.split("=")[-1]
-            if temp_mount_value != "":
-                describe_dict[pipeline_constants.MOUNTED_VOLUMES].add(f"{temp_mount_value}")
+            describe_dict[pipeline_constants.MOUNTED_VOLUMES].add(f"{mounted_volume.pvc_name}")
         # collection runtime image details
         temp_runtime_image_value = node.get_component_parameter(pipeline_constants.RUNTIME_IMAGE)
         if temp_runtime_image_value:

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -17,8 +17,6 @@ from dataclasses import asdict as dataclass_asdict
 from dataclasses import dataclass
 from dataclasses import is_dataclass
 import json
-import logging
-from logging import Logger
 import os
 import sys
 from typing import Any
@@ -197,16 +195,6 @@ class Operation(object):
     @staticmethod
     def is_generic_operation(operation_classifier) -> bool:
         return operation_classifier in Operation.generic_node_types
-
-    @staticmethod
-    def log_message(msg: str, logger: Optional[Logger] = None, level: Optional[int] = logging.DEBUG):
-        """
-        Log a message with the given logger at the given level or simply print.
-        """
-        if logger:
-            logger.log(level, msg)
-        else:
-            print(msg)
 
 
 class GenericOperation(Operation):
@@ -446,7 +434,7 @@ class KeyValueList(list):
 
     _key_value_separator: str = "="
 
-    def to_dict(self, logger: Optional[Logger] = None) -> Dict[str, str]:
+    def to_dict(self) -> Dict[str, str]:
         """
         Properties consisting of key-value pairs are stored in a list of separated
         strings, while most processing steps require a dictionary - so we must convert.
@@ -468,14 +456,13 @@ class KeyValueList(list):
 
             key = key.strip()
             if not key:
-                Operation.log_message(f"Skipping inclusion of property '{kv}': no key found", logger, logging.WARN)
+                # Invalid entry; skip inclusion and continue
                 continue
+
             if isinstance(value, str):
                 value = value.strip()
             if not value:
-                Operation.log_message(
-                    f"Skipping inclusion of property '{key}': no value specified", logger, logging.DEBUG
-                )
+                # Invalid entry; skip inclusion and continue
                 continue
 
             kv_dict[key] = value

--- a/elyra/pipeline/pipeline_definition.py
+++ b/elyra/pipeline/pipeline_definition.py
@@ -341,8 +341,10 @@ class Node(AppDataBase):
             if not value:
                 continue
 
-            if isinstance(value, KeyValueList):
-                # Any KeyValueList instance implies all relevant properties have already been converted
+            if isinstance(value, KeyValueList) or not isinstance(value[0], str):
+                # A KeyValueList instance implies all relevant properties have already been converted
+                # Similarly, if KeyValueList items aren't strings, this implies they have already been
+                # converted to the appropriate data class objects
                 return
 
             # Convert plain list to KeyValueList

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -498,7 +498,7 @@ class RuntimePipelineProcessor(PipelineProcessor):
         :return: dictionary containing environment name/value pairs
         """
 
-        envs: Dict = operation.env_vars.to_dict(logger=self.log)
+        envs: Dict = operation.env_vars.to_dict()
         envs["ELYRA_RUNTIME_ENV"] = self.name
 
         # set environment variables for Minio/S3 access, in the following order of precedence:


### PR DESCRIPTION
Fixes failing tests on master that were due to a merge conflict between #2722 and #2715

### What changes were proposed in this pull request?
Access mounted volumes using the new `VolumeMount` object attributes rather than parsing a `=`-separated string.

Removes unnecessary logging during `KeyValueList` processing.

Ensures node params are only converted to `KeyValueList` type once when running pipeline app commands.

### How was this pull request tested?
Server tests now passing
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
