### PR TITLE
Trim whitespace to prevent invalid tags in metadata editor

### DIFF
--- a/packages/ui-components/src/FormComponents/Tags.tsx
+++ b/packages/ui-components/src/FormComponents/Tags.tsx
@@ -78,8 +78,9 @@ export const Tags: React.FC<ITagProps> = ({
   ): Promise<void> => {
     const inputElement = event.target as HTMLInputElement;
 
-    if (inputElement.value.trim() !== '' && event.keyCode === 13) {
-      if (allTags.includes(inputElement.value)) {
+    const newTag = inputElement.value.trim();
+    if (newTag !== '' && event.keyCode === 13) {
+      if (allTags.includes(newTag)) {
         event.preventDefault();
         await showDialog({
           title: 'A tag with this label already exists.',
@@ -87,8 +88,6 @@ export const Tags: React.FC<ITagProps> = ({
         });
         return;
       }
-
-      const newTag = inputElement.value;
 
       // update state all tag and selected tag
       setSelectedTags([...selected, newTag]);


### PR DESCRIPTION
This trims new tags before they're added to the list of tags to prevent a validation error (which prevents a save in the metadata editor). 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
