### PR TITLE
Add support for 'file' URI scheme to URL-based connectors

### DIFF
--- a/docs/source/user_guide/pipeline-components.md
+++ b/docs/source/user_guide/pipeline-components.md
@@ -405,7 +405,7 @@ Examples (GUI):
    ```
  - Local file URL
    ```
-   file://local/path/to/component.yaml
+   file:///absolute/path/to/component.yaml
    ```
 
 Examples (CLI):
@@ -415,7 +415,7 @@ Examples (CLI):
    ```
  - Local file URL
    ```
-   ['file://local/path/to/component.yaml']
+   ['file:///absolute/path/to/component.yaml']
    ```
  - Multiple URLs
    ```
@@ -436,7 +436,7 @@ Examples:
    ```
  - Local copy of a downloaded Apache Airflow package
    ```
-   file:///local/path/to/apache_airflow-1.10.15-py2.py3-none-any.whl
+   file:///absolute/path/to/apache_airflow-1.10.15-py2.py3-none-any.whl
    ``` 
 
 #### Apache Airflow provider package catalog
@@ -452,5 +452,5 @@ Examples:
 
  - Local copy of a downloaded provider package
    ```
-   file:///local/path/to/apache_airflow_providers_http-2.0.2-py3-none-any.whl
+   file:///absolute/path/to/apache_airflow_providers_http-2.0.2-py3-none-any.whl
    ```

--- a/docs/source/user_guide/pipeline-components.md
+++ b/docs/source/user_guide/pipeline-components.md
@@ -59,7 +59,7 @@ Elyra includes connectors for the following component catalog types:
 
    Example: A directory component catalog that is configured using the `/users/jdoe/kubeflow_components/test` path makes all component files in that directory available to Elyra.
 
- - [_URL component catalogs_](#url-component-catalog) provide access to components that are stored on the web and can be retrieved using anonymous HTTP `GET` requests.
+ - [_URL component catalogs_](#url-component-catalog) provide access to components that are stored on the web and can be retrieved using HTTP `GET` requests.
 
     Example: A URL component catalog that is configured using the `http://myserver:myport/mypath/my_component.yaml` URL makes the `my_component.yaml` component file available to Elyra.
 
@@ -395,36 +395,62 @@ Examples (CLI):
 
 The URL component catalog connector provides access to components that are stored on the web:
 - You can specify one or more URL resources.
-- The specified URLs must be retrievable using an HTTP `GET` request.
+- The specified URLs must be retrievable using an HTTP `GET` request. `http`, `https`, and `file` [URI schemes](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml) are supported.
 - If the resources are secured, provide credentials, such as a user id and password or API key.
 
 Examples (GUI):
- - `https://raw.githubusercontent.com/elyra-ai/examples/main/component-catalog-connectors/kfp-example-components-connector/kfp_examples_connector/resources/filter_text_using_shell_and_grep.yaml`
+ - HTTPS URL
+   ```
+   https://raw.githubusercontent.com/elyra-ai/examples/main/component-catalog-connectors/kfp-example-components-connector/kfp_examples_connector/resources/filter_text_using_shell_and_grep.yaml
+   ```
+ - Local file URL
+   ```
+   file://local/path/to/component.yaml
+   ```
 
 Examples (CLI):
- - `['https://raw.githubusercontent.com/elyra-ai/examples/main/component-catalog-connectors/kfp-example-components-connector/kfp_examples_connector/resources/filter_text_using_shell_and_grep.yaml']`
- - `['<URL_1>','<URL_2>']`
+ - HTTPS URL
+   ```
+   ['https://raw.githubusercontent.com/elyra-ai/examples/main/component-catalog-connectors/kfp-example-components-connector/kfp_examples_connector/resources/filter_text_using_shell_and_grep.yaml']
+   ```
+ - Local file URL
+   ```
+   ['file://local/path/to/component.yaml']
+   ```
+ - Multiple URLs
+   ```
+   ['<URL_1>','<URL_2>']
+   ```
 
 
 #### Apache Airflow package catalog
 
 The [Apache Airflow package catalog connector](https://github.com/elyra-ai/elyra/tree/main/elyra/pipeline/airflow/package_catalog_connector) provides access to operators that are stored in Apache Airflow [built distributions](https://packaging.python.org/en/latest/glossary/#term-built-distribution):
 - Only the [wheel distribution format](https://packaging.python.org/en/latest/glossary/#term-Wheel) is supported.
-- The specified URL must be retrievable using an HTTP `GET` request.
+- The specified URL must be retrievable using an HTTP `GET` request. `http`, `https`, and `file` [URI schemes](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml) are supported.
 
 Examples:
  - [Apache Airflow](https://pypi.org/project/apache-airflow/) (v1.10.15): 
    ```
    https://files.pythonhosted.org/packages/f0/3a/f5ce74b2bdbbe59c925bb3398ec0781b66a64b8a23e2f6adc7ab9f1005d9/apache_airflow-1.10.15-py2.py3-none-any.whl
+   ```
+ - Local copy of a downloaded Apache Airflow package
+   ```
+   file://local/path/to/apache_airflow-1.10.15-py2.py3-none-any.whl
    ``` 
 
 #### Apache Airflow provider package catalog
 The [Apache Airflow provider package catalog connector](https://github.com/elyra-ai/elyra/tree/main/elyra/pipeline/airflow/provider_package_catalog_connector) provides access to operators that are stored in [Apache Airflow provider packages](https://airflow.apache.org/docs/apache-airflow-providers/):
 - Only the [wheel distribution format](https://packaging.python.org/en/latest/glossary/#term-Wheel) is supported.
-- The specified URL must be retrievable using an HTTP `GET` request.
+- The specified URL must be retrievable using an HTTP `GET` request. `http`, `https`, and `file` [URI schemes](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml) are supported.
 
 Examples:
  - [apache-airflow-providers-http](https://airflow.apache.org/docs/apache-airflow-providers-http/stable/index.html) (v2.0.2): 
    ```
    https://files.pythonhosted.org/packages/a1/08/91653e9f394cbefe356ac07db809be7e69cc89b094379ad91d6cef3d2bc9/apache_airflow_providers_http-2.0.2-py3-none-any.whl
+   ```
+
+ - Local copy of a downloaded provider package
+   ```
+   file://local/path/to/apache_airflow_providers_http-2.0.2-py3-none-any.whl
    ```

--- a/docs/source/user_guide/pipeline-components.md
+++ b/docs/source/user_guide/pipeline-components.md
@@ -436,7 +436,7 @@ Examples:
    ```
  - Local copy of a downloaded Apache Airflow package
    ```
-   file://local/path/to/apache_airflow-1.10.15-py2.py3-none-any.whl
+   file:///local/path/to/apache_airflow-1.10.15-py2.py3-none-any.whl
    ``` 
 
 #### Apache Airflow provider package catalog

--- a/docs/source/user_guide/pipeline-components.md
+++ b/docs/source/user_guide/pipeline-components.md
@@ -452,5 +452,5 @@ Examples:
 
  - Local copy of a downloaded provider package
    ```
-   file://local/path/to/apache_airflow_providers_http-2.0.2-py3-none-any.whl
+   file:///local/path/to/apache_airflow_providers_http-2.0.2-py3-none-any.whl
    ```

--- a/elyra/pipeline/airflow/provider_package_catalog_connector/airflow_provider_package_catalog_connector.py
+++ b/elyra/pipeline/airflow/provider_package_catalog_connector/airflow_provider_package_catalog_connector.py
@@ -28,12 +28,13 @@ from typing import Optional
 from urllib.parse import urlparse
 import zipfile
 
-from requests import get
+from requests import session
 from requests.auth import HTTPBasicAuth
 
 from elyra.pipeline.catalog_connector import AirflowEntryData
 from elyra.pipeline.catalog_connector import ComponentCatalogConnector
 from elyra.pipeline.catalog_connector import EntryData
+from elyra.util.url import FileTransportAdapter
 
 
 class AirflowProviderPackageCatalogConnector(ComponentCatalogConnector):
@@ -79,20 +80,22 @@ class AirflowProviderPackageCatalogConnector(ComponentCatalogConnector):
             )
             return operator_key_list
 
-        # determine whether authentication needs to be performed
-        auth_id = catalog_metadata.get("auth_id")
-        auth_password = catalog_metadata.get("auth_password")
-        if auth_id and auth_password:
-            auth = HTTPBasicAuth(auth_id, auth_password)
-        elif auth_id or auth_password:
-            self.log.error(
-                f"Error. Airflow provider package connector '{catalog_metadata.get('display_name')}' "
-                "is not configured properly. "
-                "Authentication requires a user id and password or API key."
-            )
-            return operator_key_list
-        else:
-            auth = None
+        pr = urlparse(airflow_provider_package_download_url)
+        auth = None
+
+        if pr.scheme != "file":
+            # determine whether authentication needs to be performed
+            auth_id = catalog_metadata.get("auth_id")
+            auth_password = catalog_metadata.get("auth_password")
+            if auth_id and auth_password:
+                auth = HTTPBasicAuth(auth_id, auth_password)
+            elif auth_id or auth_password:
+                self.log.error(
+                    f"Error. Airflow provider package connector '{catalog_metadata.get('display_name')}' "
+                    "is not configured properly. "
+                    "Authentication requires a user id and password or API key."
+                )
+                return operator_key_list
 
         # tmp_archive_dir is used to store the downloaded archive and as working directory
         if hasattr(self, "tmp_archive_dir"):
@@ -105,7 +108,10 @@ class AirflowProviderPackageCatalogConnector(ComponentCatalogConnector):
 
             # download archive
             try:
-                response = get(
+                requests_session = session()
+                if pr.scheme == "file":
+                    requests_session.mount("file://", FileTransportAdapter())
+                response = requests_session.get(
                     airflow_provider_package_download_url,
                     timeout=AirflowProviderPackageCatalogConnector.REQUEST_TIMEOUT,
                     allow_redirects=True,

--- a/elyra/tests/pipeline/airflow/test_airflow_provider_package_connector.py
+++ b/elyra/tests/pipeline/airflow/test_airflow_provider_package_connector.py
@@ -15,7 +15,12 @@
 #
 
 import io
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from urllib.parse import urlparse
 import zipfile
+
+from requests import get
 
 from elyra.pipeline.airflow.provider_package_catalog_connector.airflow_provider_package_catalog_connector import (
     AirflowProviderPackageCatalogConnector,  # noqa: H301
@@ -85,12 +90,39 @@ def test_invalid_download_input(requests_mock):
     assert len(ce) == 0
 
 
+def test_invalid_input_get_catalog_entries():
+    """
+    Validate that AirflowProviderPackageCatalogConnector.get_catalog_entries(...) returns
+    the expected results for invalid inputs
+    """
+    apc = AirflowProviderPackageCatalogConnector(AIRFLOW_SUPPORTED_FILE_TYPES)
+
+    # Test invalid "file://" inputs ...
+    # ... input refers to a directory
+    resource_location = Path(__file__).parent / ".." / "resources" / "components"
+    resource_url = resource_location.as_uri()
+    ce = apc.get_catalog_entries(
+        {"airflow_provider_package_download_url": resource_url, "display_name": "file://is-a-dir-test"}
+    )
+    assert isinstance(ce, list), resource_url
+    assert len(ce) == 0
+
+    # ... input refers to a non-existing whl file
+    resource_location = Path(__file__).parent / ".." / "resources" / "components" / "no-such.whl"
+    resource_url = resource_location.as_uri()
+    ce = apc.get_catalog_entries(
+        {"airflow_provider_package_download_url": resource_url, "display_name": "file://no-such-file-test"}
+    )
+    assert isinstance(ce, list), resource_url
+    assert len(ce) == 0
+
+
 # -----------------------------------
 # Long running test(s)
 # ----------------------------------
 
 
-def test_http_provider_package():
+def test_valid_url_http_provider_package():
     """
     Test connector using HTTP provider package
     """
@@ -114,3 +146,46 @@ def test_http_provider_package():
     assert isinstance(ce, AirflowEntryData)
     assert ce.definition is not None
     assert ce.package_name == "airflow.providers.http.operators.http"
+
+
+def test_valid_file_http_provider_package():
+    """
+    Test connector using a local copy of the HTTP provider package
+    """
+
+    # Download the test provider package and store it in the local file system
+    resp = get(HTTP_PROVIDER_PKG_URL)
+    assert resp.status_code == 200
+
+    with TemporaryDirectory() as dirpath:
+        local_file_copy = Path(dirpath) / Path(urlparse(HTTP_PROVIDER_PKG_URL).path).name
+        with open(local_file_copy, "wb") as downloaded_package:
+            downloaded_package.write(resp.content)
+
+        local_provider_package_file_copy_url = local_file_copy.as_uri()
+
+        appc = AirflowProviderPackageCatalogConnector(AIRFLOW_SUPPORTED_FILE_TYPES)
+        # get catalog entries for the specified provider package
+        ces = appc.get_catalog_entries(
+            {
+                "airflow_provider_package_download_url": local_provider_package_file_copy_url,
+                "display_name": "file://local-provider-package",
+            }
+        )
+        # this package should contain 1 Python script with operator definitions
+        assert len(ces) == 1
+        # each entry must contain three keys
+        for entry in ces:
+            # provider package file name
+            assert entry.get("provider_package") == Path(urlparse(HTTP_PROVIDER_PKG_URL).path).name
+            # provider name
+            assert entry.get("provider") == "apache_airflow_providers_http"
+            # a Python script
+            assert entry.get("file", "").endswith(".py")
+
+        # fetch and validate the first entry
+        ce = appc.get_entry_data({"file": ces[0]["file"]}, {})
+        assert ce is not None
+        assert isinstance(ce, AirflowEntryData)
+        assert ce.definition is not None
+        assert ce.package_name == "airflow.providers.http.operators.http"

--- a/elyra/tests/pipeline/test_catalog_connector.py
+++ b/elyra/tests/pipeline/test_catalog_connector.py
@@ -1,0 +1,56 @@
+#
+# Copyright 2018-2022 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pathlib import Path
+
+from elyra.pipeline.catalog_connector import UrlComponentCatalogConnector
+
+
+def test_url_connector_valid_get_entry_data():
+    """
+    Validate that UrlComponentCatalogConnector.get_entry_data(...) returns
+    the expected results
+    """
+
+    # Test valid "file://" inputs
+    test_conn = UrlComponentCatalogConnector([".yaml"])
+    resource_location = Path(__file__).parent / "resources" / "components" / "download_data.yaml"
+    resource_url = resource_location.as_uri()
+    ed = test_conn.get_entry_data({"url": resource_url}, {"display_name": "file://is-valid-test"})
+    assert ed is not None
+    with open(resource_location, "r") as source:
+        assert ed.definition == source.read()
+
+
+def test_url_connector_invalid_get_entry_data():
+    """
+    Validate that UrlComponentCatalogConnector.get_entry_data(...) returns
+    the expected results for invalid inputs
+    """
+
+    # Test invalid "file://" inputs ...
+    # ... input refers to a directory
+    test_conn = UrlComponentCatalogConnector([".yaml"])
+    resource_location = Path(__file__).parent / "resources" / "components"
+    resource_url = resource_location.as_uri()
+    ed = test_conn.get_entry_data({"url": resource_url}, {"display_name": "file://is-a-dir-test"})
+    assert ed is None, resource_url
+
+    # ... input refers to a non-existing file
+    test_conn = UrlComponentCatalogConnector([".yaml"])
+    resource_location = Path(__file__).parent / "resources" / "components" / "no-such-file.yaml"
+    resource_url = resource_location.as_uri()
+    ed = test_conn.get_entry_data({"url": resource_url}, {"display_name": "file://no-such-file-test"})
+    assert ed is None, resource_url

--- a/elyra/tests/util/test_url.py
+++ b/elyra/tests/util/test_url.py
@@ -29,7 +29,7 @@ def test_valid_file_url():
 
     # utilize the test source code as resource
     this_file = __file__
-    url = f"file://{this_file}"
+    url = Path(this_file).as_uri()
     res = requests_session.get(url)
     assert res.status_code == 200, this_file
     with open(this_file, "r") as source:
@@ -51,21 +51,21 @@ def test_invalid_file_url():
     this_file_p = Path(__file__)
 
     # requested resource is a directory
-    url = f"file://{this_file_p.parent}"
+    url = this_file_p.parent.as_uri()
     res = requests_session.get(url)
     assert res.status_code == 400, url
     assert res.reason == "Not a file"
     assert len(res.text) == 0
 
     # requested resource wasn't found
-    url = f"file://{this_file_p.resolve().with_name('no-such-file')}"
+    url = this_file_p.resolve().with_name("no-such-file").as_uri()
     res = requests_session.get(url)
     assert res.status_code == 404, url
     assert res.reason == "File not found"
     assert len(res.text) == 0
 
     # request method is not supported
-    url = f"file://{this_file_p}"
+    url = this_file_p.as_uri()
     unsupported_methods = [
         requests_session.delete,
         requests_session.head,

--- a/elyra/tests/util/test_url.py
+++ b/elyra/tests/util/test_url.py
@@ -1,0 +1,80 @@
+#
+# Copyright 2018-2022 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pathlib import Path
+
+from requests import session
+
+from elyra.util.url import FileTransportAdapter
+
+
+def test_valid_file_url():
+    """
+    Verify that the FileTransportAdapter works as expected for valid input
+    """
+    requests_session = session()
+    requests_session.mount("file://", FileTransportAdapter())
+
+    # utilize the test source code as resource
+    this_file = __file__
+    url = f"file://{this_file}"
+    res = requests_session.get(url)
+    assert res.status_code == 200, this_file
+    with open(this_file, "r") as source:
+        assert res.text == source.read()
+
+
+def test_invalid_file_url():
+    """
+    Verify that the FileTransportAdapter works as expected for error
+    scenarios:
+     - requested resource is a directory
+     - requested resource not found
+     - request method is not 'GET'
+    """
+    requests_session = session()
+    requests_session.mount("file://", FileTransportAdapter())
+
+    # utilize the test source code as resource
+    this_file_p = Path(__file__)
+
+    # requested resource is a directory
+    url = f"file://{this_file_p.parent}"
+    res = requests_session.get(url)
+    assert res.status_code == 400, url
+    assert res.reason == "Not a file"
+    assert len(res.text) == 0
+
+    # requested resource wasn't found
+    url = f"file://{this_file_p.resolve().with_name('no-such-file')}"
+    res = requests_session.get(url)
+    assert res.status_code == 404, url
+    assert res.reason == "File not found"
+    assert len(res.text) == 0
+
+    # request method is not supported
+    url = f"file://{this_file_p}"
+    unsupported_methods = [
+        requests_session.delete,
+        requests_session.head,
+        requests_session.options,
+        requests_session.patch,
+        requests_session.post,
+        requests_session.put,
+    ]
+    for unsupported_method in unsupported_methods:
+        res = unsupported_method(url)
+        assert res.status_code == 405, url
+        assert res.reason == "Method not allowed"

--- a/elyra/util/url.py
+++ b/elyra/util/url.py
@@ -1,0 +1,65 @@
+#
+# Copyright 2018-2022 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pathlib import Path
+from urllib.request import url2pathname
+
+from requests import Response
+from requests.adapters import BaseAdapter
+
+
+class FileTransportAdapter(BaseAdapter):
+    """
+    File Transport Adapter for the requests library. Use this
+    adapter to enable the requests library to load a resource
+    from the 'file' schema using HTTP 'GET'.
+    """
+
+    def send(self, req, **kwargs):
+        """
+        Return the file specified by the given request
+        """
+
+        response = Response()
+        response.request = req
+        response.connection = self
+        if isinstance(req.url, bytes):
+            response.url = req.url.decode("utf-8")
+        else:
+            response.url = req.url
+
+        if req.method.lower() not in ["get"]:
+            response.status_code = 405
+            response.reason = "Method not allowed"
+            return response
+
+        p = Path(url2pathname(req.path_url))
+        if p.is_dir():
+            response.status_code = 400
+            response.reason = "Not a file"
+            return response
+        elif not p.is_file():
+            response.status_code = 404
+            response.reason = "File not found"
+            return response
+
+        with open(p, "rb") as fh:
+            response.status_code = 200
+            response._content = fh.read()
+
+        return response
+
+    def close(self):
+        pass


### PR DESCRIPTION
Closes #2872
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
The built-in URL catalog connector, Apache Airflow package connector, and the Apache Airflow provider package connectors now support input of a URL that uses the [`file` URI scheme](https://en.wikipedia.org/wiki/File_URI_scheme) in addition to the  already supported `HTTP` and `HTTPS` schemes. No changes to the UI or validation are required.

The behavior is as follows:
 - no changes if the user enters an HTTP-based URL
 - user enters a URL that identifies an existing local file name (e.g. `file://path/to/file`) -> HTTP status code 200
 - user enters a URL that identifies an existing local directory name (e.g. `file://i/am/a/dir`) -> HTTP status code 400 (invalid input)
 - user enters a URL that identifies a non-existing local file name (e.g. `file://no/such/file`) -> HTTP status code 404 (not found)
- URL connector: If a file-scheme URL is entered, the pipeline file is not portable because the complete URL is stored (`file://path/to/file`) just like it is done for the filesystem connector when bo base directory is specified.
- Airflow package connector: If a file-scheme URL is entered, the pipeline file is portable because the file path is not stored. (The stored metadata is identical to the metadata that is stored if an HTTP-based URL is entered. )
- Airflow provider package connector: If a file-scheme URL is entered, the pipeline file is portable because the file path is not stored. (The stored metadata is identical to the metadata that is stored if an HTTP-based URL is entered.)


<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
- Reviewed the output of `make docs` (`user_guide/pipeline-components.html`)
- Added/updated server tests for new utility function/connectors
- Tested the following scenarios
   - URL connector
       - configure connector using valid `file://absolute/path/to/file.whl` URL
       - configure connector using invalid `file://absolute/path/to/no-such-file.whl` URL (specifying a file that does not exist)
       - configure connector using invalid `file://absolute/path/to/dir` URL (specifying an existing directory)
   - Apache Airflow package catalog connector
       - configure connector using valid `file://absolute/path/to/file.whl` URL
       - configure connector using invalid `file://absolute/path/to/no-such-file.whl` URL  (specifying a file that does not exist)
       - configure connector using invalid `file://absolute/path/to/dir` URL (specifying an existing directory)
   - Apache Airflow provider package catalog connector
       - configure connector using valid `file://absolute/path/to/file.whl` URL
       - configure connector using invalid `file://absolute/path/to/no-such-file.whl` URL  (specifying a file that does not exist)
       - configure connector using invalid `file://absolute/path/to/dir` URL (specifying an existing directory)
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
