### PR TITLE
Customize rendering of component catalog list

### DIFF
--- a/packages/pipeline-editor/src/ComponentCatalogsWidget.tsx
+++ b/packages/pipeline-editor/src/ComponentCatalogsWidget.tsx
@@ -91,6 +91,19 @@ class ComponentCatalogsDisplay extends MetadataDisplay<
       </div>
     );
   }
+
+  // Allow for filtering by display_name, name, and description
+  matchesSearch(searchValue: string, metadata: IMetadata): boolean {
+    searchValue = searchValue.toLowerCase();
+    // True if search string is in name or display_name,
+    // or if the search string is empty
+    const description = (metadata.metadata.description || '').toLowerCase();
+    return (
+      metadata.name.toLowerCase().includes(searchValue) ||
+      metadata.display_name.toLowerCase().includes(searchValue) ||
+      description.includes(searchValue)
+    );
+  }
 }
 
 /**

--- a/packages/pipeline-editor/src/ComponentCatalogsWidget.tsx
+++ b/packages/pipeline-editor/src/ComponentCatalogsWidget.tsx
@@ -23,6 +23,7 @@ import {
   IMetadataDisplayState,
   IMetadataActionButton
 } from '@elyra/metadata-common';
+import { IDictionary } from '@elyra/services';
 import { RequestErrors } from '@elyra/ui-components';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { IThemeManager } from '@jupyterlab/apputils';
@@ -44,7 +45,7 @@ const handleError = (error: any): void => {
 };
 
 /**
- * A React Component for displaying the runtime images list.
+ * A React Component for displaying the component catalogs list.
  */
 class ComponentCatalogsDisplay extends MetadataDisplay<
   IMetadataDisplayProps,
@@ -66,6 +67,30 @@ class ComponentCatalogsDisplay extends MetadataDisplay<
       ...super.actionButtons(metadata)
     ];
   }
+  // render catalog entries
+  renderExpandableContent(metadata: IDictionary<any>): JSX.Element {
+    let category_output = <li key="No category">No category</li>;
+    if (metadata.metadata.categories) {
+      category_output = metadata.metadata.categories.map((category: string) => (
+        <li key={category}>{category}</li>
+      ));
+    }
+
+    return (
+      <div>
+        <h6>Runtime Type</h6>
+        {metadata.metadata.runtime_type}
+        <br />
+        <br />
+        <h6>Description</h6>
+        {metadata.metadata.description ?? 'No description'}
+        <br />
+        <br />
+        <h6>Categories</h6>
+        <ul>{category_output}</ul>
+      </div>
+    );
+  }
 }
 
 /**
@@ -83,7 +108,7 @@ export interface IComponentCatalogsWidgetProps extends IMetadataWidgetProps {
 }
 
 /**
- * A widget for displaying runtime images.
+ * A widget for displaying component catalogs.
  */
 export class ComponentCatalogsWidget extends MetadataWidget {
   refreshButtonTooltip: string;


### PR DESCRIPTION
This PR replaces the generic rendering that was used in previous releases. 

![image](https://user-images.githubusercontent.com/13068832/176484926-f28768a9-a0c4-4bfb-a490-b0a2fdf9e60d.png)


With this change no sensitive information is exposed anymore in the list view.

Closes #2792 
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
- Customize how the list of component catalogs is rendered by the metadata editor
- include catalog description in search/filter

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
Confirmed that the following scenarios yield the expected output:
 - catalog connector does not define description (an optional property) -> default `No description` is displayed
 - catalog connector does define description (an optional property) -> description is displayed
 - catalog connector is not associated with a category (an optional list-valued property) -> default `No category` is displayed (similar to what is rendered in the palette)
 - catalog connector is associated with a single category (an optional list-valued property) -> category is displayed
 - catalog connector is associated with a multiple categories (an optional list-valued property) -> categories are displayed, one per line

The screen capture above illustrates all scenarios.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
