### PR TITLE
Explicitly specify units of gigabytes for RAM in Airflow DAG template

### DIFF
--- a/docs/source/user_guide/pipelines.md
+++ b/docs/source/user_guide/pipelines.md
@@ -279,7 +279,7 @@ The following alphabetically sorted list identifies the node properties that are
    - Example: `data/*.csv`
 
 ##### Resources: CPU, GPU, and RAM
-   - Resources that the notebook or script requires. RAM takes units of gigabytes (G or GB).
+   - Resources that the notebook or script requires. RAM takes units of gigabytes (10<sup>9</sup> bytes).
    - The values are ignored when the pipeline is executed locally. 
 
 ##### Runtime image

--- a/docs/source/user_guide/pipelines.md
+++ b/docs/source/user_guide/pipelines.md
@@ -279,7 +279,7 @@ The following alphabetically sorted list identifies the node properties that are
    - Example: `data/*.csv`
 
 ##### Resources: CPU, GPU, and RAM
-   - Resources that the notebook or script requires.
+   - Resources that the notebook or script requires. RAM takes units of gigabytes (G or GB).
    - The values are ignored when the pipeline is executed locally. 
 
 ##### Runtime image

--- a/elyra/templates/airflow/airflow_template.jinja2
+++ b/elyra/templates/airflow/airflow_template.jinja2
@@ -53,7 +53,7 @@ op_{{ operation.id|regex_replace }} = KubernetesPodOperator(name='{{ operation.n
                                                                        'request_cpu': '{{ operation.cpu_request }}',
             {% endif %}
             {% if operation.mem_request %}
-                                                                       'request_memory': '{{ operation.mem_request }}',
+                                                                       'request_memory': '{{ operation.mem_request }}G',
             {% endif %}
             {% if operation.gpu_limit %}
                                                                        'limit_gpu': '{{ operation.gpu_limit }}',


### PR DESCRIPTION
Fixes an issue raised in [this PR comment](https://github.com/elyra-ai/elyra/pull/2942#issuecomment-1262714563).

### What changes were proposed in this pull request?
A "G" is added to the Airflow DAG template `resources` argument for the `request_memory` key. 

Docs have also been updated to reflect that the units are in gigabytes for both KFP and Airflow.

<img width="713" alt="Screen Shot 2022-10-04 at 11 59 32 AM" src="https://user-images.githubusercontent.com/31816267/193881224-396be555-729b-45e4-9128-d469283e38fe.png">


### How was this pull request tested?
Ran a pipeline with RAM resource amount specified. 

```
$ kubectl describe pod <pod-name>
...
Ready:          False
    Restart Count:  0
    Requests:
      memory:  3G
    Environment:
      AWS_ACCESS_KEY_ID:           <set to the key 'AWS_ACCESS_KEY_ID' in secret 'airflow-cos-secret'>      Optional: false
      AWS_SECRET_ACCESS_KEY:       <set to the key 'AWS_SECRET_ACCESS_KEY' in secret 'airflow-cos-secret'>  Optional: false
      ELYRA_ENABLE_PIPELINE_INFO:  True
      ELYRA_RUNTIME_ENV:           airflow
      ELYRA_RUN_NAME:              test-ram-units-20221003T000000
...
```

Reviewed output of `make docs`


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
