### PR TITLE
Remove deprecation warning for local runtime type

### DIFF
--- a/elyra/pipeline/handlers.py
+++ b/elyra/pipeline/handlers.py
@@ -57,14 +57,15 @@ def get_runtime_processor_type(runtime_type: str, log: Logger, request_path: str
     """
     processor_manager = PipelineProcessorManager.instance()
     if processor_manager.is_supported_runtime(runtime_type):
-        # The endpoint path contains the shorthand version of a runtime (e.g., 'kfp',
-        # 'airflow'). This case and its associated functions should eventually be removed
-        # in favor of using the RuntimeProcessorType name in the request path.
-        log.warning(
-            f"Deprecation warning: when calling endpoint '{request_path}' "
-            f"use runtime type name (e.g. 'KUBEFLOW_PIPELINES', 'APACHE_AIRFLOW') "
-            f"instead of shorthand name (e.g., 'kfp', 'airflow')"
-        )
+        if runtime_type != "local":
+            # The endpoint path contains the shorthand version of a runtime (e.g., 'kfp',
+            # 'airflow'). This case and its associated functions should eventually be removed
+            # in favor of using the RuntimeProcessorType name in the request path.
+            log.warning(
+                f"Deprecation warning: when calling endpoint '{request_path}' "
+                f"use runtime type name (e.g. 'KUBEFLOW_PIPELINES', 'APACHE_AIRFLOW') "
+                f"instead of shorthand name (e.g., 'kfp', 'airflow')"
+            )
         return processor_manager.get_runtime_type(runtime_type)
     elif processor_manager.is_supported_runtime_type(runtime_type):
         # The request path uses the appropriate RuntimeProcessorType name. Use this

--- a/elyra/pipeline/handlers.py
+++ b/elyra/pipeline/handlers.py
@@ -56,21 +56,20 @@ def get_runtime_processor_type(runtime_type: str, log: Logger, request_path: str
     :returns: the RuntimeProcessorType for the given runtime_type, or None
     """
     processor_manager = PipelineProcessorManager.instance()
-    if processor_manager.is_supported_runtime(runtime_type):
-        if runtime_type != "local":
-            # The endpoint path contains the shorthand version of a runtime (e.g., 'kfp',
-            # 'airflow'). This case and its associated functions should eventually be removed
-            # in favor of using the RuntimeProcessorType name in the request path.
-            log.warning(
-                f"Deprecation warning: when calling endpoint '{request_path}' "
-                f"use runtime type name (e.g. 'KUBEFLOW_PIPELINES', 'APACHE_AIRFLOW') "
-                f"instead of shorthand name (e.g., 'kfp', 'airflow')"
-            )
-        return processor_manager.get_runtime_type(runtime_type)
-    elif processor_manager.is_supported_runtime_type(runtime_type):
+    if processor_manager.is_supported_runtime_type(runtime_type):
         # The request path uses the appropriate RuntimeProcessorType name. Use this
         # to get the RuntimeProcessorType instance to pass to get_all_components
         return RuntimeProcessorType.get_instance_by_name(runtime_type)
+    elif processor_manager.is_supported_runtime(runtime_type):
+        # The endpoint path contains the shorthand version of a runtime (e.g., 'kfp',
+        # 'airflow'). This case and its associated functions should eventually be removed
+        # in favor of using the RuntimeProcessorType name in the request path.
+        log.warning(
+            f"Deprecation warning: when calling endpoint '{request_path}' "
+            f"use runtime type name (e.g. 'KUBEFLOW_PIPELINES', 'APACHE_AIRFLOW') "
+            f"instead of shorthand name (e.g., 'kfp', 'airflow')"
+        )
+        return processor_manager.get_runtime_type(runtime_type)
     return None
 
 

--- a/elyra/pipeline/processor.py
+++ b/elyra/pipeline/processor.py
@@ -87,7 +87,7 @@ class PipelineProcessorRegistry(SingletonConfigurable):
 
     def is_valid_runtime_type(self, runtime_type_name: str) -> bool:
         for processor in self._processors.values():
-            if processor.type.name == runtime_type_name:
+            if processor.type.name == runtime_type_name.upper():
                 return True
         return False
 

--- a/elyra/pipeline/runtime_type.py
+++ b/elyra/pipeline/runtime_type.py
@@ -45,7 +45,7 @@ class RuntimeProcessorType(Enum):
 
         Raises KeyError if parameter is not a name in the enumeration.
         """
-        return RuntimeProcessorType.__members__[name]
+        return RuntimeProcessorType.__members__[name.upper()]
 
     @staticmethod
     def get_instance_by_value(value: str) -> "RuntimeProcessorType":

--- a/elyra/tests/pipeline/test_handlers.py
+++ b/elyra/tests/pipeline/test_handlers.py
@@ -87,6 +87,23 @@ async def test_get_components(jp_fetch):
     assert payload == palette
 
 
+async def test_get_components_runtime_name_vs_type(jp_fetch, caplog):
+    # Ensure deprecation warning appears when querying endpoint with shorthand runtime name
+    runtime_name = "kfp"
+    response = await jp_fetch("elyra", "pipeline", "components", runtime_name)
+    assert response.code == 200
+    assert "Deprecation warning: when calling endpoint" in caplog.text
+    caplog.clear()
+
+    # Ensure no deprecation warning appears when using runtime type name. The type
+    # is case-insensitive, e.g., a runtime type can use either lowercase 'local' or
+    # uppercase 'LOCAL'
+    runtime_type = RuntimeProcessorType.LOCAL  # use LOCAL runtime type
+    response = await jp_fetch("elyra", "pipeline", "components", runtime_type.name.lower())  # fetch with 'local'
+    assert response.code == 200
+    assert "Deprecation warning: when calling endpoint" not in caplog.text
+
+
 async def test_get_component_properties_config(jp_fetch):
     # Ensure all valid component_entry properties can be found
     runtime_type = RuntimeProcessorType.LOCAL


### PR DESCRIPTION
Fixes #2855 

### What changes were proposed in this pull request?
Based on some discussion related to #2855, we decided to consider lowercase `local` equivalent to uppercase `LOCAL` when checking against runtime types. This PR suppresses the warning message about using (eventually) deprecated runtime type names (`kfp`, `airflow`) for the local runtime only. This is the 'path of least resistance' for this issue. If we ever fully remove the ability to query with the lowercase `local`, we'll probably want the frontend to adjust its API call to use the `LOCAL` `RuntimeProcessorType` Enum member.

### How was this pull request tested?
Queried the `elyra/pipeline/components/{runtime_type}` endpoint with `local` as the `runtime_type`, and no warning message is shown in the logs. A new test is added to cover this case as well.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
