### PR TITLE
Fix save as code snippet

### DIFF
--- a/packages/code-snippet/src/index.ts
+++ b/packages/code-snippet/src/index.ts
@@ -131,17 +131,17 @@ export const code_snippet_extension: JupyterFrontEndPlugin<void> = {
             code: selection.split('\n'),
             onSave: codeSnippetWidget.updateMetadata
           });
+        } else {
+          const selectedCells = getSelectedCellContents();
+          const code = selectedCells.join('\n\n').split('\n');
+
+          codeSnippetWidget.openMetadataEditor({
+            schemaspace: CODE_SNIPPET_SCHEMASPACE,
+            schema: CODE_SNIPPET_SCHEMA,
+            code: code,
+            onSave: codeSnippetWidget.updateMetadata
+          });
         }
-
-        const selectedCells = getSelectedCellContents();
-        const code = selectedCells.join('\n\n').split('\n');
-
-        codeSnippetWidget.openMetadataEditor({
-          schemaspace: CODE_SNIPPET_SCHEMASPACE,
-          schema: CODE_SNIPPET_SCHEMA,
-          code: code,
-          onSave: codeSnippetWidget.updateMetadata
-        });
       }
     });
 

--- a/packages/metadata-common/src/MetadataEditorWidget.tsx
+++ b/packages/metadata-common/src/MetadataEditorWidget.tsx
@@ -87,6 +87,8 @@ export interface IMetadataEditorProps {
   themeManager?: IThemeManager;
 
   titleContext?: string;
+
+  code?: string[];
 }
 
 /**
@@ -194,6 +196,9 @@ export class MetadataEditorWidget extends ReactWidget {
         }
         metadataWithCategories[category][schemaProperty] =
           metadata?.metadata?.[schemaProperty] ?? properties.default;
+        if (schemaProperty === 'code' && this.props.code) {
+          metadataWithCategories[category][schemaProperty] = this.props.code;
+        }
         if (!schemaPropertiesByCategory[category]) {
           schemaPropertiesByCategory[category] = {
             type: 'object',

--- a/packages/metadata-common/src/MetadataEditorWidget.tsx
+++ b/packages/metadata-common/src/MetadataEditorWidget.tsx
@@ -86,8 +86,14 @@ export interface IMetadataEditorProps {
    */
   themeManager?: IThemeManager;
 
+  /**
+   * String used to make the title of the editor more readable
+   */
   titleContext?: string;
 
+  /**
+   * Optional field used for the "Save as code snippet" feature
+   */
   code?: string[];
 }
 

--- a/packages/metadata-common/src/MetadataEditorWidget.tsx
+++ b/packages/metadata-common/src/MetadataEditorWidget.tsx
@@ -92,7 +92,7 @@ export interface IMetadataEditorProps {
   titleContext?: string;
 
   /**
-   * Optional field used for the "Save as code snippet" feature
+   * A default value for code fields
    */
   code?: string[];
 }


### PR DESCRIPTION
Fixes a bug introduced by #2464 that breaks the "Save as a code snippet" functionality. 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
