### PR TITLE
Fix annotations and label processing

### DIFF
--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -631,7 +631,7 @@ be fully qualified (i.e., prefixed with their package names).
         :returns: a string literal containing the python code to be rendered in the DAG
         """
         annotations = elyra_parameters.get(pipeline_constants.KUBERNETES_POD_ANNOTATIONS, ElyraPropertyList([]))
-        return annotations.to_dict()
+        return {key: value or "" for key, value in annotations.to_dict().items()}
 
     def render_labels(self, elyra_parameters: Dict[str, ElyraProperty]) -> Dict:
         """
@@ -639,7 +639,7 @@ be fully qualified (i.e., prefixed with their package names).
         :returns: a string literal containing the python code to be rendered in the DAG
         """
         labels = elyra_parameters.get(pipeline_constants.KUBERNETES_POD_LABELS, ElyraPropertyList([]))
-        return labels.to_dict()
+        return {key: value or "" for key, value in labels.to_dict().items()}
 
     def render_tolerations(self, elyra_parameters: Dict[str, ElyraProperty]):
         """

--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -686,13 +686,13 @@ be fully qualified (i.e., prefixed with their package names).
         """Add KubernetesAnnotation instance to the execution object for the given runtime processor"""
         if "annotations" not in execution_object:
             execution_object["annotations"] = {}
-        execution_object["annotations"][instance.key] = instance.value
+        execution_object["annotations"][instance.key] = instance.value or ""
 
     def add_kubernetes_pod_label(self, instance: KubernetesLabel, execution_object: Any, **kwargs) -> None:
         """Add KubernetesLabel instance to the execution object for the given runtime processor"""
         if "labels" not in execution_object:
             execution_object["labels"] = {}
-        execution_object["labels"][instance.key] = instance.value
+        execution_object["labels"][instance.key] = instance.value or ""
 
     def add_kubernetes_toleration(self, instance: KubernetesToleration, execution_object: Any, **kwargs) -> None:
         """Add KubernetesToleration instance to the execution object for the given runtime processor"""

--- a/elyra/pipeline/component_parameter.py
+++ b/elyra/pipeline/component_parameter.py
@@ -37,9 +37,11 @@ from elyra.pipeline.pipeline_constants import KUBERNETES_SECRETS
 from elyra.pipeline.pipeline_constants import KUBERNETES_TOLERATIONS
 from elyra.pipeline.pipeline_constants import MOUNTED_VOLUMES
 from elyra.util.kubernetes import is_valid_annotation_key
+from elyra.util.kubernetes import is_valid_annotation_value
 from elyra.util.kubernetes import is_valid_kubernetes_key
 from elyra.util.kubernetes import is_valid_kubernetes_resource_name
 from elyra.util.kubernetes import is_valid_label_key
+from elyra.util.kubernetes import is_valid_label_value
 
 
 class ElyraProperty:
@@ -425,7 +427,7 @@ class KubernetesAnnotation(ElyraPropertyListItem):
     _keys = ["key"]
     _ui_details_map = {
         "key": {"display_name": "Key", "placeholder": "annotation_key", "json_type": "string", "required": True},
-        "value": {"display_name": "Value", "placeholder": "annotation_value", "json_type": "string", "required": True},
+        "value": {"display_name": "Value", "placeholder": "annotation_value", "json_type": "string", "required": False},
     }
 
     def __init__(self, key, value, **kwargs):
@@ -440,12 +442,14 @@ class KubernetesAnnotation(ElyraPropertyListItem):
     def get_all_validation_errors(self) -> List[str]:
         """Perform custom validation on an instance."""
         validation_errors = []
+        # verify annotation key
         if not self.key:
             validation_errors.append("Required annotation key was not specified.")
         elif not is_valid_annotation_key(self.key):
             validation_errors.append(f"'{self.key}' is not a valid Kubernetes annotation key.")
-        if not self.value:
-            validation_errors.append("Required annotation value was not specified.")
+        # verify annotation value
+        if not is_valid_annotation_value(self.value):
+            validation_errors.append(f"'{self.value}' is not a valid Kubernetes annotation value.")
 
         return validation_errors
 
@@ -472,7 +476,7 @@ class KubernetesLabel(ElyraPropertyListItem):
     _keys = ["key"]
     _ui_details_map = {
         "key": {"display_name": "Key", "placeholder": "label_key", "json_type": "string", "required": True},
-        "value": {"display_name": "Value", "placeholder": "label_value", "json_type": "string", "required": True},
+        "value": {"display_name": "Value", "placeholder": "label_value", "json_type": "string", "required": False},
     }
 
     def __init__(self, key, value, **kwargs):
@@ -487,13 +491,14 @@ class KubernetesLabel(ElyraPropertyListItem):
     def get_all_validation_errors(self) -> List[str]:
         """Perform custom validation on an instance."""
         validation_errors = []
+        # verify label key
         if not self.key:
             validation_errors.append("Required label key was not specified.")
         elif not is_valid_label_key(self.key):
             validation_errors.append(f"'{self.key}' is not a valid Kubernetes label key.")
-        if not self.value:
-            validation_errors.append("Required label value was not specified.")
-
+        # verify label value
+        if not is_valid_label_value(self.value):
+            validation_errors.append(f"'{self.value}' is not a valid Kubernetes label value.")
         return validation_errors
 
     def get_value_for_dict_entry(self) -> str:

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -797,12 +797,12 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
     def add_kubernetes_pod_annotation(self, instance: KubernetesAnnotation, execution_object: Any, **kwargs) -> None:
         """Add KubernetesAnnotation instance to the execution object for the given runtime processor"""
         if instance.key not in execution_object.pod_annotations:
-            execution_object.add_pod_annotation(instance.key, instance.value)
+            execution_object.add_pod_annotation(instance.key, instance.value or "")
 
     def add_kubernetes_pod_label(self, instance: KubernetesLabel, execution_object: Any, **kwargs) -> None:
         """Add KubernetesLabel instance to the execution object for the given runtime processor"""
         if instance.key not in execution_object.pod_labels:
-            execution_object.add_pod_label(instance.key, instance.value)
+            execution_object.add_pod_label(instance.key, instance.value or "")
 
     def add_kubernetes_toleration(self, instance: KubernetesToleration, execution_object: Any, **kwargs) -> None:
         """Add KubernetesToleration instance to the execution object for the given runtime processor"""

--- a/elyra/tests/pipeline/resources/additional_generic_properties.json
+++ b/elyra/tests/pipeline/resources/additional_generic_properties.json
@@ -17,7 +17,7 @@
           "default": ""
         }
       },
-      "required": ["key", "value"]
+      "required": ["key"]
     },
     "uihints": {
       "items": {
@@ -81,7 +81,7 @@
           "default": ""
         }
       },
-      "required": ["key", "value"]
+      "required": ["key"]
     },
     "uihints": {
       "items": {

--- a/elyra/tests/pipeline/test_validation.py
+++ b/elyra/tests/pipeline/test_validation.py
@@ -535,6 +535,8 @@ def test_valid_node_property_kubernetes_pod_annotation(validation_manager):
     node_dict = {"id": "test-id", "app_data": {"label": "test", "ui_data": {}, "component_parameters": {}}}
     annotations = ElyraPropertyList(
         [
+            KubernetesAnnotation(key="key", value=""),
+            KubernetesAnnotation(key="key", value=None),
             KubernetesAnnotation(key="key", value="value"),
             KubernetesAnnotation(key="n-a-m-e", value="value"),
             KubernetesAnnotation(key="n.a.m.e", value="value"),
@@ -631,8 +633,6 @@ def test_invalid_node_property_kubernetes_pod_annotation(validation_manager):
     invalid_annotations = ElyraPropertyList(
         [
             # test length violations (key name and prefix)
-            KubernetesAnnotation(key="a", value=""),  # empty value (min 1)
-            KubernetesAnnotation(key="a", value=None),  # empty value (min 1)
             KubernetesAnnotation(key="a" * TOO_SHORT_LENGTH, value="val"),  # empty key (min 1)
             KubernetesAnnotation(key=None, value="val"),  # empty key (min 1)
             KubernetesAnnotation(key="a" * TOO_LONG_LENGTH, value="val"),  # key too long
@@ -656,8 +656,6 @@ def test_invalid_node_property_kubernetes_pod_annotation(validation_manager):
         ]
     )
     expected_error_messages = [
-        "Required annotation value was not specified.",
-        "Required annotation value was not specified.",
         "Required annotation key was not specified.",
         "Required annotation key was not specified.",
         f"'{'a' * TOO_LONG_LENGTH}' is not a valid Kubernetes annotation key.",

--- a/elyra/tests/util/test_kubernetes.py
+++ b/elyra/tests/util/test_kubernetes.py
@@ -13,7 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from elyra.util.kubernetes import is_valid_annotation_key
+from elyra.util.kubernetes import is_valid_annotation_value
 from elyra.util.kubernetes import is_valid_kubernetes_resource_name
+from elyra.util.kubernetes import is_valid_label_key
+from elyra.util.kubernetes import is_valid_label_value
 
 
 def test_is_valid_kubernetes_resource_name_invalid_input():
@@ -59,3 +63,166 @@ def test_is_valid_kubernetes_resource_name_valid_input():
     assert is_valid_kubernetes_resource_name(name="l.l")
     assert is_valid_kubernetes_resource_name(name="4-you")
     assert is_valid_kubernetes_resource_name(name="you.2")
+
+
+def test_is_valid_label_key_invalid_input():
+    """
+    Verify that is_valid_label_key detects whether or
+    not a given string is a valid Kubernetes label key:
+    Valid label keys have two segments: an optional prefix and name,
+    separated by a slash (/). The name segment is required and must
+    be 63 characters or less, beginning and ending with an alphanumeric
+    character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.),
+    and alphanumerics between. The prefix is optional. If specified,
+    the prefix must be a DNS subdomain: a series of DNS labels separated
+    by dots (.), not longer than 253 characters in total, followed by a slash (/).
+    """
+    # test length violations
+    assert not is_valid_label_key(key=None)  # Too short
+    assert not is_valid_label_key(key="")  # Too short
+    assert not is_valid_label_key(key=f"{'p' * 254}/n")  # prefix too long
+    assert not is_valid_label_key(key="/n")  # prefix too short
+    assert not is_valid_label_key(key="p/")  # name too short
+    assert not is_valid_label_key(key="a" * 254)  # name too long
+    assert not is_valid_label_key(key=f"d/{'b'*64}")  # name too long
+    # test first character violations (not alphanum)
+    assert not is_valid_label_key(key="-a")
+    assert not is_valid_label_key(key=".b")
+    assert not is_valid_label_key(key=" c")
+    # test last character violations (not alphanum)
+    assert not is_valid_label_key(key="a-")
+    assert not is_valid_label_key(key="b.")
+    assert not is_valid_label_key(key="c ")
+    assert not is_valid_label_key(key="sw33T#")
+    # test middle characters violations
+    assert not is_valid_label_key(key="a$$a")
+    assert not is_valid_label_key(key="b  b")
+
+
+def test_is_valid_label_key_valid_input():
+    """
+    Verify that is_valid_label_key doesn't report valid input as problematic
+    """
+    # test valid label keys
+    assert is_valid_label_key(key="l0l")
+    assert is_valid_label_key(key="l0L")
+    assert is_valid_label_key(key="L-l")
+    assert is_valid_label_key(key="L.L")
+    assert is_valid_label_key(key="4-you")
+    assert is_valid_label_key(key="you.2")
+    assert is_valid_label_key(key="p/n")
+    assert is_valid_label_key(key="prefix/you.2")
+    assert is_valid_label_key(key="how.sad/to-see")
+    assert is_valid_label_key(key=f"{'d'*253}/{'n'*63}")
+
+
+def test_is_valid_label_value_invalid_input():
+    """
+    Verify that is_valid_label_value detects whether or
+    not a given string is a valid Kubernetes label value:
+    """
+    # test length violations
+    assert not is_valid_label_value(value=f"{'v' * 64}")  # value too long
+    # test first character violations (not alphanum)
+    assert not is_valid_label_value(value="-")
+    assert not is_valid_label_value(value="-a")
+    assert not is_valid_label_value(value=".b")
+    assert not is_valid_label_value(value=" c")
+    # test last character violations (not alphanum)
+    assert not is_valid_label_value(value="a-")
+    assert not is_valid_label_value(value="b.")
+    assert not is_valid_label_value(value="c ")
+    assert not is_valid_label_value(value="sw33T#")
+    # test middle characters violations
+    assert not is_valid_label_value(value="a$$a")
+    assert not is_valid_label_value(value="b  b")
+
+
+def test_is_valid_label_value_valid_input():
+    """
+    Verify that is_valid_label_value doesn't report valid input as problematic
+    """
+    # test valid label values
+    assert is_valid_label_value(value=None)
+    assert is_valid_label_value(value="")
+    assert is_valid_label_value(value="l0L")
+    assert is_valid_label_value(value="L-l")
+    assert is_valid_label_value(value="L.L")
+    assert is_valid_label_value(value="l_4")
+    assert is_valid_label_value(value="4-you")
+    assert is_valid_label_value(value="You.2")
+
+
+def test_is_valid_annotation_key_invalid_input():
+    """
+    Verify that is_valid_annotation_key detects whether or
+    not a given string is a valid Kubernetes annotation key:
+    Valid annotation keys have two segments: an optional prefix and name,
+    separated by a slash (/). The name segment is required and must
+    be 63 characters or less, beginning and ending with an alphanumeric
+    character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.),
+    and alphanumerics between. The prefix is optional. If specified,
+    the prefix must be a DNS subdomain: a series of DNS labels separated
+    by dots (.), not longer than 253 characters in total, followed by a slash (/).
+    """
+    # test length violations
+    assert not is_valid_annotation_key(key=None)  # Too short
+    assert not is_valid_annotation_key(key="")  # Too short
+    assert not is_valid_annotation_key(key=f"{'p' * 254}/n")  # prefix too long
+    assert not is_valid_annotation_key(key="/n")  # prefix too short
+    assert not is_valid_annotation_key(key="p/")  # name too short
+    assert not is_valid_annotation_key(key="a" * 254)  # name too long
+    assert not is_valid_annotation_key(key=f"d/{'b'*64}")  # name too long
+    # test first character violations (not alphanum)
+    assert not is_valid_annotation_key(key="-a")
+    assert not is_valid_annotation_key(key=".b")
+    assert not is_valid_annotation_key(key=" c")
+    # test last character violations (not alphanum)
+    assert not is_valid_annotation_key(key="a-")
+    assert not is_valid_annotation_key(key="b.")
+    assert not is_valid_annotation_key(key="c ")
+    assert not is_valid_annotation_key(key="sw33T#")
+    # test middle characters violations
+    assert not is_valid_annotation_key(key="a$$a")
+    assert not is_valid_annotation_key(key="b  b")
+
+
+def test_is_valid_annotation_key_valid_input():
+    """
+    Verify that is_valid_label_key doesn't report valid input as problematic
+    """
+    # test valid label keys
+    assert is_valid_annotation_key(key="l0l")
+    assert is_valid_annotation_key(key="l0L")
+    assert is_valid_annotation_key(key="L-l")
+    assert is_valid_annotation_key(key="L.L")
+    assert is_valid_annotation_key(key="4-you")
+    assert is_valid_annotation_key(key="you.2")
+    assert is_valid_annotation_key(key="p/n")
+    assert is_valid_annotation_key(key="prefix/you.2")
+    assert is_valid_annotation_key(key="how.sad/to-see")
+    assert is_valid_annotation_key(key=f"{'d'*253}/{'n'*63}")
+
+
+def test_is_valid_annotation_value_invalid_input():
+    """
+    Verify that is_valid_annotation_value detects whether or
+    not a given string is a valid Kubernetes annotation value:
+    """
+    # test valid label values
+    assert not is_valid_annotation_value(value=1)
+
+
+def test_is_valid_annotation_value_valid_input():
+    """
+    Verify that is_valid_label_value doesn't report valid input as problematic
+    """
+    # test valid label values
+    assert is_valid_annotation_value(value=None)
+    assert is_valid_annotation_value(value="")
+    assert is_valid_annotation_value(value="l0L")
+    assert is_valid_annotation_value(value="L-l")
+    assert is_valid_annotation_value(value="L.L")
+    assert is_valid_annotation_value(value="l_4")
+    assert is_valid_annotation_value(value="4-you")
+    assert is_valid_annotation_value(value="You.2")

--- a/elyra/util/kubernetes.py
+++ b/elyra/util/kubernetes.py
@@ -87,14 +87,32 @@ def is_valid_annotation_key(key: str) -> bool:
         return False
 
     # validate optional prefix
+    if "/" in key and len(prefix) == 0:
+        return False
+
     if len(prefix) > 0 and not is_valid_dns_subdomain_name(prefix):
         return False
 
     # validate name
-    if len(name) > 63 or not name[0].isalnum() or not name[-1].isalnum():
+    if len(name) == 0 or len(name) > 63:
+        return False
+    if not name[0].isalnum() or not name[-1].isalnum():
         return False
 
     return re.match(r"^[\w\-_.]+$", name) is not None
+
+
+def is_valid_annotation_value(value: str) -> bool:
+    """
+    Returns a truthy value indicating whether name meets the kubernetes
+    naming constraints for annotation values, as outlined in the link below.
+
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+    """
+    if value is None or (isinstance(value, str) and (len(value) == 0)):
+        return True
+
+    return isinstance(value, str)
 
 
 def is_valid_label_key(key: str) -> bool:
@@ -107,3 +125,23 @@ def is_valid_label_key(key: str) -> bool:
 
     # rules are identical to those applied to annotation keys; re-use existing code
     return is_valid_annotation_key(key)
+
+
+def is_valid_label_value(value: str) -> bool:
+    """
+    Returns a truthy value indicating whether name meets the kubernetes
+    naming constraints for label values, as outlined in the link below.
+
+    https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+    - must be 63 characters or less (can be empty),
+    - unless empty, must begin and end with an alphanumeric character ([a-z0-9A-Z]),
+    - could contain dashes (-), underscores (_), dots (.), and alphanumerics between.
+    """
+
+    if value is None or (isinstance(value, str) and (len(value) == 0)):
+        return True
+
+    if len(value) > 63 or not value[0].isalnum() or not value[-1].isalnum():
+        return False
+
+    return re.match(r"^[a-zA-Z0-9]([-_\.A-Za-z0-9]*[a-zA-Z0-9])*$", value) is not None


### PR DESCRIPTION
Fixes various issues related to kubernetes pod label and annotations processing.
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
- Treat empty label values  and empty annotations values as valid input
- Added missing annotations tests
- Updated existing labels tests
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
- Updated server tests
- Reviewed the output of `kubectl describe pod ...` to confirm that labels (`prefix.org/lk1`, `prefix.org/lk2`, `prefix/lk3`) and annotations (`ak1`, `prefix/ak2`, `ak3`) are set as expected for custom components and generic components

```
$ kubectl describe pod -n kubeflow-user-example-com lambda-bw9rk-440379885
Name:             lambda-bw9rk-440379885
Namespace:        kubeflow-user-example-com
Priority:         0
Service Account:  default-editor
Node:             cloning1.fyre.ibm.com/9.30.189.14
Start Time:       Tue, 04 Oct 2022 09:36:06 -0700
Labels:           pipeline/runid=b97f3544-2b1a-460e-bd3c-b9a26f2b1538
                  pipelines.kubeflow.org/cache_enabled=true
                  pipelines.kubeflow.org/cache_id=
                  pipelines.kubeflow.org/enable_caching=true
                  pipelines.kubeflow.org/kfp_sdk_version=1.8.13
                  pipelines.kubeflow.org/metadata_context_id=8
                  pipelines.kubeflow.org/metadata_execution_id=14
                  pipelines.kubeflow.org/metadata_written=true
                  pipelines.kubeflow.org/pipeline-sdk-type=kfp
                  prefix.org/lk1=1
                  prefix.org/lk2=
                  prefix/lk3=lv3-is-the-value
                  workflows.argoproj.io/completed=true
                  workflows.argoproj.io/workflow=lambda-bw9rk
Annotations:      ak1: 
                  ak3: av3
                  pipelines.kubeflow.org/arguments.parameters: {"URL": "https://www.google.com"}
                  pipelines.kubeflow.org/component_ref: {"digest": "8e4384f422a088e4814024df7955e952c1488bd091fa0d4873d5f611d741ceb4"}
                  pipelines.kubeflow.org/component_spec:
                    {"description": "Downloads a file from a public HTTP/S URL using a GET request.", "implementation": {"container": {"command": ["python3", ...
                  pipelines.kubeflow.org/execution_cache_key: 0001ef28c66b445b3629d5df1db2ca146a0287fc0c90b92880ca26ef4fdf79cc
                  pipelines.kubeflow.org/metadata_input_artifact_ids: []
                  pipelines.kubeflow.org/metadata_output_artifact_ids:
                    [{"id": 22, "name": "downloaded-file", "uri": "minio:///artifacts/lambda-bw9rk/2022/10/04/lambda-bw9rk-440379885/download-file-downloaded-...
                  pipelines.kubeflow.org/task_display_name: Download File
                  prefix/ak2: 0
                  sidecar.istio.io/inject: false
```
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
