### PR TITLE
Clear all singleton instances during shutdown

### DIFF
--- a/elyra/elyra_app.py
+++ b/elyra/elyra_app.py
@@ -130,8 +130,14 @@ class ElyraApp(ExtensionAppJinjaMixin, ExtensionApp):
         pass
 
     async def stop_extension(self):
+        PipelineProcessorRegistry.clear_instance()
+        PipelineProcessorManager.clear_instance()
+        PipelineValidationManager.clear_instance()
+        FileMetadataCache.clear_instance()
         if ComponentCache.initialized():
             ComponentCache.instance(parent=self).cache_manager.stop()  # terminate CacheUpdateManager
+            ComponentCache.clear_instance()
+        SchemaManager.clear_instance()
 
 
 launch_instance = ElyraApp.launch_instance

--- a/elyra/tests/cli/test_pipeline_app.py
+++ b/elyra/tests/cli/test_pipeline_app.py
@@ -35,9 +35,9 @@ SUB_COMMANDS = ["run", "submit", "describe", "validate", "export"]
 @pytest.fixture(autouse=True)
 def destroy_component_cache():
     """
-    This fixture provides a workaround for a (yet unexplained)
-    issue that causes tests to fail that utilize the component
-    cache.
+    This fixture clears any ComponentCache instances that
+    may have been created during CLI processes so that
+    those instance doesn't side-affect later tests.
     """
     yield
     ComponentCache.clear_instance()


### PR DESCRIPTION
Related to #2778

### What changes were proposed in this pull request?
This PR clears all singleton variables (those always created during startup) during extension shutdown.

### How was this pull request tested?
Tests passing locally even with `jupyter-server==1.17.1`

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
