### PR TITLE
Optionally search for operators in airflow.contrib.operators package

### DIFF
--- a/elyra/pipeline/airflow/component_parser_airflow.py
+++ b/elyra/pipeline/airflow/component_parser_airflow.py
@@ -244,11 +244,16 @@ class AirflowComponentParser(ComponentParser):
                 ("NestedEnumControl", "inputpath", ControllerMap["NestedEnumControl"].value),
             ]
 
+            value = arg_attributes.get("default_value") or data_type_info.default_value
+            if isinstance(value, str):
+                # Escape quotation marks to avoid error during json.loads
+                value = value.replace('"', '\\"').replace('"""', '\\"\\"\\"')
+
             component_param = ComponentParameter(
                 id=arg_name,
                 name=arg_name,
                 data_type=data_type_info.data_type,
-                value=(arg_attributes.get("default_value") or data_type_info.default_value),
+                value=value,
                 description=description,
                 default_control_type=default_control_type,
                 control_id=CONTROL_ID,
@@ -304,6 +309,12 @@ class AirflowComponentParser(ComponentParser):
                 elif isinstance(default, ast.Num):
                     # The value of interest in this case is accessed by the 'n' attribute
                     default_value = default.n
+                if isinstance(default, ast.Attribute):
+                    if hasattr(default.value, "id") and hasattr(default, "attr"):
+                        # The value of interest in accessed by the 'attr' attribute and value 'id' attribute
+                        default_value = f"{default.value.id}.{default.attr}"
+                    else:
+                        default_value = ""
 
                 # If a default value is provided in the argument list, the processor
                 # can use this value if the user doesn't supply their own

--- a/elyra/pipeline/airflow/package_catalog_connector/README.md
+++ b/elyra/pipeline/airflow/package_catalog_connector/README.md
@@ -11,6 +11,7 @@ https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html#manag
 1. Specify a catalog name, e.g. '`Airflow 1.10.15 wheel`'.
 1. (Optional) Specify a category under which the loaded operators will be organized in the palette.
 1. Configure the '`Airflow package download URL`'. The URL must reference a location that Elyra can access using an HTTP `GET` request. If the resource is secured, provide credentials, such as a user id and password or API key.
+1. If desired, include operators that are located in the `airflow.contrib.operators` package. The connector excludes them by default.
 
 ### Example
 

--- a/elyra/pipeline/airflow/package_catalog_connector/airflow-package-catalog.json
+++ b/elyra/pipeline/airflow/package_catalog_connector/airflow-package-catalog.json
@@ -64,6 +64,14 @@
             "ui:placeholder": "https://host:port/path/apache_airflow.whl"
           }
         },
+        "search_contrib": {
+          "title": "Include operators in contrib package",
+          "description": "Include operators in package airflow.contrib.operators",
+          "type": "boolean",
+          "uihints": {
+            "category": "Source"
+          }
+        },
         "auth_id": {
           "title": "User Id",
           "description": "User id that has read access for the specified URL resource",

--- a/elyra/pipeline/airflow/package_catalog_connector/airflow_package_catalog_connector.py
+++ b/elyra/pipeline/airflow/package_catalog_connector/airflow_package_catalog_connector.py
@@ -148,6 +148,10 @@ class AirflowPackageCatalogConnector(ComponentCatalogConnector):
             # Locate Python scripts that are stored in the 'airflow/operators' directory
             python_scripts = [s for s in self.tmp_archive_dir.glob("airflow/operators/*.py")]
 
+            # If requested, also locate Python scripts that are stored in the 'airflow/contrib/operators' directory
+            if catalog_metadata.get("search_contrib"):
+                python_scripts.extend([s for s in self.tmp_archive_dir.glob("airflow/contrib/operators/*.py")])
+
             #
             # Identify Python scripts that define classes that extend the
             # airflow.models.BaseOperator class


### PR DESCRIPTION
When configuring an Apache Airflow package connector, users can now optionally specify whether or not to include operators that are located in the `airflow.contrib.operators` Python package. 

![image](https://user-images.githubusercontent.com/13068832/177382406-66f81bcf-7bab-4ecf-b20e-a8f9c01f0495.png)


By default these operators are excluded. (For Airflow version >= 2.0 this option should result in a no-op, because the operator implementations should be located in provider packages, which are supported by [this connector](https://github.com/elyra-ai/elyra/tree/main/elyra/pipeline/airflow/provider_package_catalog_connector).)

A migration of existing connectors is not required.

Closes #2818 

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?

- See above
- Updated documentation

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?

Use Airflow 1.10.15 whl as input:
 - configure connector to not search for operators in the `contrib` package and review components in VPE palette
 - configure connector to search for operators in the `contrib` package and review components in VPE palette (there should be more, e.g. the `KubernetesPodOperator`)

<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
