### PR TITLE
Fix mybinder.org install

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -28,12 +28,12 @@ export PATH=$(pwd)/.npm-global/bin/:$PATH
 # Download and install Yarn Package Manager using npm
 npm install -g yarn
 
-# Build Elyra Distribution
-make release
-
 # Updage dependencies and install Elyra wheel
 pip install --upgrade pip
-pip install --upgrade tornado jupyter-core jupyter-server jupyterlab dist/*.whl
+pip install --upgrade tornado jupyter-core jupyter-server jupyter-packaging jupyterlab dist/*.whl
+
+# Build Elyra Distribution
+make release
 
 mkdir -p binder-demo
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -30,10 +30,11 @@ npm install -g yarn
 
 # Updage dependencies and install Elyra wheel
 pip install --upgrade pip
-pip install --upgrade tornado jupyter-core jupyter-server jupyter-packaging jupyterlab dist/*.whl
+pip install --upgrade tornado jupyter-core jupyter-server jupyter-packaging jupyterlab
 
 # Build Elyra Distribution
 make release
+pip install dist/*.whl
 
 mkdir -p binder-demo
 


### PR DESCRIPTION
I wanted to test Elyra. Currently it seems that clicking on `binder` buttons in this repo results in a failed build due to `jupyter-packaging` not being available in the environment.

### What changes were proposed in this pull request?

Reorder `pip install` in the `binder/` folder; add `jupyter-packaging` as dependency.

### How was this pull request tested?

Submitted my branch (https://github.com/tkukurin/elyra and `patch-1` as branch name) to mybinder.org.
Build is successful.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
