### PR TITLE
Fix doc requirements to address build issue

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 sphinx>=1.8
 sphinx_rtd_theme
 recommonmark>=0.6.0
-sphinx-markdown-tables
+sphinx-markdown-tables>=0.0.16
 sphinx-version-warning
-markdown!=3.3.5,<3.4  # Exclusion of 3.3.5 is a workaround for ryanfox/sphinx-markdown-tables#34
+markdown>=3.4.1


### PR DESCRIPTION
A new version of `sphinx-markdown-tables` (0.0.16) was recently released and is compatible with the current `Markdown` release (3.4.1) that had previously broken `sphinx-markdown-tables`.  This PR updates the relative minimum versions of these packages and removes the previously imposed cap and exclusion.

Fixes: #2837
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
