### PR TITLE
Remove .ONESHELL Makefile directive so multi-step targets properly fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,6 @@
 .PHONY: elyra-image elyra-image-env publish-elyra-image kf-notebook-image publish-kf-notebook-image
 .PHONY: container-images publish-container-images validate-runtime-image validate-runtime-images
 
-.ONESHELL:
-
 SHELL:=/bin/bash
 
 # Container execs


### PR DESCRIPTION
#2886 documents an issue where the `lint-server` Makefile target does not stop when the `flake8` portion of the multi-step target encounters a non-zero exit code.  Based on initial investigation, there appears to have been a change in behavior between GNU `make` 3.81 (which I, and probably others, use on our desktops) and 4.2.1 (which is used in CI, with 4.3 being the latest).  In versions < 4, the multi-step targets will stop on non-zero exit status, but with versions < 4, that is not the case.

It turns out that the `.ONESHELL` directive was causing this issue - which makes sense - because only the last command of the target is the status that is checked.  Not sure why 3.x versions work - perhaps they don't properly support `.ONESHELL`.

At any rate, `.ONESHELL` was added in #2721 and there's no mention during the review as to why.  I have confirmed appropriate behavior without the directive so perhaps the reason for it is no longer present or it was thought to be an improvement - especially since desktop builds were still behaving okay.  Since this is a fairly serious issue, we should move forward without `.ONESHELL` and tackle any related issues of that when they come up.

Resolves #2886 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
