### PR TITLE
Move CLI component cache build to occur before pre-processing

### DIFF
--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -303,13 +303,10 @@ def validate(pipeline_path, runtime_config="local"):
     print_banner("Elyra Pipeline Validation")
 
     runtime = _get_runtime_schema_name(runtime_config)
-
-    pipeline_definition = _preprocess_pipeline(pipeline_path, runtime=runtime, runtime_config=runtime_config)
-
-    pipeline_runtime_type = _get_pipeline_runtime_type(pipeline_definition)
-    if pipeline_runtime_type:
+    if runtime != "local":
         _build_component_cache()
 
+    pipeline_definition = _preprocess_pipeline(pipeline_path, runtime=runtime, runtime_config=runtime_config)
     try:
         _validate_pipeline_definition(pipeline_definition)
     except Exception:
@@ -364,17 +361,13 @@ def submit(json_option, pipeline_path, runtime_config_name, monitor_option, time
     print_banner("Elyra Pipeline Submission")
 
     runtime_config = _get_runtime_config(runtime_config_name)
-
     runtime_schema = runtime_config.schema_name
+    if runtime_schema != "local":
+        _build_component_cache()
 
     pipeline_definition = _preprocess_pipeline(
         pipeline_path, runtime=runtime_schema, runtime_config=runtime_config_name
     )
-
-    pipeline_runtime_type = _get_pipeline_runtime_type(pipeline_definition)
-    if pipeline_runtime_type:
-        _build_component_cache()
-
     try:
         _validate_pipeline_definition(pipeline_definition)
     except Exception:
@@ -697,8 +690,10 @@ def export(pipeline_path, runtime_config, output, overwrite):
     print_banner("Elyra pipeline export")
 
     rtc = _get_runtime_config(runtime_config)
-    runtime_schema = rtc.schema_name
     runtime_type = rtc.metadata.get("runtime_type")
+    runtime_schema = rtc.schema_name
+    if runtime_schema != "local":
+        _build_component_cache()
 
     pipeline_definition = _preprocess_pipeline(pipeline_path, runtime=runtime_schema, runtime_config=runtime_config)
 
@@ -751,9 +746,6 @@ def export(pipeline_path, runtime_config, output, overwrite):
         raise click.ClickException(
             f"Output file '{str(output_file)}' exists and " "option '--overwrite' was not specified."
         )
-
-    if pipeline_runtime_type:
-        _build_component_cache()
 
     # validate the pipeline
     try:

--- a/elyra/tests/cli/test_pipeline_app.py
+++ b/elyra/tests/cli/test_pipeline_app.py
@@ -883,8 +883,10 @@ def test_describe_custom_component_dependencies_json():
 # ------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("catalog_instance", [KFP_COMPONENT_CACHE_INSTANCE], indirect=True)
-def test_validate_with_kfp_components(jp_environ, kubeflow_pipelines_runtime_instance, catalog_instance):
+@pytest.mark.parametrize("catalog_instance_no_server_process", [KFP_COMPONENT_CACHE_INSTANCE], indirect=True)
+def test_validate_with_kfp_components(
+    jp_environ, kubeflow_pipelines_runtime_instance, catalog_instance_no_server_process
+):
     runner = CliRunner()
     pipeline_file_path = Path(__file__).parent / "resources" / "pipelines" / "kfp_3_node_custom.pipeline"
     result = runner.invoke(
@@ -1066,8 +1068,10 @@ def test_export_incompatible_runtime_config(kubeflow_pipelines_runtime_instance,
     )
 
 
-@pytest.mark.parametrize("catalog_instance", [KFP_COMPONENT_CACHE_INSTANCE], indirect=True)
-def test_export_kubeflow_output_option(jp_environ, kubeflow_pipelines_runtime_instance, catalog_instance):
+@pytest.mark.parametrize("catalog_instance_no_server_process", [KFP_COMPONENT_CACHE_INSTANCE], indirect=True)
+def test_export_kubeflow_output_option(
+    jp_environ, kubeflow_pipelines_runtime_instance, catalog_instance_no_server_process
+):
     """Verify that the '--output' option works as expected for Kubeflow Pipelines"""
     runner = CliRunner()
     with runner.isolated_filesystem():
@@ -1217,8 +1221,10 @@ def test_export_airflow_output_option(airflow_runtime_instance):
         ), result.output
 
 
-@pytest.mark.parametrize("catalog_instance", [KFP_COMPONENT_CACHE_INSTANCE], indirect=True)
-def test_export_kubeflow_overwrite_option(jp_environ, kubeflow_pipelines_runtime_instance, catalog_instance):
+@pytest.mark.parametrize("catalog_instance_no_server_process", [KFP_COMPONENT_CACHE_INSTANCE], indirect=True)
+def test_export_kubeflow_overwrite_option(
+    jp_environ, kubeflow_pipelines_runtime_instance, catalog_instance_no_server_process
+):
     """Verify that the '--overwrite' option works as expected for Kubeflow Pipelines"""
     runner = CliRunner()
     with runner.isolated_filesystem():


### PR DESCRIPTION
Fixes #2911 

### What changes were proposed in this pull request?
This PR moves the build of the component cache for relevant CLI tasks (`validate`, `export` and `submit`) to occur before pipeline pre-processing. Pipeline CLI tests have also been updated to catch this case in the future. Long-winded explanation below.

Recall that `ComponentCache` instances are either considered server processes (_usually_ a running Elyra instance) or not (_mostly_ CLI processes), and only in the former case is a cache built. For the pipeline CLI tasks of `validate`, `export` and `submit`, we pass `emulate_server_app=True` to the creation/retrieval of the cache instance so that it builds and can reference the cache during pipeline validation. 

The issue referenced above was caused by the fact that, as of #2799,  pipeline pre-processing (e.g. the creation of a `PipelineDefinition` object) *also* creates/retrieves a `ComponentCache` instance (and does not specify anything in regards to `emulate_server_app`). Because pre-processing previously occurred before `_build_component_cache` in the CLI app, the `ComponentCache` instance was created during pre-process and did not appropriately set `emulate_server_app` to `True`. This PR moves the build of the cache to occur before pre-processing, such that creation of the `ComponentCache` instance is done "as a server process".

Another issue is that this problem was not caught by the tests because the `component_cache` fixture explicitly sets `emulate_server_app` to True during `ComponentCache` instance creation. To more accurately reflect how things flow during use of the CLI, I've created a new fixture that does not result in the creation of a `ComponentCache` instance.

### How was this pull request tested?
Tested manually. Also ran the updated backend tests against current `main` to ensure that the expected tests fail on `main`, but pass on this branch.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
