### PR TITLE
Do not persist the jupyter baseUrl in pipelines

### DIFF
--- a/packages/pipeline-editor/src/pipeline-hooks.ts
+++ b/packages/pipeline-editor/src/pipeline-hooks.ts
@@ -213,10 +213,9 @@ export const componentFetcher = async (type: string): Promise<any> => {
       category.node_types?.[0]?.runtime_type ?? 'LOCAL';
 
     const type = types.find((t: any) => t.id === category_runtime_type);
-    const defaultIcon = URLExt.join(
-      ServerConnection.makeSettings().baseUrl,
-      type?.icon || ''
-    );
+    const defaultIcon = URLExt.parse(
+      URLExt.join(ServerConnection.makeSettings().baseUrl, type?.icon || '')
+    ).pathname;
 
     category.image = defaultIcon;
 


### PR DESCRIPTION
The changes in #2728 cause the pipeline-editor to persist the full
url for a node's image. This could cause issues with surfacing PI,
as such I've updated that fix to instead use the full URL path,
which will behave the same as before the fix, but including the
URL path from the baseUrl if one exists.

Note that if a baseUrl path conatains PI that would still be
persisted, but putting PI in a URL path is considered inappropriate
handling of PI by the server owner, not Elyra.

Fixes #2773

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
