### PR TITLE
CI: fetch packages info if server tests fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,15 @@ jobs:
       - name: Version Snapshot
         run: pip freeze
       - name: Test
+        id: Test
         run: make pytest
+      - name: Fetch packages metadata (Test step failed)
+        # Note: checking for general failure() first is needed according to docs
+        if: ${{ failure() && steps.Test.conclusion == 'failure' }}
+        env:
+          days: 7 # check for newer package versions in past X days
+        run: |
+          python3 ./.github/workflows/scripts/fetch_packages_metadata.py $days
 
   test-ui:
     name: Test UI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Test
         id: Test
         run: make pytest
-      - name: Fetch packages metadata (Test step failed)
+      - name: Fetch packages metadata (if Test step failed)
         # Note: checking for general failure() first is needed according to docs
         if: ${{ failure() && steps.Test.conclusion == 'failure' }}
         env:

--- a/.github/workflows/scripts/fetch_packages_metadata.py
+++ b/.github/workflows/scripts/fetch_packages_metadata.py
@@ -27,7 +27,8 @@ def check_release_date(pkg_list):
         try:
             pkg, v = row.split("==")
         except Exception:
-            print(f"skipping {row}")
+            if len(row) > 1:
+                print(f"skipping {row}")
             continue
 
         res = get_info_from_pypi(pkg)
@@ -55,6 +56,7 @@ if __name__ == "__main__":
         max_days = int(sys.argv[1])
 
     print(f"packages that were updated in the last {max_days} days:")
+    print()
 
     pkg_list = get_outdated_pkg_list()
     l = len(pkg_list)

--- a/.github/workflows/scripts/fetch_packages_metadata.py
+++ b/.github/workflows/scripts/fetch_packages_metadata.py
@@ -1,0 +1,69 @@
+from requests import get
+from datetime import datetime, timedelta
+from concurrent.futures import ThreadPoolExecutor
+from itertools import islice
+import sys
+import subprocess
+
+
+def get_info_from_pypi(pkg):
+    url = f"https://pypi.org/pypi/{pkg}/json"
+    try:
+        res = get(url).json()
+        return res
+    except Exception as e:
+        print(f"request to pypi failed for <{pkg}>: {e}")
+        return None
+
+
+def get_outdated_pkg_list():
+    out = subprocess.check_output(["python", "-m", "pip", "list", "--outdated", "--format", "freeze"])
+    req_list = out.decode().split("\n")
+    return req_list
+
+
+def check_release_date(pkg_list):
+    for row in pkg_list:
+        try:
+            pkg, v = row.split("==")
+        except Exception:
+            print(f"skipping {row}")
+            continue
+
+        res = get_info_from_pypi(pkg)
+        if not res:
+            continue
+
+        latest = res["info"]["version"]
+        latest_upload_time = res["releases"][latest][0]["upload_time"]
+
+        # continue if release older than argv[1]
+        today = datetime.utcnow()
+        release_date = datetime.fromisoformat(latest_upload_time)
+        if today - release_date > timedelta(days=max_days):
+            continue
+
+        print(f"Newer version for <{pkg}>:")
+        print(f" - released {latest}  {latest_upload_time[:10]}")
+        print(f" - current  {v}")
+        print("")
+
+
+if __name__ == "__main__":
+    max_days = 7  # default
+    if len(sys.argv) > 1:
+        max_days = int(sys.argv[1])
+
+    print(f"packages that were updated in the last {max_days} days:")
+
+    pkg_list = get_outdated_pkg_list()
+    l = len(pkg_list)
+    workers = 3
+    parts = [i for i in range(0, l, l // workers)]
+    parts[-1] = l
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        executor.map(
+            check_release_date,
+            [islice(pkg_list, parts[i], parts[i + 1]) for i in range(len(parts) - 1)],
+        )

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ lint-dependencies:
 	@$(PYTHON_PIP) install -q -r lint_requirements.txt
 
 lint-server: lint-dependencies
-	$(PYTHON) -m flake8 elyra
+	$(PYTHON) -m flake8 elyra .github
 	@echo $(BLACK_CMD)
 	@$(BLACK_CMD) || (echo "Black formatting encountered issues.  Use 'make black-format' to apply the suggested changes."; exit 1)
 


### PR DESCRIPTION
Hi, this closes #2777.
I used `pip list --outdated`. So basically, this script is only necessary because of the 'past X days' requirement.

see my (other) experimental branch for demo run that fails on purpose: https://github.com/tal66/elyra/actions/runs/2477060776