### PR TITLE
Add authentication support to URL catalog connector

### DIFF
--- a/docs/source/user_guide/pipeline-components.md
+++ b/docs/source/user_guide/pipeline-components.md
@@ -394,8 +394,9 @@ Examples (CLI):
 #### URL component catalog
 
 The URL component catalog connector provides access to components that are stored on the web:
-- The specified URL must be retrievable using an anonymous HTTP `GET` request.
-- You can specify one or more URLs.
+- You can specify one or more URL resources.
+- The specified URLs must be retrievable using an HTTP `GET` request.
+- If the resources are secured, provide credentials, such as a user id and password or API key.
 
 Examples (GUI):
  - `https://raw.githubusercontent.com/elyra-ai/examples/main/component-catalog-connectors/kfp-example-components-connector/kfp_examples_connector/resources/filter_text_using_shell_and_grep.yaml`

--- a/elyra/metadata/schemas/url-catalog.json
+++ b/elyra/metadata/schemas/url-catalog.json
@@ -64,7 +64,9 @@
           },
           "uihints": {
             "category": "Configuration",
-            "ui:placeholder": "https://host:port/path/component_file"
+            "items": {
+              "ui:placeholder": "https://host:port/path/component_file"
+            }
           }
         },
         "auth_id": {

--- a/elyra/metadata/schemas/url-catalog.json
+++ b/elyra/metadata/schemas/url-catalog.json
@@ -63,7 +63,27 @@
             "format": "uri"
           },
           "uihints": {
-            "category": "Configuration"
+            "category": "Configuration",
+            "ui:placeholder": "https://host:port/path/component_file"
+          }
+        },
+        "auth_id": {
+          "title": "User Id",
+          "description": "User id that has read access for the specified URL resources",
+          "type": "string",
+          "minLength": 1,
+          "uihints": {
+            "category": "Source credentials"
+          }
+        },
+        "auth_password": {
+          "title": "Password",
+          "description": "Password or API key for the specified user id",
+          "type": "string",
+          "minLength": 1,
+          "uihints": {
+            "ui:field": "password",
+            "category": "Source credentials"
           }
         }
       },


### PR DESCRIPTION
This PR adds 
- authentication support for the [URL component catalog connector](https://elyra.readthedocs.io/en/latest/user_guide/pipeline-components.html#url-component-catalog):
 - closes https://github.com/elyra-ai/elyra/issues/2793
- support for UI placeholder values for list-valued properties

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?

The URL catalog connector now accepts optional credentials and displays a placeholder URL.

![image](https://user-images.githubusercontent.com/13068832/176264751-e708fa20-7a47-4c75-9080-8554fe181d02.png)

- If complete credentials (user id and password/API key) are provided, they are used to fetch every specified URL.
- To use different credentials for different URLs, a user has to configure multiple URL connectors.
 
The URL connectors' log messages now indicate the name of the connector that is encountering the problem, i.e. if this connector is misconfigured

![image](https://user-images.githubusercontent.com/13068832/176015875-3c408369-e015-4ac5-8f64-8b60127033e1.png)

this error message might appear in the log:
```
Error. URL catalog connector 'count rows' is not configured properly. Authentication requires a user id and password or API key.
```

Existing URL component catalog connectors should continue to work as is, without the need for migration.


<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
- reviewed the output of `make docs`
- tested the following scenarios:
   - no user id and password provided (should work for resources that allow for public access)
   - user id and password provided (should work for resources that require authentication)
   - user id provided, but no password (should fail - component is not listed in the VPE palette, error is logged in the JupyterLab console)
   - password provided, but no user id (should fail - component is not listed in the VPE palette, error is logged in the JupyterLab console)
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
