### PR TITLE
Removes max limit for the GPU and RAM properties

### DIFF
--- a/elyra/templates/components/generic_properties_template.jinja2
+++ b/elyra/templates/components/generic_properties_template.jinja2
@@ -128,8 +128,7 @@
             "placement": "on_panel"
           },
           "data": {
-            "minimum": 0,
-            "maximum": 99
+            "minimum": 0
           }
         },
         {
@@ -144,8 +143,7 @@
             "placement": "on_panel"
           },
           "data": {
-            "minimum": 0,
-            "maximum": 99
+            "minimum": 0
           }
         },
         {

--- a/elyra/tests/pipeline/resources/properties.json
+++ b/elyra/tests/pipeline/resources/properties.json
@@ -128,8 +128,7 @@
           "placement": "on_panel"
         },
         "data": {
-          "minimum": 0,
-          "maximum": 99
+          "minimum": 0
         }
       },
       {
@@ -144,8 +143,7 @@
           "placement": "on_panel"
         },
         "data": {
-          "minimum": 0,
-          "maximum": 99
+          "minimum": 0
         }
       },
       {


### PR DESCRIPTION
Fixes #2822 

### What changes were proposed in this pull request?

Removes the max limits for the GPU and RAM properties for pipeline nodes. Removes maximum field in jinja2 pipeline template file and in the pipeline properties test file.

### How was this pull request tested?

Passes all pipeline backend tests.

Example:
![image](https://user-images.githubusercontent.com/72038310/181081681-5c53f475-93b4-48a3-82cf-64fccc03acfe.png)

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
