### PR TITLE
Fix metadata editor being able to open in multiple tabs

### DIFF
--- a/packages/metadata/src/index.ts
+++ b/packages/metadata/src/index.ts
@@ -119,13 +119,12 @@ const extension: JupyterFrontEndPlugin<void> = {
         translator: translator.load('jupyterlab'),
         componentRegistry
       });
-      metadataEditorWidget.title.label = widgetLabel;
-      metadataEditorWidget.id = widgetId;
-      metadataEditorWidget.title.closable = true;
-      metadataEditorWidget.title.icon = textEditorIcon;
-      metadataEditorWidget.addClass(METADATA_EDITOR_ID);
-      // TODO: add back MainAreaWidget for styling purposes
       const main = new MainAreaWidget({ content: metadataEditorWidget });
+      main.title.label = widgetLabel;
+      main.id = widgetId;
+      main.title.closable = true;
+      main.title.icon = textEditorIcon;
+      main.addClass(METADATA_EDITOR_ID);
       app.shell.add(main, 'main');
     };
 


### PR DESCRIPTION
#2464 introduced this bug - the metadata editor is supposed to only allow one tab to be open per instance of metadata, this fixes this behavior. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
