### PR TITLE
Add support for Kubernetes annotations

### DIFF
--- a/docs/source/user_guide/pipelines.md
+++ b/docs/source/user_guide/pipelines.md
@@ -79,6 +79,11 @@ The [tutorials](/getting_started/tutorials.md) provide comprehensive step-by-ste
            - A list of [Persistent Volume Claims](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVC) to be mounted into the container that executes the component. Format: `/mnt/path=existing-pvc-name`. Entries that are empty (`/mnt/path=`) or malformed are ignored. Entries with a PVC name considered to be an [invalid Kubernetes resource name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names) will raise a validation error after pipeline submission or export.
            - The referenced PVCs must exist in the Kubernetes namespace where the pipeline nodes are executed.
            - Data volumes are not mounted when the pipeline is executed locally.
+         - **Kubernetes pod annotations** 
+           - A list of [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects) to be attached to the pod that executes the node.
+           - Format: `annotation-key=annotation-value`. Entries that are empty (`annotation-key=`) are ignored. Entries with a key considered to be [invalid](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set) will raise a validation error after pipeline submission or export.
+           - Annotations are ignored when the pipeline is executed locally.
+
       - Properties that apply to every generic pipeline node. In this release the following properties are supported:
         - **Object storage path prefix**. Elyra stores pipeline input and output artifacts in a cloud object storage bucket. By default these artifacts are located in the `/<pipeline-instance-name>` path. The example below depicts the artifact location for several pipelines in the `pipeline-examples` bucket:
           ![artifacts default storage layout on object storage](../images/user_guide/pipelines/node-artifacts-on-object-storage.png)
@@ -152,6 +157,11 @@ The [tutorials](/getting_started/tutorials.md) provide comprehensive step-by-ste
    - Optional. A list of [Persistent Volume Claims](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVC) to be mounted into the container that executes the component and allows for data exchange between components. Format: `/mnt/path=existing-pvc-name`. Entries that are empty (`/mnt/path=`) or malformed are ignored. Entries with a PVC name considered to be an [invalid Kubernetes resource name](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names) will raise a validation error after pipeline submission or export. The referenced PVCs must exist in the Kubernetes namespace where the node is executed. Note that only certain Apache Airflow operators are capable of supporting volumes in the manner explained here.
    - Data volumes are not mounted when the pipeline is executed locally.   
    - Example: `/mnt/vol1=data-pvc`
+
+   **Kubernetes Pod Annotations** 
+   - Optional. A list of [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#attaching-metadata-to-objects) to be attached to the pod that executes the node.
+   - Format: `annotation-key=annotation-value`. Entries that are empty (`annotation-key=`) are ignored. Entries with a key considered to be [invalid](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set) will raise a validation error after pipeline submission or export.
+   - Annotations are ignored when the pipeline is executed locally.   
 
 5. Associate each node with a comment to document its purpose.
 

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -334,6 +334,7 @@ be fully qualified (i.e., prefixed with their package names).
                     "doc": operation.doc,
                     "volumes": operation.mounted_volumes,
                     "secrets": operation.kubernetes_secrets,
+                    "kubernetes_pod_annotations": operation.kubernetes_pod_annotations,
                 }
 
                 if runtime_image_pull_secret is not None:
@@ -447,6 +448,7 @@ be fully qualified (i.e., prefixed with their package names).
                     "is_generic_operator": operation.is_generic,
                     "doc": operation.doc,
                     "volumes": operation.mounted_volumes,
+                    "kubernetes_pod_annotations": operation.kubernetes_pod_annotations,
                 }
 
                 target_ops.append(target_op)
@@ -499,6 +501,7 @@ be fully qualified (i.e., prefixed with their package names).
                 "render_executor_config_for_custom_op": AirflowPipelineProcessor.render_executor_config_for_custom_op,
                 "render_secrets_for_generic_op": AirflowPipelineProcessor.render_secrets_for_generic_op,
                 "render_secrets_for_cos": AirflowPipelineProcessor.render_secrets_for_cos,
+                "render_executor_config_for_generic_op": AirflowPipelineProcessor.render_executor_config_for_generic_op,
             }
             template.globals.update(rendering_functions)
 
@@ -636,18 +639,59 @@ be fully qualified (i.e., prefixed with their package names).
 
         :returns: a dict defining the volumes and mounts to be rendered in the DAG
         """
-        executor_config = {"KubernetesExecutor": {"volumes": [], "volume_mounts": []}}
-        for volume in op.get("volumes", []):
-            # Define volumes and volume mounts
-            executor_config["KubernetesExecutor"]["volumes"].append(
-                {
-                    "name": volume.pvc_name,
-                    "persistentVolumeClaim": {"claimName": volume.pvc_name},
-                }
-            )
-            executor_config["KubernetesExecutor"]["volume_mounts"].append(
-                {"mountPath": volume.path, "name": volume.pvc_name, "read_only": False}
-            )
+
+        executor_config = {"KubernetesExecutor": {}}
+
+        # Handle volume mounts
+        if op.get("volumes"):
+            executor_config["KubernetesExecutor"]["volumes"] = []
+            executor_config["KubernetesExecutor"]["volume_mounts"] = []
+            for volume in op.get("volumes", []):
+                # Add volume and volume mount entry
+                executor_config["KubernetesExecutor"]["volumes"].append(
+                    {
+                        "name": volume.pvc_name,
+                        "persistentVolumeClaim": {"claimName": volume.pvc_name},
+                    }
+                )
+                executor_config["KubernetesExecutor"]["volume_mounts"].append(
+                    {"mountPath": volume.path, "name": volume.pvc_name, "read_only": False}
+                )
+
+        # Handle annotations
+        if op.get("kubernetes_pod_annotations"):
+            executor_config["KubernetesExecutor"]["pod_override"] = []
+            for annotation in op.get("kubernetes_pod_annotations", []):
+                # Add Kubernetes annotation entry
+                executor_config["KubernetesExecutor"]["pod_override"].append(
+                    {
+                        "key": annotation.key,
+                        "value": annotation.value,
+                    }
+                )
+
+        return executor_config
+
+    @staticmethod
+    def render_executor_config_for_generic_op(op: Dict) -> Dict[str, Dict[str, List]]:
+        """
+        Render annotations defined for the specified generic op
+        for use in the Airflow DAG template
+        :returns: a dict defining the annotations to be rendered in the DAG
+        """
+        executor_config = {"KubernetesExecutor": {}}
+
+        # Handle annotations
+        if op.get("kubernetes_pod_annotations"):
+            executor_config["KubernetesExecutor"]["pod_override"] = []
+            for annotation in op.get("kubernetes_pod_annotations", []):
+                # Add Kubernetes annotation entry
+                executor_config["KubernetesExecutor"]["pod_override"].append(
+                    {
+                        "key": annotation.key,
+                        "value": annotation.value,
+                    }
+                )
 
         return executor_config
 

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -660,15 +660,10 @@ be fully qualified (i.e., prefixed with their package names).
 
         # Handle annotations
         if op.get("kubernetes_pod_annotations"):
-            executor_config["KubernetesExecutor"]["pod_override"] = []
+            executor_config["KubernetesExecutor"]["annotations"] = {}
             for annotation in op.get("kubernetes_pod_annotations", []):
                 # Add Kubernetes annotation entry
-                executor_config["KubernetesExecutor"]["pod_override"].append(
-                    {
-                        "key": annotation.key,
-                        "value": annotation.value,
-                    }
-                )
+                executor_config["KubernetesExecutor"]["annotations"][annotation.key] = annotation.value
 
         return executor_config
 
@@ -683,15 +678,10 @@ be fully qualified (i.e., prefixed with their package names).
 
         # Handle annotations
         if op.get("kubernetes_pod_annotations"):
-            executor_config["KubernetesExecutor"]["pod_override"] = []
+            executor_config["KubernetesExecutor"]["annotations"] = {}
             for annotation in op.get("kubernetes_pod_annotations", []):
                 # Add Kubernetes annotation entry
-                executor_config["KubernetesExecutor"]["pod_override"].append(
-                    {
-                        "key": annotation.key,
-                        "value": annotation.value,
-                    }
-                )
+                executor_config["KubernetesExecutor"]["annotations"][annotation.key] = annotation.value
 
         return executor_config
 

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -546,6 +546,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                     },
                     volume_mounts=operation.mounted_volumes,
                     kubernetes_secrets=operation.kubernetes_secrets,
+                    kubernetes_pod_annotations=operation.kubernetes_pod_annotations,
                 )
 
                 if operation.doc:
@@ -673,6 +674,14 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                             container_op.add_volume_mount(
                                 V1VolumeMount(mount_path=volume_mount.path, name=volume_mount.pvc_name)
                             )
+
+                    # Add user-specified pod annotations
+                    if operation.kubernetes_pod_annotations:
+                        unique_annotations = []
+                        for annotation in operation.kubernetes_pod_annotations:
+                            if annotation.key not in unique_annotations:
+                                container_op.add_pod_annotation(annotation.key, annotation.value)
+                                unique_annotations.append(annotation.key)
 
                     target_ops[operation.id] = container_op
                 except Exception as e:

--- a/elyra/pipeline/pipeline_constants.py
+++ b/elyra/pipeline/pipeline_constants.py
@@ -19,7 +19,8 @@ RUNTIME_IMAGE = "runtime_image"
 ENV_VARIABLES = "env_vars"
 MOUNTED_VOLUMES = "mounted_volumes"
 KUBERNETES_SECRETS = "kubernetes_secrets"
+KUBERNETES_POD_ANNOTATIONS = "kubernetes_pod_annotations"
 PIPELINE_META_PROPERTIES = ["name", "description", "runtime"]
 # optional static prefix to be used when generating an object name for object storage
 COS_OBJECT_PREFIX = "cos_object_prefix"
-ELYRA_COMPONENT_PROPERTIES = [MOUNTED_VOLUMES]
+ELYRA_COMPONENT_PROPERTIES = [MOUNTED_VOLUMES, KUBERNETES_POD_ANNOTATIONS]

--- a/elyra/pipeline/pipeline_definition.py
+++ b/elyra/pipeline/pipeline_definition.py
@@ -27,11 +27,13 @@ from jinja2 import Undefined
 
 from elyra.pipeline.component_catalog import ComponentCache
 from elyra.pipeline.pipeline import KeyValueList
+from elyra.pipeline.pipeline import KubernetesAnnotation
 from elyra.pipeline.pipeline import KubernetesSecret
 from elyra.pipeline.pipeline import Operation
 from elyra.pipeline.pipeline import VolumeMount
 from elyra.pipeline.pipeline_constants import ELYRA_COMPONENT_PROPERTIES
 from elyra.pipeline.pipeline_constants import ENV_VARIABLES
+from elyra.pipeline.pipeline_constants import KUBERNETES_POD_ANNOTATIONS
 from elyra.pipeline.pipeline_constants import KUBERNETES_SECRETS
 from elyra.pipeline.pipeline_constants import MOUNTED_VOLUMES
 from elyra.pipeline.pipeline_constants import PIPELINE_DEFAULTS
@@ -433,6 +435,16 @@ class Node(AppDataBase):
                 secret_objects.append(KubernetesSecret(env_var_name, secret_name.strip(), secret_key))
 
             self.set_component_parameter(KUBERNETES_SECRETS, secret_objects)
+
+        kubernetes_pod_annotations = self.get_component_parameter(KUBERNETES_POD_ANNOTATIONS)
+        if kubernetes_pod_annotations and isinstance(kubernetes_pod_annotations, KeyValueList):
+            annotations_objects = []
+            for annotation_key, annotation_value in kubernetes_pod_annotations.to_dict().items():
+                # Validation should have verified that the provided values are valid
+                # Create a KubernetesAnnotation class instance and add to list
+                annotations_objects.append(KubernetesAnnotation(annotation_key, annotation_value))
+
+            self.set_component_parameter(KUBERNETES_POD_ANNOTATIONS, annotations_objects)
 
 
 class PipelineDefinition(object):

--- a/elyra/pipeline/validation.py
+++ b/elyra/pipeline/validation.py
@@ -32,12 +32,14 @@ from elyra.pipeline.component import Component
 from elyra.pipeline.component_catalog import ComponentCache
 from elyra.pipeline.pipeline import DataClassJSONEncoder
 from elyra.pipeline.pipeline import KeyValueList
+from elyra.pipeline.pipeline import KubernetesAnnotation
 from elyra.pipeline.pipeline import KubernetesSecret
 from elyra.pipeline.pipeline import Operation
 from elyra.pipeline.pipeline import PIPELINE_CURRENT_SCHEMA
 from elyra.pipeline.pipeline import PIPELINE_CURRENT_VERSION
 from elyra.pipeline.pipeline import VolumeMount
 from elyra.pipeline.pipeline_constants import ENV_VARIABLES
+from elyra.pipeline.pipeline_constants import KUBERNETES_POD_ANNOTATIONS
 from elyra.pipeline.pipeline_constants import KUBERNETES_SECRETS
 from elyra.pipeline.pipeline_constants import MOUNTED_VOLUMES
 from elyra.pipeline.pipeline_constants import RUNTIME_IMAGE
@@ -45,6 +47,7 @@ from elyra.pipeline.pipeline_definition import Node
 from elyra.pipeline.pipeline_definition import PipelineDefinition
 from elyra.pipeline.processor import PipelineProcessorManager
 from elyra.pipeline.runtime_type import RuntimeProcessorType
+from elyra.util.kubernetes import is_valid_annotation_key
 from elyra.util.kubernetes import is_valid_kubernetes_key
 from elyra.util.kubernetes import is_valid_kubernetes_resource_name
 from elyra.util.path import get_expanded_path
@@ -419,6 +422,7 @@ class PipelineValidationManager(SingletonConfigurable):
         env_vars = node.get_component_parameter(ENV_VARIABLES)
         volumes = node.get_component_parameter(MOUNTED_VOLUMES)
         secrets = node.get_component_parameter(KUBERNETES_SECRETS)
+        annotations = node.get_component_parameter(KUBERNETES_POD_ANNOTATIONS)
 
         self._validate_filepath(
             node_id=node.id, node_label=node_label, property_name="filename", filename=filename, response=response
@@ -442,6 +446,8 @@ class PipelineValidationManager(SingletonConfigurable):
                 self._validate_mounted_volumes(node.id, node_label, volumes, response=response)
             if secrets:
                 self._validate_kubernetes_secrets(node.id, node_label, secrets, response=response)
+            if annotations:
+                self._validate_kubernetes_pod_annotations(node.id, node_label, annotations, response=response)
 
         self._validate_label(node_id=node.id, node_label=node_label, response=response)
         if dependencies:
@@ -489,6 +495,10 @@ class PipelineValidationManager(SingletonConfigurable):
         volumes = node.get_component_parameter(MOUNTED_VOLUMES)
         if volumes and MOUNTED_VOLUMES not in node.elyra_properties_to_skip:
             self._validate_mounted_volumes(node.id, node.label, volumes, response=response)
+
+        annotations = node.get_component_parameter(KUBERNETES_POD_ANNOTATIONS)
+        if annotations and KUBERNETES_POD_ANNOTATIONS not in node.elyra_properties_to_skip:
+            self._validate_kubernetes_pod_annotations(node.id, node.label, annotations, response=response)
 
         for default_parameter in current_parameter_defaults_list:
             node_param = node.get_component_parameter(default_parameter)
@@ -704,6 +714,32 @@ class PipelineValidationManager(SingletonConfigurable):
                         "nodeName": node_label,
                         "propertyName": KUBERNETES_SECRETS,
                         "value": KeyValueList.to_str(secret.env_var, f"{secret.name}:{secret.key}"),
+                    },
+                )
+
+    def _validate_kubernetes_pod_annotations(
+        self, node_id: str, node_label: str, annotations: List[KubernetesAnnotation], response: ValidationResponse
+    ) -> None:
+        """
+        Checks the format of the user-provided annotations to ensure they're in the correct form
+        e.g. annotation_key=annotation_value
+        :param node_id: the unique ID of the node
+        :param node_label: the given node name or user customized name/label of the node
+        :param annotations: a KeyValueList of annotations to check
+        :param response: ValidationResponse containing the issue list to be updated
+        """
+        for annotation in annotations:
+            # Ensure the annotation key is valid
+            if not is_valid_annotation_key(annotation.key):
+                response.add_message(
+                    severity=ValidationSeverity.Error,
+                    message_type="invalidKubernetesAnnotation",
+                    message=f"'{annotation.key}' is not a valid Kubernetes annotation key.",
+                    data={
+                        "nodeID": node_id,
+                        "nodeName": node_label,
+                        "propertyName": KUBERNETES_POD_ANNOTATIONS,
+                        "value": KeyValueList.to_str(annotation.key, annotation.value),
                     },
                 )
 

--- a/elyra/templates/airflow/airflow_template.jinja2
+++ b/elyra/templates/airflow/airflow_template.jinja2
@@ -31,16 +31,18 @@ dag = DAG(
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 {% endif %}
 
-{% if operation.operator_source %}# Operator source: {{ operation.operator_source }}{% endif %}{% if not operation.is_generic_operator %}
+{% if operation.operator_source %}# Operator source: {{ operation.operator_source }}
+{% endif %}
+{% if not operation.is_generic_operator %}
 op_{{ operation.id|regex_replace }} = {{ operation.class_name }}(
                                                            task_id='{{ operation.notebook|regex_replace }}',
         {% for param, value in operation.component_params.items() %}
                                                            {{ param }}={{ value }},
         {% endfor %}
-        {% if operation.volumes %}
+        {% if operation.volumes or operation.kubernetes_pod_annotations %}
                                                             executor_config={{ render_executor_config_for_custom_op(operation) }},
         {% endif %}
-    {% else %}
+{% else %}
 op_{{ operation.id|regex_replace }} = KubernetesPodOperator(name='{{ operation.notebook|regex_replace }}',
                                                             namespace='{{ user_namespace }}',
                                                             image='{{ operation.runtime_image }}',
@@ -71,6 +73,9 @@ op_{{ operation.id|regex_replace }} = KubernetesPodOperator(name='{{ operation.n
                                                           volumes=[{% for volume_var in operation.volume_vars %}{{ volume_var }},{% endfor %}],
                                                           volume_mounts=[{% for mount_var in operation.volume_mount_vars %}{{ mount_var }},{% endfor %}],
     {% endif %}
+    {% if operation.kubernetes_pod_annotations %}
+                                                          executor_config={{ render_executor_config_for_generic_op(operation) }},
+    {% endif %} 
                                                           in_cluster={{ in_cluster }},
                                                           config_file="{{ kube_config_path }}",
     {% endif %}

--- a/elyra/templates/components/canvas_properties_template.jinja2
+++ b/elyra/templates/components/canvas_properties_template.jinja2
@@ -28,6 +28,9 @@
 {% if "mounted_volumes" not in elyra_property_collisions_list %}
       "elyra_mounted_volumes": [],
 {% endif %}
+{% if "kubernetes_pod_annotations" not in elyra_property_collisions_list %}
+      "elyra_kubernetes_pod_annotations": [],
+{% endif %}
       "component_source": {{ component.component_source|tojson|safe }}
     },
     "parameters": [
@@ -45,6 +48,11 @@
 {% if "mounted_volumes" not in elyra_property_collisions_list %}
       {
         "id": "elyra_mounted_volumes"
+      },
+{% endif %}
+{% if "kubernetes_pod_annotations" not in elyra_property_collisions_list %}
+      {
+        "id": "elyra_kubernetes_pod_annotations"
       },
 {% endif %}
       {
@@ -153,6 +161,25 @@
           }
         },
 {% endif %}
+{% if "kubernetes_pod_annotations" not in elyra_property_collisions_list %}
+        {
+          "parameter_ref": "elyra_kubernetes_pod_annotations",
+          "control": "custom",
+          "custom_control_id": "StringArrayControl",
+          "label": {
+            "default": "Kubernetes Pod Annotations"
+          },
+          "description": {
+           "default": "Metadata to be added to this node. The metadata is exposed as annotation in the Kubernetes pod that executes this node.",
+           "placement": "on_panel"
+          },
+          "data": {
+            "required": false,
+            "placeholder": "annotation_key=annotation_value",
+            "keyValueEntries": true
+          }
+        },
+{% endif %}
         {
           "parameter_ref": "component_source",
           "control": "readonly",
@@ -215,7 +242,8 @@
             },
     {% endfor %}
 {% endif %}
-{% if "mounted_volumes" not in elyra_property_collisions_list %}
+{% if (("mounted_volumes" not in elyra_property_collisions_list) or
+       ("kubernetes_pod_annotations" not in elyra_property_collisions_list)) %}
             {
               "id": "elyra_other_propertiesCategoryHeader",
               "type": "textPanel",
@@ -228,10 +256,19 @@
                 "placement": "on_panel"
               }
             },
+{% endif %}
+{% if "mounted_volumes" not in elyra_property_collisions_list %}
             {
               "id": "elyra_mounted_volumes",
               "type": "controls",
               "parameter_refs": ["elyra_mounted_volumes"]
+            },
+{% endif %}
+{% if "kubernetes_pod_annotations" not in elyra_property_collisions_list %}
+            {
+              "id": "elyra_kubernetes_pod_annotations",
+              "type": "controls",
+              "parameter_refs": ["elyra_kubernetes_pod_annotations"]
             },
 {% endif %}
             {

--- a/elyra/templates/components/generic_properties_template.jinja2
+++ b/elyra/templates/components/generic_properties_template.jinja2
@@ -9,6 +9,7 @@
       "elyra_outputs": [],
       "elyra_env_vars": [],
       "elyra_kubernetes_secrets": [],
+      "elyra_kubernetes_pod_annotations": [],
       "elyra_dependencies": [],
       "elyra_include_subdirectories": false,
       "elyra_mounted_volumes": []
@@ -43,6 +44,9 @@
       },
       {
         "id": "elyra_kubernetes_secrets"
+      },
+      {
+        "id": "elyra_kubernetes_pod_annotations"
       },
       {
         "id": "elyra_outputs"
@@ -237,6 +241,22 @@
             "placeholder": "/mount/path=pvc-name",
             "keyValueEntries": true
           }
+        },
+        {
+          "parameter_ref": "elyra_kubernetes_pod_annotations",
+          "control": "custom",
+          "custom_control_id": "StringArrayControl",
+          "label": {
+            "default": "Kubernetes Pod Annotations"
+          },
+          "description": {
+           "default": "Metadata to be added to this node. The metadata is exposed as annotation in the Kubernetes pod that executes this node.",
+           "placement": "on_panel"
+          },
+          "data": {
+            "placeholder": "annotation_key=annotation_value",
+            "keyValueEntries": true
+          }
         }
       ],
       "group_info": [
@@ -293,6 +313,11 @@
               "id": "elyra_mounted_volumes",
               "type": "controls",
               "parameter_refs": ["elyra_mounted_volumes"]
+            },
+            {
+              "id": "elyra_kubernetes_pod_annotations",
+              "type": "controls",
+              "parameter_refs": ["elyra_kubernetes_pod_annotations"]
             }
           ]
         }

--- a/elyra/templates/pipeline/pipeline_properties_template.jinja2
+++ b/elyra/templates/pipeline/pipeline_properties_template.jinja2
@@ -7,7 +7,8 @@
     "elyra_runtime_image": null,
     "elyra_env_vars": [],
     "elyra_kubernetes_secrets": [],
-    "elyra_mounted_volumes": []
+    "elyra_mounted_volumes": [],
+    "elyra_kubernetes_pod_annotations": []
   },
   "parameters": [
     {
@@ -33,7 +34,10 @@
     },
     {
       "id": "elyra_mounted_volumes"
-    }
+    },
+    {
+      "id": "elyra_kubernetes_pod_annotations"
+    }    
   ],
   "uihints": {
     "id": "nodeProperties",
@@ -134,6 +138,22 @@
           "placeholder": "/mount/path=pvc-name",
           "keyValueEntries": true
         }
+      },
+      {
+        "parameter_ref": "elyra_kubernetes_pod_annotations",
+        "control": "custom",
+        "custom_control_id": "StringArrayControl",
+        "label": {
+          "default": "Kubernetes Pod Annotations"
+        },
+        "description": {
+          "default": "Metadata to be added to all nodes. The metadata is exposed as annotations in the Kubernetes pods that execute the nodes.",
+          "placement": "on_panel"
+        },
+        "data": {
+          "placeholder": "annotation_key=annotation_value",
+          "keyValueEntries": true
+        }
       }
     ],
     "group_info": [
@@ -177,6 +197,11 @@
             "id": "elyra_mounted_volumes",
             "type": "controls",
             "parameter_refs": ["elyra_mounted_volumes"]
+          },
+          {
+            "id": "elyra_kubernetes_pod_annotations",
+            "type": "controls",
+            "parameter_refs": ["elyra_kubernetes_pod_annotations"]
           },
           {
             "id": "elyra_generic_nodesCategoryHeader",

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -441,9 +441,9 @@ def test_parse_airflow_component_file_no_inputs():
     no_input_op = parser.parse(catalog_entry)[0]
     properties_json = ComponentCache.to_canvas_properties(no_input_op)
 
-    # Properties JSON should only include the two parameters common to every
-    # component: ('label', 'component_source' and 'mounted_volumes')
-    num_common_params = 3
+    # Properties JSON should only include the four parameters common to every
+    # component: ('label', 'component_source', 'mounted_volumes', and 'kubernetes_pod_annotations')
+    num_common_params = 4
     assert len(properties_json["current_parameters"].keys()) == num_common_params
     assert len(properties_json["parameters"]) == num_common_params
     assert len(properties_json["uihints"]["parameter_info"]) == num_common_params

--- a/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
@@ -430,12 +430,12 @@ def test_parse_kfp_component_file_no_inputs():
     component = parser.parse(catalog_entry)[0]
     properties_json = ComponentCache.to_canvas_properties(component)
 
-    # Properties JSON should only include the three parameters common to every
-    # component ('label', 'component_source' and 'mounted_volumes'), the component
+    # Properties JSON should only include the four parameters common to every
+    # component ('label', 'component_source', 'mounted_volumes', and 'kubernetes_pod_annotations'), the component
     # description if it exists (which it does for this component), and the output
     # parameter for this component
-    num_common_params = 5
-    assert len(properties_json["current_parameters"].keys()) == num_common_params
+    num_common_params = 6
+    assert len(properties_json["current_parameters"].keys()) == num_common_params, properties_json["current_parameters"]
     assert len(properties_json["parameters"]) == num_common_params
     assert len(properties_json["uihints"]["parameter_info"]) == num_common_params
 

--- a/elyra/tests/pipeline/resources/properties.json
+++ b/elyra/tests/pipeline/resources/properties.json
@@ -10,6 +10,7 @@
     "elyra_outputs": [],
     "elyra_env_vars": [],
     "elyra_kubernetes_secrets": [],
+    "elyra_kubernetes_pod_annotations": [],
     "elyra_dependencies": [],
     "elyra_include_subdirectories": false
   },
@@ -43,6 +44,9 @@
     },
     {
       "id": "elyra_kubernetes_secrets"
+    },
+    {
+      "id": "elyra_kubernetes_pod_annotations"
     },
     {
       "id": "elyra_outputs"
@@ -237,6 +241,22 @@
           "placeholder": "/mount/path=pvc-name",
           "keyValueEntries": true
         }
+      },
+      {
+        "parameter_ref": "elyra_kubernetes_pod_annotations",
+        "control": "custom",
+        "custom_control_id": "StringArrayControl",
+        "label": {
+          "default": "Kubernetes Pod Annotations"
+        },
+        "description": {
+          "default": "Metadata to be added to this node. The metadata is exposed as annotation in the Kubernetes pod that executes this node.",
+          "placement": "on_panel"
+        },
+        "data": {
+          "placeholder": "annotation_key=annotation_value",
+          "keyValueEntries": true
+        }
       }
     ],
     "group_info": [
@@ -293,6 +313,11 @@
             "id": "elyra_mounted_volumes",
             "type": "controls",
             "parameter_refs": ["elyra_mounted_volumes"]
+          },
+          {
+            "id": "elyra_kubernetes_pod_annotations",
+            "type": "controls",
+            "parameter_refs": ["elyra_kubernetes_pod_annotations"]
           }
         ]
       }

--- a/elyra/tests/pipeline/test_handlers.py
+++ b/elyra/tests/pipeline/test_handlers.py
@@ -220,4 +220,5 @@ async def test_get_pipeline_properties_definition(jp_fetch):
             {"id": "elyra_env_vars"},
             {"id": "elyra_kubernetes_secrets"},
             {"id": "elyra_mounted_volumes"},
+            {"id": "elyra_kubernetes_pod_annotations"},
         ]

--- a/elyra/util/kubernetes.py
+++ b/elyra/util/kubernetes.py
@@ -40,6 +40,19 @@ def is_valid_kubernetes_resource_name(name: str) -> bool:
     return True
 
 
+def is_valid_dns_subdomain_name(name: str) -> bool:
+    """
+    Returns a truthy value indicating whether name meets the kubernetes
+    naming constraints for DNS subdomains, as outlined in the link below.
+
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+    """
+    if name is None or len(name) > 253:
+        return False
+
+    return re.match(r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$", name) is not None
+
+
 def is_valid_kubernetes_key(name: str) -> bool:
     """
     Returns a truthy value indicating whether name meets the kubernetes
@@ -60,7 +73,7 @@ def is_valid_annotation_key(key: str) -> bool:
 
     https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
     """
-    if key is None or (len(key) == 0) or (len(key) > 253 + 1 + 63):
+    if key is None or (len(key) == 0):
         return False
 
     parts = key.split("/")
@@ -73,8 +86,8 @@ def is_valid_annotation_key(key: str) -> bool:
     else:
         return False
 
-    # validate prefix
-    if len(prefix) > 0 and not is_valid_kubernetes_resource_name(prefix):
+    # validate optional prefix
+    if len(prefix) > 0 and not is_valid_dns_subdomain_name(prefix):
         return False
 
     # validate name

--- a/elyra/util/kubernetes.py
+++ b/elyra/util/kubernetes.py
@@ -51,3 +51,34 @@ def is_valid_kubernetes_key(name: str) -> bool:
         return False
 
     return re.match(r"^[\w\-_.]+$", name) is not None
+
+
+def is_valid_annotation_key(key: str) -> bool:
+    """
+    Returns a truthy value indicating whether name meets the kubernetes
+    naming constraints for annotation keys, as outlined in the link below.
+
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+    """
+    if key is None or (len(key) == 0) or (len(key) > 253 + 1 + 63):
+        return False
+
+    parts = key.split("/")
+    if len(parts) == 1:
+        prefix = ""
+        name = parts[0]
+    elif len(parts) == 2:
+        prefix = parts[0]
+        name = parts[1]
+    else:
+        return False
+
+    # validate prefix
+    if len(prefix) > 0 and not is_valid_kubernetes_resource_name(prefix):
+        return False
+
+    # validate name
+    if len(name) > 63 or not name[0].isalnum() or not name[-1].isalnum():
+        return False
+
+    return re.match(r"^[\w\-_.]+$", name) is not None

--- a/tests/snapshots/pipeline-editor-tests/matches-complex-pipeline-snapshot.1.snap
+++ b/tests/snapshots/pipeline-editor-tests/matches-complex-pipeline-snapshot.1.snap
@@ -25,6 +25,7 @@ Object {
               ],
               "filename": "producer.ipynb",
               "include_subdirectories": false,
+              "kubernetes_pod_annotations": Array [],
               "kubernetes_secrets": Array [],
               "mounted_volumes": Array [],
               "outputs": Array [
@@ -81,6 +82,7 @@ Object {
               "env_vars": Array [],
               "filename": "consumer.ipynb",
               "include_subdirectories": false,
+              "kubernetes_pod_annotations": Array [],
               "kubernetes_secrets": Array [],
               "mounted_volumes": Array [],
               "outputs": Array [],
@@ -136,6 +138,7 @@ Object {
               "env_vars": Array [],
               "filename": "../scripts/setup.py",
               "include_subdirectories": false,
+              "kubernetes_pod_annotations": Array [],
               "kubernetes_secrets": Array [],
               "mounted_volumes": Array [],
               "outputs": Array [],
@@ -189,6 +192,7 @@ Object {
               "env_vars": Array [],
               "filename": "create-source-files.py",
               "include_subdirectories": false,
+              "kubernetes_pod_annotations": Array [],
               "kubernetes_secrets": Array [],
               "mounted_volumes": Array [],
               "outputs": Array [
@@ -245,6 +249,7 @@ Object {
               "env_vars": Array [],
               "filename": "producer-script.py",
               "include_subdirectories": false,
+              "kubernetes_pod_annotations": Array [],
               "kubernetes_secrets": Array [],
               "mounted_volumes": Array [],
               "outputs": Array [

--- a/tests/snapshots/pipeline-editor-tests/matches-simple-pipeline-snapshot.1.snap
+++ b/tests/snapshots/pipeline-editor-tests/matches-simple-pipeline-snapshot.1.snap
@@ -26,6 +26,7 @@ Object {
               ],
               "filename": "helloworld.ipynb",
               "include_subdirectories": false,
+              "kubernetes_pod_annotations": Array [],
               "kubernetes_secrets": Array [],
               "mounted_volumes": Array [],
               "outputs": Array [],


### PR DESCRIPTION
This PR adds support for [Kubernetes annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) for Kubeflow Pipelines and Apache Airflow runtime environments.

Annotations are supported for generic components and custom components and can be defined as pipeline defaults or for individual nodes.

Input needs to be entered as a string using the `annotation_key=annotation_value` format until proper UI support (https://github.com/elyra-ai/elyra/pull/2780) is released. 

Annotation keys are validated according to [this spec](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set).

Closes #2849

**Pipeline default settings in VPE**
  Displayed in section "Node defaults" (Settings in this section apply to all nodes):

   ![image](https://user-images.githubusercontent.com/13068832/183346530-0bb4d56a-9990-43f0-b5b2-93244a63cc55.png)


**Generic node setting in VPE**
 
   ![image](https://user-images.githubusercontent.com/13068832/183346747-73709331-a642-4ccb-8ef2-8c9a8133b759.png)


**Custom node setting in VPE**
Displayed in section "Additional properties"
  
   ![image](https://user-images.githubusercontent.com/13068832/183347871-70aab734-8604-4448-a0bb-f9041c816537.png)

**Applied annotations (KFP)**

Example `describe pod` output (KFP)
 ```
 $ kubectl describe pod lambda-... -n kubeflow-user-example-com
Name:         lambda-6sj47-3256227022
Namespace:    kubeflow-user-example-com
Priority:     0
Node:         cloning1.fyre.ibm.com/9.30.189.14
Start Time:   Sun, 07 Aug 2022 22:57:16 -0700
Labels:       pipeline/runid=e0b80cae-9c4b-4e89-a594-0b7c7eb55c16
              pipelines.kubeflow.org/cache_enabled=true
              pipelines.kubeflow.org/cache_id=
              pipelines.kubeflow.org/enable_caching=true
              pipelines.kubeflow.org/kfp_sdk_version=1.8.13
              pipelines.kubeflow.org/metadata_context_id=1
              pipelines.kubeflow.org/metadata_execution_id=1
              pipelines.kubeflow.org/metadata_written=true
              pipelines.kubeflow.org/pipeline-sdk-type=kfp
              workflows.argoproj.io/completed=true
              workflows.argoproj.io/workflow=lambda-6sj47
Annotations:  a-to-Z: soup to nuts
              annotationA: annotation default  A
              pipelines.kubeflow.org/arguments.parameters: {"URL": "http://www.bing.com"}
              pipelines.kubeflow.org/component_ref: {"digest": "8e4384f422a088e4814024df7955e952c1488bd091fa0d4873d5f611d741ceb4"}

 ```

**Applied annotations (Airflow)**

The applied annotations can be inspected using the `kubectl describe pod` command or in the _DAG task instance details_ page in the Airflow UI:

 ![image](https://user-images.githubusercontent.com/13068832/183418542-81752598-6f4e-4deb-a556-cfba57664fd0.png)


Notes:
  - Status (if checked, functionality is implemented and was verified):
    - [x] Pipeline editor: validation  
    - [x] KFP generic node property
    - [x] KFP custom node property
    - [x] KFP pipeline default
    - [x] Airflow generic node property
    - [x] Airflow custom node property
    - [x] Airflow pipeline default


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
- Added new optional 'Kubernetes pod annotations' pipeline default property
- Added new optional 'Kubernetes pod annotations' node property
- Updated the `user_guide/pipelines.html` documentation 
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
- Added new validation tests
- Manual testing (see scope and status in previous section)
- Reviewed output of `make docs`
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
