### PR TITLE
Enable debugger on kernel change

### DIFF
--- a/packages/script-debugger/src/index.ts
+++ b/packages/script-debugger/src/index.ts
@@ -93,10 +93,8 @@ const scriptEditorDebuggerExtension: JupyterFrontEndPlugin<void> = {
             activeSessions[sessionModel.id] = sessionConnection;
           }
           if (sessionModel.kernel?.name !== kernelSelection) {
-            // New kernel selection detected, restart session connection for new kernel
-            await shutdownSession(sessionConnection);
-
-            sessionConnection = await startSession(kernelSelection, path);
+            // New kernel selection detected, update session connection
+            await changeKernel(sessionConnection, kernelSelection);
             sessionModel = await sessions.findByPath(path);
             if (sessionConnection && sessionModel) {
               activeSessions[sessionModel.id] = sessionConnection;
@@ -177,15 +175,16 @@ const scriptEditorDebuggerExtension: JupyterFrontEndPlugin<void> = {
       return sessionConnection;
     };
 
-    const shutdownSession = async (
-      sessionConnection: Session.ISessionConnection
+    const changeKernel = async (
+      sessionConnection: Session.ISessionConnection,
+      kernelSelection: string
     ): Promise<void> => {
       try {
-        const kernelName = sessionConnection.kernel?.name;
-        await sessionConnection.shutdown();
-        console.log(`${kernelName} kernel shut down.`);
+        const prev = sessionConnection.kernel?.name;
+        await sessionConnection.changeKernel({ name: kernelSelection });
+        console.log(`Kernel change from ${prev} to ${kernelSelection}`);
       } catch (error) {
-        console.warn('Exception: shutdown = ' + JSON.stringify(error));
+        console.warn('Exception: change kernel = ' + JSON.stringify(error));
       }
     };
   }

--- a/packages/script-editor/src/ScriptEditorController.ts
+++ b/packages/script-editor/src/ScriptEditorController.ts
@@ -75,13 +75,18 @@ export class ScriptEditorController {
       return kernelSpecs.default;
     }
 
+    return this.getFirstKernelName(language);
+  };
+
+  getFirstKernelName = async (language: string): Promise<string> => {
     const specsByLang = await this.getKernelSpecsByLanguage(language);
-    const first = (k: any): any => k[Object.keys(k)[0]];
-    let kernelName = '';
+
+    const empty = '';
     if (specsByLang && Object.keys(specsByLang.kernelspecs).length !== 0) {
-      kernelName = first(specsByLang.kernelspecs.name);
+      const [key, value]: any = Object.entries(specsByLang.kernelspecs)[0];
+      return value.name ?? key;
     }
-    return kernelName;
+    return empty;
   };
 
   /**

--- a/packages/script-editor/src/ScriptRunner.ts
+++ b/packages/script-editor/src/ScriptRunner.ts
@@ -203,6 +203,7 @@ export class ScriptRunner {
         kernel &&
           (await KernelAPI.interruptKernel(kernel.id, kernel.serverSettings));
         console.log(kernel?.name + ' kernel interrupted.');
+        this.disableButton(false);
       } catch (e) {
         console.log('Exception: kernel interrupt = ' + JSON.stringify(e));
       }

--- a/packages/script-editor/src/test/script-editor.spec.ts
+++ b/packages/script-editor/src/test/script-editor.spec.ts
@@ -18,6 +18,7 @@ import { JupyterServer } from '@jupyterlab/testutils';
 
 import { ScriptEditorController } from '../ScriptEditorController';
 import { ScriptRunner } from '../ScriptRunner';
+
 jest.setTimeout(3 * 60 * 1000);
 
 const server = new JupyterServer();
@@ -33,29 +34,28 @@ afterAll(async () => {
 
 describe('@elyra/script-editor', () => {
   describe('ScriptEditorController', () => {
+    let controller: ScriptEditorController;
+
+    beforeEach(async () => {
+      controller = new ScriptEditorController();
+    });
+
     describe('#kernelSpecs', () => {
-      let controller: ScriptEditorController;
-      let kernelName: string;
-
-      beforeEach(async () => {
-        controller = new ScriptEditorController();
-        kernelName = await controller.getDefaultKernel(language);
-      });
-
       it('should get Python kernel specs', async () => {
         const kernelSpecs = await controller.getKernelSpecsByLanguage(language);
-        for (const [key, value] of Object.entries(
-          kernelSpecs?.kernelspecs ?? []
-        )) {
-          expect(key).toContain(language);
-          expect(value?.language).toContain(language);
-        }
+        Object.entries(kernelSpecs?.kernelspecs ?? []).forEach(([, value]) =>
+          expect(value?.language).toContain(language)
+        );
       });
+    });
 
-      it('default kernel should have debugger available', async () => {
-        const available = await controller.debuggerAvailable(kernelName);
-        expect(kernelName).toContain(language);
+    describe('#debuggerAvailable', () => {
+      it('should return true for kernels that have support for debugging', async () => {
+        let available = await controller.debuggerAvailable('python3');
         expect(available).toBe(true);
+
+        available = await controller.debuggerAvailable('test');
+        expect(available).toBe(false);
       });
     });
   });
@@ -69,9 +69,7 @@ describe('@elyra/script-editor', () => {
       beforeEach(async () => {
         runner = new ScriptRunner((x: boolean): void => console.log(x));
         const controller = new ScriptEditorController();
-        const kernelSpecs = await controller.getKernelSpecsByLanguage(language);
-        kernelName =
-          Object.values(kernelSpecs?.kernelspecs ?? [])[0]?.name || '';
+        kernelName = await controller.getDefaultKernel(language);
       });
 
       it('should start a kernel session', async () => {

--- a/packages/script-editor/src/test/script-editor.spec.ts
+++ b/packages/script-editor/src/test/script-editor.spec.ts
@@ -33,9 +33,16 @@ afterAll(async () => {
 
 describe('@elyra/script-editor', () => {
   describe('ScriptEditorController', () => {
-    describe('#getKernelSpecs', () => {
+    describe('#kernelSpecs', () => {
+      let controller: ScriptEditorController;
+      let kernelName: string;
+
+      beforeEach(async () => {
+        controller = new ScriptEditorController();
+        kernelName = await controller.getDefaultKernel(language);
+      });
+
       it('should get Python kernel specs', async () => {
-        const controller = new ScriptEditorController();
         const kernelSpecs = await controller.getKernelSpecsByLanguage(language);
         for (const [key, value] of Object.entries(
           kernelSpecs?.kernelspecs ?? []
@@ -43,6 +50,12 @@ describe('@elyra/script-editor', () => {
           expect(key).toContain(language);
           expect(value?.language).toContain(language);
         }
+      });
+
+      it('default kernel should have debugger available', async () => {
+        const available = await controller.debuggerAvailable(kernelName);
+        expect(kernelName).toContain(language);
+        expect(available).toBe(true);
       });
     });
   });


### PR DESCRIPTION
Fixes #2902 : Changing kernels disables debugging
With this fix, changing the kernel selection to any kernel that supports debugging enables the debug button accordingly.
![change-kernel-fix](https://user-images.githubusercontent.com/25207344/186267457-4535a1a5-eb89-4c72-9a99-f17bc6c5e020.gif)

### What changes were proposed in this pull request?
On kernel change, the kernel was shutdown and restarted, although the debugger service and handlers were not updated for some reason.
A simpler solution was to use the `changeKernel` method instead of `shutdown` then `startKernel`.

Other enhancements:
- Reset run button state after interrupting kernel
- Better handle default kernel selection (not to assume there is a language match with the name property)

### How was this pull request tested?
- Added unit tests for default kernel selection + debugging support

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
