### PR TITLE
Fix for Script Editor console does not properly highlight error messages

### DIFF
--- a/packages/script-editor/src/ScriptEditor.tsx
+++ b/packages/script-editor/src/ScriptEditor.tsx
@@ -229,10 +229,11 @@ export abstract class ScriptEditor extends DocumentWidget<
       output = 'Error : ' + msg.error.type + ' - ' + msg.error.output;
       this.displayOutput(output);
       this.getOutputAreaChildWidget().addClass(OUTPUT_AREA_ERROR_CLASS);
+      return;
     } else if (msg.output) {
       output = msg.output;
-      this.displayOutput(output);
     }
+    this.displayOutput(output);
   };
 
   private createScrollButtons = (

--- a/packages/script-editor/src/ScriptEditor.tsx
+++ b/packages/script-editor/src/ScriptEditor.tsx
@@ -227,11 +227,12 @@ export abstract class ScriptEditor extends DocumentWidget<
       return;
     } else if (msg.error) {
       output = 'Error : ' + msg.error.type + ' - ' + msg.error.output;
+      this.displayOutput(output);
       this.getOutputAreaChildWidget().addClass(OUTPUT_AREA_ERROR_CLASS);
     } else if (msg.output) {
       output = msg.output;
+      this.displayOutput(output);
     }
-    this.displayOutput(output);
   };
 
   private createScrollButtons = (


### PR DESCRIPTION
Fixes #1513 

### What changes were proposed in this pull request?

Changes displayOutput to occur before setting the OUTPUT_AREA_ERROR_CLASS on the output area child if there's an error. This makes a code with the first output line as an error message be highlighted in red.
 
### How was this pull request tested?

Passed all script editor unit tests
Tested with the broken code provided in the issue
```
for i in range(10):
    print('i:' + i)
```
![Screenshot 2022-06-24 145223](https://user-images.githubusercontent.com/72038310/175647440-4307dddb-aa9a-4093-a7e6-23e79cda3846.jpg)


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
