### PR TITLE
Fix rendering of toleration effect in generic components

### DIFF
--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -650,7 +650,7 @@ be fully qualified (i.e., prefixed with their package names).
         for t in elyra_parameters.get(pipeline_constants.KUBERNETES_TOLERATIONS, []):
             key = f'"{t.key}"' if t.key is not None else t.key
             value = f'"{t.value}"' if t.value is not None else t.value
-            effect = f'"{t.effect}"' if t.value is not None else t.effect
+            effect = f'"{t.effect}"' if t.effect is not None else t.effect
             str_to_render += f"""
                 {{"key": {key}, "operator": "{t.operator}", "value": {value}, "effect": {effect}}},"""
         return dedent(str_to_render)


### PR DESCRIPTION

### What changes were proposed in this pull request?
Corrects processing of the 'effect' variable for tolerations in Airflow generic components.

### How was this pull request tested?
Tested manually by exporting a pipeline that includes a toleration with an `effect` but no `value` specified.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
