### PR TITLE
Support not publicly trusted certificates in built-in component catalog connectors

### DIFF
--- a/docs/source/user_guide/pipeline-components.md
+++ b/docs/source/user_guide/pipeline-components.md
@@ -397,6 +397,7 @@ The URL component catalog connector provides access to components that are store
 - You can specify one or more URL resources.
 - The specified URLs must be retrievable using an HTTP `GET` request. `http`, `https`, and `file` [URI schemes](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml) are supported.
 - If the resources are secured, provide credentials, such as a user id and password or API key.
+- In secured environments where SSL server authenticity can only be validated using certificates based on private public key infrastructure (PKI) with root and optionally intermediate certificate authorities (CAs) that are not publicly trusted, you must define environment variable `TRUSTED_CA_BUNDLE_PATH` in the environment where JupyterLab/Elyra is running. The variable value must identify an existing [Privacy-Enhanced Mail (PEM) file](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail).
 
 Examples (GUI):
  - HTTPS URL
@@ -428,6 +429,7 @@ Examples (CLI):
 The [Apache Airflow package catalog connector](https://github.com/elyra-ai/elyra/tree/main/elyra/pipeline/airflow/package_catalog_connector) provides access to operators that are stored in Apache Airflow [built distributions](https://packaging.python.org/en/latest/glossary/#term-built-distribution):
 - Only the [wheel distribution format](https://packaging.python.org/en/latest/glossary/#term-Wheel) is supported.
 - The specified URL must be retrievable using an HTTP `GET` request. `http`, `https`, and `file` [URI schemes](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml) are supported.
+- In secured environments where SSL server authenticity can only be validated using certificates based on private public key infrastructure (PKI) with root and optionally intermediate certificate authorities (CAs) that are not publicly trusted, you must define environment variable `TRUSTED_CA_BUNDLE_PATH` in the environment where JupyterLab/Elyra is running. The variable value must identify an existing [Privacy-Enhanced Mail (PEM) file](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail).
 
 Examples:
  - [Apache Airflow](https://pypi.org/project/apache-airflow/) (v1.10.15): 
@@ -443,6 +445,7 @@ Examples:
 The [Apache Airflow provider package catalog connector](https://github.com/elyra-ai/elyra/tree/main/elyra/pipeline/airflow/provider_package_catalog_connector) provides access to operators that are stored in [Apache Airflow provider packages](https://airflow.apache.org/docs/apache-airflow-providers/):
 - Only the [wheel distribution format](https://packaging.python.org/en/latest/glossary/#term-Wheel) is supported.
 - The specified URL must be retrievable using an HTTP `GET` request. `http`, `https`, and `file` [URI schemes](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml) are supported.
+- In secured environments where SSL server authenticity can only be validated using certificates based on private public key infrastructure (PKI) with root and optionally intermediate certificate authorities (CAs) that are not publicly trusted, you must define environment variable `TRUSTED_CA_BUNDLE_PATH` in the environment where JupyterLab/Elyra is running. The variable value must identify an existing [Privacy-Enhanced Mail (PEM) file](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail).
 
 Examples:
  - [apache-airflow-providers-http](https://airflow.apache.org/docs/apache-airflow-providers-http/stable/index.html) (v2.0.2): 

--- a/elyra/pipeline/airflow/package_catalog_connector/airflow_package_catalog_connector.py
+++ b/elyra/pipeline/airflow/package_catalog_connector/airflow_package_catalog_connector.py
@@ -33,6 +33,7 @@ from elyra.pipeline.catalog_connector import AirflowEntryData
 from elyra.pipeline.catalog_connector import ComponentCatalogConnector
 from elyra.pipeline.catalog_connector import EntryData
 from elyra.util.url import FileTransportAdapter
+from elyra.util.url import get_verify_parm
 
 
 class AirflowPackageCatalogConnector(ComponentCatalogConnector):
@@ -111,6 +112,7 @@ class AirflowPackageCatalogConnector(ComponentCatalogConnector):
                     timeout=AirflowPackageCatalogConnector.REQUEST_TIMEOUT,
                     allow_redirects=True,
                     auth=auth,
+                    verify=get_verify_parm(),
                 )
             except Exception as ex:
                 self.log.error(

--- a/elyra/pipeline/airflow/provider_package_catalog_connector/airflow_provider_package_catalog_connector.py
+++ b/elyra/pipeline/airflow/provider_package_catalog_connector/airflow_provider_package_catalog_connector.py
@@ -35,6 +35,7 @@ from elyra.pipeline.catalog_connector import AirflowEntryData
 from elyra.pipeline.catalog_connector import ComponentCatalogConnector
 from elyra.pipeline.catalog_connector import EntryData
 from elyra.util.url import FileTransportAdapter
+from elyra.util.url import get_verify_parm
 
 
 class AirflowProviderPackageCatalogConnector(ComponentCatalogConnector):
@@ -116,6 +117,7 @@ class AirflowProviderPackageCatalogConnector(ComponentCatalogConnector):
                     timeout=AirflowProviderPackageCatalogConnector.REQUEST_TIMEOUT,
                     allow_redirects=True,
                     auth=auth,
+                    verify=get_verify_parm(),
                 )
             except Exception as ex:
                 self.log.error(

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -42,6 +42,7 @@ from elyra.pipeline.component import Component
 from elyra.pipeline.component import ComponentParameter
 from elyra.pipeline.runtime_type import RuntimeProcessorType
 from elyra.util.url import FileTransportAdapter
+from elyra.util.url import get_verify_parm
 
 
 class EntryData(object):
@@ -664,6 +665,7 @@ class UrlComponentCatalogConnector(ComponentCatalogConnector):
                 timeout=UrlComponentCatalogConnector.REQUEST_TIMEOUT,
                 allow_redirects=True,
                 auth=auth,
+                verify=get_verify_parm(),
             )
         except Exception as e:
             self.log.error(

--- a/elyra/tests/util/test_url.py
+++ b/elyra/tests/util/test_url.py
@@ -86,31 +86,46 @@ def test_invalid_file_url():
 @pytest.fixture
 def setup_env_vars():
     # runs before test (save the value of environment variable
-    # CA_CERT_BUNDLE_PATH to avoid any contamination by tests
+    # TRUSTED_CA_BUNDLE_PATH to avoid any contamination by tests
     # that modify it)
-    current_ca_cert_bundle_path_value = os.environ.get("CA_CERT_BUNDLE_PATH")
+    current_TRUSTED_CA_BUNDLE_PATH_value = os.environ.get("TRUSTED_CA_BUNDLE_PATH")
     yield
     # runs after test (restore the value of environment variable
-    # CA_CERT_BUNDLE_PATH, if it was defined)
-    if current_ca_cert_bundle_path_value is not None:
-        os.environ["CA_CERT_BUNDLE_PATH"] = current_ca_cert_bundle_path_value
+    # TRUSTED_CA_BUNDLE_PATH, if it was defined)
+    if current_TRUSTED_CA_BUNDLE_PATH_value is not None:
+        os.environ["TRUSTED_CA_BUNDLE_PATH"] = current_TRUSTED_CA_BUNDLE_PATH_value
 
 
 @pytest.mark.usefixtures("setup_env_vars")
-def test_get_verify_parm():
+def test_valid_get_verify_parm():
     """
     Verify that method get_verify_parm works as expected:
-     - env variable CA_CERT_BUNDLE_PATH is defined
-     - env variable CA_CERT_BUNDLE_PATH is not defined, but a default is specified
-     - env variable CA_CERT_BUNDLE_PATH is not defined and no default is specified
+     - env variable TRUSTED_CA_BUNDLE_PATH is defined
+     - env variable TRUSTED_CA_BUNDLE_PATH is not defined, but a default is specified
+     - env variable TRUSTED_CA_BUNDLE_PATH is not defined and no default is specified
     """
-    test_ca_cert_bundle_path_value = "/path/to/cert/bundle"
-    os.environ["CA_CERT_BUNDLE_PATH"] = test_ca_cert_bundle_path_value
-    assert get_verify_parm() == test_ca_cert_bundle_path_value
-    del os.environ["CA_CERT_BUNDLE_PATH"]
+    test_TRUSTED_CA_BUNDLE_PATH_value = "/path/to/cert/bundle"
+    os.environ["TRUSTED_CA_BUNDLE_PATH"] = test_TRUSTED_CA_BUNDLE_PATH_value
+    assert get_verify_parm() == test_TRUSTED_CA_BUNDLE_PATH_value
+    del os.environ["TRUSTED_CA_BUNDLE_PATH"]
     # set explicit default
     assert get_verify_parm(False) is False
     # set explicit default
     assert get_verify_parm(True) is True
     # use implicit default
+    assert get_verify_parm() is True
+
+
+@pytest.mark.usefixtures("setup_env_vars")
+def test_invalid_get_verify_parm():
+    """
+    Verify that method get_verify_parm works as if environment variable
+    TRUSTED_CA_BUNDLE_PATH contains an invalid value
+    """
+    test_TRUSTED_CA_BUNDLE_PATH_value = ""
+    os.environ["TRUSTED_CA_BUNDLE_PATH"] = test_TRUSTED_CA_BUNDLE_PATH_value
+    assert get_verify_parm() is True
+
+    test_TRUSTED_CA_BUNDLE_PATH_value = "   "
+    os.environ["TRUSTED_CA_BUNDLE_PATH"] = test_TRUSTED_CA_BUNDLE_PATH_value
     assert get_verify_parm() is True

--- a/elyra/tests/util/test_url.py
+++ b/elyra/tests/util/test_url.py
@@ -13,11 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
 from pathlib import Path
 
+import pytest
 from requests import session
 
 from elyra.util.url import FileTransportAdapter
+from elyra.util.url import get_verify_parm
 
 
 def test_valid_file_url():
@@ -78,3 +81,36 @@ def test_invalid_file_url():
         res = unsupported_method(url)
         assert res.status_code == 405, url
         assert res.reason == "Method not allowed"
+
+
+@pytest.fixture
+def setup_env_vars():
+    # runs before test (save the value of environment variable
+    # CA_CERT_BUNDLE_PATH to avoid any contamination by tests
+    # that modify it)
+    current_ca_cert_bundle_path_value = os.environ.get("CA_CERT_BUNDLE_PATH")
+    yield
+    # runs after test (restore the value of environment variable
+    # CA_CERT_BUNDLE_PATH, if it was defined)
+    if current_ca_cert_bundle_path_value is not None:
+        os.environ["CA_CERT_BUNDLE_PATH"] = current_ca_cert_bundle_path_value
+
+
+@pytest.mark.usefixtures("setup_env_vars")
+def test_get_verify_parm():
+    """
+    Verify that method get_verify_parm works as expected:
+     - env variable CA_CERT_BUNDLE_PATH is defined
+     - env variable CA_CERT_BUNDLE_PATH is not defined, but a default is specified
+     - env variable CA_CERT_BUNDLE_PATH is not defined and no default is specified
+    """
+    test_ca_cert_bundle_path_value = "/path/to/cert/bundle"
+    os.environ["CA_CERT_BUNDLE_PATH"] = test_ca_cert_bundle_path_value
+    assert get_verify_parm() == test_ca_cert_bundle_path_value
+    del os.environ["CA_CERT_BUNDLE_PATH"]
+    # set explicit default
+    assert get_verify_parm(False) is False
+    # set explicit default
+    assert get_verify_parm(True) is True
+    # use implicit default
+    assert get_verify_parm() is True

--- a/elyra/util/url.py
+++ b/elyra/util/url.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
 from pathlib import Path
+from typing import Union
 from urllib.request import url2pathname
 
 from requests import Response
@@ -63,3 +65,16 @@ class FileTransportAdapter(BaseAdapter):
 
     def close(self):
         pass
+
+
+def get_verify_parm(default: bool = True) -> Union[bool, str]:
+    """
+    Returns a value for the 'verify' parameter of the requests.request
+    method (https://requests.readthedocs.io/en/latest/api/). The value
+    is determined as follows: if environment variable CA_CERT_BUNDLE_PATH
+    is defined, use its value, otherwise return the default value.
+    """
+    if os.environ.get("CA_CERT_BUNDLE_PATH"):
+        return os.environ.get("CA_CERT_BUNDLE_PATH")
+
+    return default

--- a/elyra/util/url.py
+++ b/elyra/util/url.py
@@ -71,10 +71,10 @@ def get_verify_parm(default: bool = True) -> Union[bool, str]:
     """
     Returns a value for the 'verify' parameter of the requests.request
     method (https://requests.readthedocs.io/en/latest/api/). The value
-    is determined as follows: if environment variable CA_CERT_BUNDLE_PATH
+    is determined as follows: if environment variable TRUSTED_CA_BUNDLE_PATH
     is defined, use its value, otherwise return the default value.
     """
-    if os.environ.get("CA_CERT_BUNDLE_PATH"):
-        return os.environ.get("CA_CERT_BUNDLE_PATH")
+    if len(os.environ.get("TRUSTED_CA_BUNDLE_PATH", "").strip()) > 0:
+        return os.environ.get("TRUSTED_CA_BUNDLE_PATH")
 
     return default


### PR DESCRIPTION
This PR enables administrators/users to utilize the HTTP-based built-in catalog connectors ([URL catalog](https://elyra.readthedocs.io/en/latest/user_guide/pipeline-components.html#url-component-catalog), [Apache Airflow package connector](https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html#apache-airflow-package-catalog), [Apache Airflow provider package connector](https://elyra.readthedocs.io/en/stable/user_guide/pipeline-components.html#apache-airflow-provider-package-catalog)) in in secured environments where SSL server authenticity can only be validated using certificates based on private public key infrastructure (PKI) with root and optionally intermediate certificate authorities (CAs) that are not publicly trusted. To accomplish the goal a new environment variable `TRUSTED_CA_BUNDLE_PATH` is introduced, which the built-in catalog connectors utilize as input. See #2797 for motivation. 

- Other URL-based connectors such as the [Artifactory connector](https://github.com/elyra-ai/examples/tree/main/component-catalog-connectors/artifactory-connector) and the [MLX connector](https://github.com/elyra-ai/examples/tree/main/component-catalog-connectors/mlx-connector) can be enabled in the future by adding https://github.com/elyra-ai/elyra/pull/2912/files#diff-c1e598e1c49c4e714cfc557209f7b1a2ac60d0e5c18e2a0e6528a1bdda1f805dR36 and https://github.com/elyra-ai/elyra/pull/2912/files#diff-c1e598e1c49c4e714cfc557209f7b1a2ac60d0e5c18e2a0e6528a1bdda1f805dR115.
- This PR intentionally does not impose how the environment variable is defined because the best approach depends on how JupyterLab/Elyra is deployed.
- This PR does not support defining custom certificate locations for individual catalog connector instances (meaning, for example, connector instance A uses one certificate and connector instance B uses another certificate). This could be accomplished by extending the catalog connectors to include an additional property, but would result in more work for users because the certificate location would have to be entered manually for every catalog connector instance.
- Even though the `get_verify_parm` method in `elyra/util/url.py` currently only utilizes a proprietary environment variable `TRUSTED_CA_BUNDLE_PATH` to obtain the local filesystem location for certificates, the intention is to perhaps extend this in the future to also take into account other inputs that might already be defined. A hypothetical example is a JupyterLab configuration setting that might serve a similar purpose.

Closes #2797

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
 - See above
 - Updated the connector documentation in the 'pipeline components' topic in the user guide.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
 - Added tests for new utility method (`pytest -v elyra/tests/util/test_url.py`)
 - Reviewed the output of `make docs`
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
