### PR TITLE
Fix Airflow Operator execution bugs in handling of Elyra-owned properties

### DIFF
--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -101,8 +101,12 @@ class Operation(object):
 
         self._mounted_volumes = []
         param_volumes = component_params.get(MOUNTED_VOLUMES)
-        if param_volumes and isinstance(param_volumes, list) and isinstance(param_volumes[0], VolumeMount):
-            # The mounted_volumes property is the Elyra system property (ie, not defined in the component
+        if (
+            param_volumes is not None
+            and isinstance(param_volumes, list)
+            and (len(param_volumes) == 0 or isinstance(param_volumes[0], VolumeMount))
+        ):
+            # The mounted_volumes property is an Elyra system property (ie, not defined in the component
             # spec) and must be removed from the component_params dict
             self._mounted_volumes = self._component_params.pop(MOUNTED_VOLUMES, [])
 

--- a/elyra/pipeline/pipeline_definition.py
+++ b/elyra/pipeline/pipeline_definition.py
@@ -623,7 +623,7 @@ class PipelineDefinition(object):
                 if not pipeline_default_value:
                     continue
 
-                if not Operation.is_generic_operation(node) and property_name not in ELYRA_COMPONENT_PROPERTIES:
+                if not Operation.is_generic_operation(node.op) and property_name not in ELYRA_COMPONENT_PROPERTIES:
                     # Do not propagate default properties that do not apply to custom components, e.g. runtime image
                     continue
 

--- a/elyra/pipeline/pipeline_definition.py
+++ b/elyra/pipeline/pipeline_definition.py
@@ -623,6 +623,10 @@ class PipelineDefinition(object):
                 if not pipeline_default_value:
                     continue
 
+                if not Operation.is_generic_operation(node) and property_name not in ELYRA_COMPONENT_PROPERTIES:
+                    # Do not propagate default properties that do not apply to custom components, e.g. runtime image
+                    continue
+
                 node_value = node.get_component_parameter(property_name)
                 if not node_value:
                     node.set_component_parameter(property_name, pipeline_default_value)

--- a/elyra/tests/pipeline/resources/sample_pipelines/pipeline_valid_with_pipeline_default.json
+++ b/elyra/tests/pipeline/resources/sample_pipelines/pipeline_valid_with_pipeline_default.json
@@ -41,7 +41,7 @@
             "component_source": "{{component_source}}",
             "ui_data": {
               "label": "{{label}}",
-              "description": "Notebook file"
+              "description": "A test operator"
             }
           }
         },
@@ -57,7 +57,7 @@
             "component_source": "{{component_source}}",
             "ui_data": {
               "label": "{{label}}",
-              "description": "Notebook file"
+              "description": "An operator that derives from TestOperator"
             }
           }
         },
@@ -73,7 +73,7 @@
             "component_source": "{{component_source}}",
             "ui_data": {
               "label": "{{label}}",
-              "description": "Notebook file"
+              "description": "An operator that derives from TestOperator"
             }
           }
         }

--- a/elyra/tests/pipeline/resources/sample_pipelines/pipeline_valid_with_pipeline_default.json
+++ b/elyra/tests/pipeline/resources/sample_pipelines/pipeline_valid_with_pipeline_default.json
@@ -9,7 +9,7 @@
       "id": "primary",
       "nodes": [
         {
-          "id": "{{uuid}}",
+          "id": "{{uuid-Notebook}}",
           "type": "execution_node",
           "op": "execute-notebook-node",
           "app_data": {
@@ -30,7 +30,7 @@
           }
         },
         {
-          "id": "{{uuid}}",
+          "id": "{{uuid-TestOperator1}}",
           "type": "execution_node",
           "op": "local-file-catalog:8371f5970c7b:TestOperator",
           "app_data": {
@@ -46,13 +46,29 @@
           }
         },
         {
-          "id": "{{uuid}}",
+          "id": "{{uuid-DeriveFromTestOperator1}}",
           "type": "execution_node",
           "op": "local-file-catalog:8371f5970c7b:DeriveFromTestOperator",
           "app_data": {
             "label": "{{label}}",
             "component_parameters": {
               "mounted_volumes": ["/mnt/vol1=pvc-claim-1"]
+            },
+            "component_source": "{{component_source}}",
+            "ui_data": {
+              "label": "{{label}}",
+              "description": "Notebook file"
+            }
+          }
+        },
+        {
+          "id": "{{uuid-DeriveFromTestOperator2}}",
+          "type": "execution_node",
+          "op": "local-file-catalog:8371f5970c7b:DeriveFromTestOperator",
+          "app_data": {
+            "label": "{{label}}",
+            "component_parameters": {
+              "mounted_volumes": []
             },
             "component_source": "{{component_source}}",
             "ui_data": {

--- a/elyra/tests/pipeline/resources/sample_pipelines/pipeline_with_airflow_components.json
+++ b/elyra/tests/pipeline/resources/sample_pipelines/pipeline_with_airflow_components.json
@@ -15,6 +15,10 @@
           "app_data": {
             "label": "b",
             "component_parameters": {
+              "mounted_volumes": {
+                "activeControl": "StringControl",
+                "StringControl": "a component-defined property"
+              },
               "str_no_default": {
                 "activeControl": "StringControl",
                 "StringControl": "echo 'test one'"
@@ -41,6 +45,53 @@
               "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
               "x_pos": 352,
               "y_pos": 137,
+              "description": "BashOperator"
+            }
+          },
+          "inputs": [
+            {
+              "id": "inPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Input Port"
+                }
+              },
+              "links": []
+            }
+          ],
+          "outputs": [
+            {
+              "id": "outPort",
+              "app_data": {
+                "ui_data": {
+                  "cardinality": {
+                    "min": 0,
+                    "max": -1
+                  },
+                  "label": "Output Port"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "id": "bb9473ca-12ec-0472-a36a-45bd2a1f6dc1",
+          "type": "execution_node",
+          "op": "local-file-catalog:8371f5970c7b:DeriveFromTestOperator",
+          "app_data": {
+            "label": "a",
+            "component_parameters": {
+              "mounted_volumes": []
+            },
+            "ui_data": {
+              "label": "b",
+              "image": "data:image/svg+xml;utf8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20viewBox%3D%220%200%2022%2022%22%3E%0A%20%20%3Cg%20class%3D%22jp-icon-warn0%20jp-icon-selectable%22%20fill%3D%22%23EF6C00%22%3E%0A%20%20%20%20%3Cpath%20d%3D%22M18.7%203.3v15.4H3.3V3.3h15.4m1.5-1.5H1.8v18.3h18.3l.1-18.3z%22%2F%3E%0A%20%20%20%20%3Cpath%20d%3D%22M16.5%2016.5l-5.4-4.3-5.6%204.3v-11h11z%22%2F%3E%0A%20%20%3C%2Fg%3E%0A%3C%2Fsvg%3E%0A",
+              "x_pos": 242,
+              "y_pos": 37,
               "description": "BashOperator"
             }
           },


### PR DESCRIPTION
This PR fixes 2 bugs related to volumes for Airflow operators:

1. Brought to our attention in the `elyra-ai/community` gitter - The issue is that the `mounted_volume` property is being persisted as an empty list in the case where no values are added. This value is then not being popped off the dict of `component_parameters` for a given component before being passed to the DAG to render. The extra, unexpected `kwarg` is causing certain operators to fail.


```
airflow.exceptions.AirflowException: Invalid arguments were passed to PythonOperator (task_id: PythonOperator). Invalid arguments were:
**kwargs: {'mounted_volumes': []}
``` 

2. Fixes #2866 - The issue here is that pipeline default properties such as runtime image and kubernetes secrets are being incorrectly propagated to custom components and appearing in the `component_parameters` dict. Due to formatting errors with the `runtime_image` field in the DAG, `black` is throwing an error. Even without this formatting error, however, these operators would not execute properly.


### What changes were proposed in this pull request?
This PR adds more conditions around property propagation and persistence on the `Operation` object. 

Re: issue 1 above, the `mounted_volumes` property is now appropriately popped off the dict of `component_params` for an `Operation` object. If the value of the `mounted_volumes` param is not `None`, is a `list`, and either 1. the list is empty or 2. the list consists of `VolumeMount` dataclass objects, the `mounted_volumes` key is popped off the dict. This means it will not be rendered alongside the component-defined parameters for which a value was supplied. Recall that we are accounting for the possibility that the component defined its own `mounted_volumes` parameter. If this is the case, and if that property happens to be list-valued and the value entered is an empty list, the consequences of popping this off the param dict should be minor.

Re: issue 2 above, any property that is 1. considered a pipeline default and 2. only applies to generic components is now appropriately skipped during property propagation for custom components. A list of such properties that adhere to the 2 conditions listed above already exists as the `ELYRA_COMPONENT_PROPERTIES` variable.

### How was this pull request tested?
Manual testing shows that `mounted_volumes` no longer appears as an extra arg during operator construction and that runtime image, env vars, and secrets are not propagated to custom components.. 

 - [x] Add backend test for empty mounted volumes on a custom component
   - see new `test_pipeline_parser.py::test_custom_component_parsed_properties` - this test takes a pipeline with 2 operators, one of which defines its own `mounted_volumes` property and one of which doesn't
     - the operator that defines it's own `mounted_volumes` property should have that component parameter in its `component_params_as_dict` attribute and it's value should be as-given in the pipeline file
     - the operator that does not define it's own `mounted_volumes` property and has no Elyra-owned mounted volumes given (and therefore has `mounted_volumes: []` in the pipeline JSON) should not have the `mounted_volumes` property appear in its `component_params_as_dict` attribute
 - [x] Add backend test for runtime image (or other pipeline default) to ensure it does not appear in the `component_params` dict for custom components
   - see additions to existing `test_pipeline_definition.py::test_propagate_pipeline_default_properties` - these additions ensure that properties such as runtime image and env vars are not propagated to custom components

Test resources have been updated according to the needs of the above tests. A small change to `test_processor_airflow.py::test_create_file_custom_components` was also required in order to compare a parsed pipeline file against the correct expected component parameters. I've confirmed that these new tests fail without the accompanying changes to the code base proposed in this PR.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
