### PR TITLE
Support file contents as component property input value

### DIFF
--- a/elyra/pipeline/component_catalog.py
+++ b/elyra/pipeline/component_catalog.py
@@ -673,7 +673,7 @@ class ComponentCache(SingletonConfigurable):
             template = ComponentCache.load_jinja_template("canvas_properties_template.jinja2")
 
         canvas_properties = template.render(component=component)
-        return json.loads(canvas_properties)
+        return canvas_properties
 
 
 class ManifestFileChangeHandler(FileSystemEventHandler):

--- a/elyra/templates/components/canvas_properties_template.jinja2
+++ b/elyra/templates/components/canvas_properties_template.jinja2
@@ -6,7 +6,7 @@
         "elyra_{{ property.ref }}":
     {% if property.control_id == "OneOfControl" %}
         {
-        "activeControl": "{{ property.default_control_type }}",
+        "activeControl": "OneOfControl",
         "{{ property.default_control_type }}":
     {% endif %}
     {% set property_data_type = property.data_type %}
@@ -90,10 +90,10 @@
     {% if property.control_id == "OneOfControl" %}
             "controls":{
         {% for control, control_data_type, control_label in property.one_of_control_types %}
-                  "{{ control }}": {
+            {% if control == 'NestedEnumControl' %}
+                "{{ control }}": {
                     "label": "{{ control_label }}",
                     "format": "{{ control_data_type }}"
-            {% if control == 'NestedEnumControl' %}
                     ,
                     "allownooptions":
                 {% if property.allow_no_options %}
@@ -101,6 +101,22 @@
                 {% else %}
                     false
                 {% endif %}
+            {% else %}
+                "OneOfControl": {
+                    "label": "one-of control label",
+                    "description": "idk",
+                    "data": {
+                        "controls": {
+                            "{{ control }}": {
+                                "label": "{{ control_label }}",
+                                "format": "{{ control_data_type }}"
+                            },
+                            "StringControl2": {
+                                "label": "Choose a file...",
+                                "format": "file"
+                            }
+                        }
+                      }
             {% endif %}
                   }
             {% if loop.index != loop.length %}

--- a/elyra/templates/components/canvas_properties_template.jinja2
+++ b/elyra/templates/components/canvas_properties_template.jinja2
@@ -103,8 +103,7 @@
                 {% endif %}
             {% else %}
                 "OneOfControl": {
-                    "label": "one-of control label",
-                    "description": "idk",
+                    "label": "Please select an input type :",
                     "data": {
                         "controls": {
                             "{{ control }}": {
@@ -112,7 +111,7 @@
                                 "format": "{{ control_data_type }}"
                             },
                             "StringControl2": {
-                                "label": "Choose a file...",
+                                "label": "Please choose a file :",
                                 "format": "file"
                             }
                         }


### PR DESCRIPTION
#2759
May depend on #2780 

### What changes were proposed in this pull request?
When complete, this PR will support the ability to use file contents as the input value for component properties. Right now, this is an extremely rough draft with changes to the properties template temporarily hardcoded in order to figure out the correct JSON structure required for correct frontend rendering.

For now, the following questions need to be answered:

- [ ] How to best structure component properties JSON
  - Depending on how this ends up, we may need to test that the removal of `json.loads()` for component properties does not cause any unexpected issues; `json.loads()` removes duplicate keys within the same sub-stanza, which we may need to allow in the case of 2 different types of `StringControl`'s (one for text input and one for file input)
- [ ] How to best structure pipeline JSON (small changes may be required since both plain strings and file types are `StringControl` types, but their processing will be different)
- [ ] How to enforce the size limit Kubernetes sets on YAMLs

### How was this pull request tested?
- [ ] Add tests
- [ ] Fix existing tests

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
