### PR TITLE
Remove final instance of `BashOperator` from tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -32,17 +32,6 @@ KFP_COMPONENT_CACHE_INSTANCE = {
     "schema_name": "elyra-kfp-examples-catalog",
 }
 
-AIRFLOW_COMPONENT_CACHE_INSTANCE = {
-    "display_name": "Airflow Example Components",
-    "metadata": {
-        "runtime_type": "APACHE_AIRFLOW",
-        "categories": ["examples"],
-        "paths": [
-            "https://raw.githubusercontent.com/elyra-ai/elyra/main/elyra/tests/pipeline/resources/components/bash_operator.py"  # noqa
-        ],
-    },
-    "schema_name": "url-catalog",
-}
 AIRFLOW_TEST_OPERATOR_CATALOG = {
     "display_name": "Airflow Test Operator",
     "metadata": {

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -18,7 +18,7 @@ import os
 from subprocess import CompletedProcess
 from subprocess import run
 
-from conftest import AIRFLOW_COMPONENT_CACHE_INSTANCE
+from conftest import AIRFLOW_TEST_OPERATOR_CATALOG
 from conftest import TEST_CATALOG_NAME
 import jupyter_core.paths
 import pytest
@@ -49,7 +49,7 @@ def _get_resource_path(filename):
     return resource_path
 
 
-@pytest.mark.parametrize("catalog_instance", [AIRFLOW_COMPONENT_CACHE_INSTANCE], indirect=True)
+@pytest.mark.parametrize("catalog_instance", [AIRFLOW_TEST_OPERATOR_CATALOG], indirect=True)
 def test_component_catalog_can_load_components_from_registries(catalog_instance, component_cache):
     components = component_cache.get_all_components(RUNTIME_PROCESSOR)
     assert len(components) > 0


### PR DESCRIPTION
Fixes failing test on `main`.

### What changes were proposed in this pull request?
Removes the final instance of `AIRFLOW_COMPONENT_CACHE_INSTANCE` in favor of the new `AIRFLOW_TEST_OPERATOR_CATALOG` instance created in #2815 

### How was this pull request tested?
Tests are passing locally
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
