### PR TITLE
Add support for COS public endpoint to Kubeflow Pipelines runtime config

### DIFF
--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -323,6 +323,13 @@ This should be the URL address of your S3-compatible Object Storage. If running 
 
 Example: `https://minio-service.kubeflow:9000`
 
+##### Public Cloud Object Storage endpoint (public_cos_endpoint)
+
+If the `Cloud Object Storage endpoint` setting identifies a URL that can only be resolved within the kubernetes cluster, Elyra cannot generate valid links to the object storage page. 
+If your instalation requires a different public URL specify it as `Public Cloud Object Storage endpoint`.
+
+Example: `https://public-kubernetes-service-url/storage`
+
 ##### Cloud Object Storage bucket name (cos_bucket)
 
 Name of the bucket you want Elyra to store pipeline artifacts in. This setting is required. If the bucket doesn't exist, it will be created. The specified bucket name must meet the naming conventions imposed by the Object Storage service.

--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -325,8 +325,8 @@ Example: `https://minio-service.kubeflow:9000`
 
 ##### Public Cloud Object Storage endpoint (public_cos_endpoint)
 
-If the `Cloud Object Storage endpoint` setting identifies a URL that can only be resolved within the kubernetes cluster, Elyra cannot generate valid links to the object storage page. 
-If your instalation requires a different public URL specify it as `Public Cloud Object Storage endpoint`.
+If the `Cloud Object Storage endpoint` setting identifies a URL that can only be resolved within the Kubernetes cluster, Elyra cannot generate valid links to the object storage page. 
+If your installation requires a different public URL specify it as `Public Cloud Object Storage endpoint`.
 
 Example: `https://public-kubernetes-service-url/storage`
 

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -120,7 +120,7 @@
             "ui:placeholder": "https://your-cos-service:port"
           }
         },
-        "cos_public_endpoint": {
+        "public_cos_endpoint": {
           "title": "Public Cloud Object Storage Endpoint",
           "description": "The public Cloud Object Storage endpoint",
           "type": "string",

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -120,6 +120,16 @@
             "ui:placeholder": "https://your-cos-service:port"
           }
         },
+        "cos_public_endpoint": {
+          "title": "Public Cloud Object Storage Endpoint",
+          "description": "The public Cloud Object Storage endpoint",
+          "type": "string",
+          "format": "uri",
+          "uihints": {
+            "category": "Cloud Object Storage",
+            "ui:placeholder": "https://your-public-cos-endpoint:port"
+          }
+        },
         "cos_bucket": {
           "title": "Cloud Object Storage Bucket Name",
           "description": "The Cloud Object Storage bucket name",

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -101,6 +101,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
 
         # unpack Cloud Object Storage configs
         cos_endpoint = runtime_configuration.metadata["cos_endpoint"]
+        cos_public_endpoint = runtime_configuration.metadata.get("cos_public_endpoint", cos_endpoint)
         cos_bucket = runtime_configuration.metadata["cos_bucket"]
 
         # Determine which provider to use to authenticate with Kubeflow
@@ -362,7 +363,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
             )
 
         if pipeline.contains_generic_operations():
-            object_storage_url = f"{cos_endpoint}"
+            object_storage_url = f"{cos_public_endpoint}"
             os_path = join_paths(pipeline.pipeline_parameters.get(COS_OBJECT_PREFIX), pipeline_instance_id)
             object_storage_path = f"/{cos_bucket}/{os_path}"
         else:

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -101,7 +101,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
 
         # unpack Cloud Object Storage configs
         cos_endpoint = runtime_configuration.metadata["cos_endpoint"]
-        cos_public_endpoint = runtime_configuration.metadata.get("cos_public_endpoint", cos_endpoint)
+        cos_public_endpoint = runtime_configuration.metadata.get("public_cos_endpoint", cos_endpoint)
         cos_bucket = runtime_configuration.metadata["cos_bucket"]
 
         # Determine which provider to use to authenticate with Kubeflow

--- a/packages/pipeline-editor/src/RuntimesWidget.tsx
+++ b/packages/pipeline-editor/src/RuntimesWidget.tsx
@@ -64,7 +64,7 @@ class RuntimesDisplay extends MetadataDisplay<
 > {
   renderExpandableContent(metadata: IDictionary<any>): JSX.Element {
     let apiEndpoint = addTrailingSlash(metadata.metadata.api_endpoint);
-    const cosEndpoint = addTrailingSlash(metadata.metadata.cos_endpoint);
+    let cosEndpoint = addTrailingSlash(metadata.metadata.cos_endpoint);
 
     let githubRepoElement = null;
     let metadata_props = null;
@@ -97,6 +97,11 @@ class RuntimesDisplay extends MetadataDisplay<
       if (metadata.metadata.public_api_endpoint) {
         // user specified a public API endpoint. use it instead of the API endpoint
         apiEndpoint = addTrailingSlash(metadata.metadata.public_api_endpoint);
+      }
+
+      if (metadata.metadata.public_cos_endpoint) {
+        // user specified a public COS endpoint. use it instead of the API endpoint
+        cosEndpoint = addTrailingSlash(metadata.metadata.public_cos_endpoint);
       }
     }
 

--- a/tests/support/commands.ts
+++ b/tests/support/commands.ts
@@ -80,7 +80,7 @@ Cypress.Commands.add('createRuntimeConfig', ({ type } = {}): void => {
     );
   }
 
-  cy.findByLabelText(/object storage .* endpoint\*/i).type(
+  cy.findByLabelText(/^cloud object storage endpoint/i).type(
     'http://0.0.0.0:9000'
   );
   cy.findByLabelText(/object storage username/i).type('minioadmin');

--- a/tests/support/commands.ts
+++ b/tests/support/commands.ts
@@ -80,7 +80,9 @@ Cypress.Commands.add('createRuntimeConfig', ({ type } = {}): void => {
     );
   }
 
-  cy.findByLabelText(/object storage endpoint/i).type('http://0.0.0.0:9000');
+  cy.findByLabelText(/object storage .* endpoint\*/i).type(
+    'http://0.0.0.0:9000'
+  );
   cy.findByLabelText(/object storage username/i).type('minioadmin');
   cy.findByLabelText(/object storage password/i).type('minioadmin');
   cy.findByLabelText(/object storage bucket/i).type('test-bucket');


### PR DESCRIPTION
### What changes were proposed in this pull request?

This aims to introduce a new property to configure the public endpoint for the Cloud Objecte Storage if necessary.

In some cases (ours for example) we run separate services with separate policies for access, so we use a private endpoint for the API (which normally writes or it's meant to be used by automated components) and a public endpoint only for read that is meant to be provided to the user.

This is the result of this change

![Screenshot 2022-08-12 at 13 14 15](https://user-images.githubusercontent.com/1502403/184351954-df82489d-1559-4b0c-91c2-f808f4ac3f7e.png)


### How was this pull request tested?

This change is very easy, no "new logic", well apart of creating a variable that tries to get the configured value from the runtime configuration an if doesn't exists uses the API endpoint that is mandatory.

Make sure that the pre change works well:
- create a runtime configuration without public endpoint configured
- run pipeline
- click on the `object storage` link and open the private one

Make sure that the new public endpoint works
- create a runtime configuration with public endpoint
- - run pipeline
- click on the `object storage` link and open the public one
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
