### PR TITLE
Install jupyterlab during normal builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Build
         run: |
-          pip install "jupyterlab>=3.4.0"
           make build-dependencies
           make yarn-install
           make build-ui
@@ -152,7 +151,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
       - name: Build
         run: |
-          pip install "jupyterlab>=3.4.0"
           make build-dependencies
           make yarn-install
           make build-ui

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@
 .PHONY: help purge uninstall-src uninstall clean
 .PHONY: lint-dependencies lint-server black-format prettier-check-ui eslint-check-ui prettier-ui eslint-ui lint-ui lint
 .PHONY: dev-link dev-unlink
-.PHONY: build-dependencies yarn-install build-ui package-ui package-ui-dev build-server install-server-package install-server
+.PHONY: build-dependencies dev-dependencies yarn-install build-ui package-ui package-ui-dev
+.PHONY: build-server install-server-package install-server
 .PHONY: install install-all install-dev install-examples install-gitlab-dependency check-install watch release
 .PHONY: test-dependencies pytest test-server test-ui-unit test-integration test-integration-debug test-ui test
 .PHONY: docs-dependencies docs
@@ -151,6 +152,10 @@ build-dependencies:
 	@$(PYTHON_PIP) install -q --upgrade pip
 	@$(PYTHON_PIP) install -q -r build_requirements.txt
 
+dev-dependencies:
+	@$(PYTHON_PIP) install -q --upgrade pip
+	@$(PYTHON_PIP) install -q jupyter-packaging
+
 yarn-install:
 	yarn install
 
@@ -159,7 +164,7 @@ build-ui: # Build packages
 
 package-ui: build-dependencies yarn-install lint-ui build-ui
 
-package-ui-dev: build-dependencies yarn-install dev-link lint-ui build-ui
+package-ui-dev: dev-dependencies yarn-install dev-link lint-ui build-ui
 
 build-server: # Build backend
 	$(PYTHON) -m setup bdist_wheel sdist

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -1,1 +1,2 @@
+jupyterlab>=3.4.0
 jupyter-packaging>=0.10


### PR DESCRIPTION
In #2709 I removed jupyterlab from the build_requires.txt so that
the local versaion of jupyterlab could be used if installed. This
has caused frustration in users, so I've added the dependency back
and update the make dev-install target to not use the dependency
file at all, instead using a new make target to install the
required dependency.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
