### PR TITLE
Tolerate runtime configuration instances named 'local'

### DIFF
--- a/elyra/cli/pipeline_app.py
+++ b/elyra/cli/pipeline_app.py
@@ -31,7 +31,7 @@ from kfp import Client as ArgoClient
 
 from elyra._version import __version__
 from elyra.metadata.manager import MetadataManager
-from elyra.metadata.schema import SchemaManager
+from elyra.metadata.metadata import Metadata
 from elyra.metadata.schemaspaces import Runtimes
 from elyra.pipeline import pipeline_constants
 from elyra.pipeline.component_catalog import ComponentCache
@@ -46,7 +46,6 @@ from elyra.pipeline.processor import PipelineProcessorManager
 from elyra.pipeline.processor import PipelineProcessorResponse
 from elyra.pipeline.runtime_type import RuntimeProcessorType
 from elyra.pipeline.runtime_type import RuntimeTypeResources
-from elyra.pipeline.runtimes_metadata import RuntimesMetadata
 from elyra.pipeline.validation import PipelineValidationManager
 from elyra.pipeline.validation import ValidationSeverity
 
@@ -66,10 +65,10 @@ SEVERITY = {
 }
 
 
-def _get_runtime_config(runtime_config_name: Optional[str]) -> Optional[RuntimesMetadata]:
+def _get_runtime_config(runtime_config_name: Optional[str]) -> Optional[Metadata]:
     """Fetch runtime configuration for the specified name"""
-    if not runtime_config_name or runtime_config_name == "local":
-        # No runtime configuration was specified or it is local.
+    if not runtime_config_name:
+        # No runtime configuration was specified so treat as local.
         # Cannot use metadata manager to determine the runtime type.
         return None
     try:
@@ -89,29 +88,14 @@ def _get_runtime_type(runtime_config_name: Optional[str]) -> Optional[str]:
 
 def _get_runtime_schema_name(runtime_config_name: Optional[str]) -> Optional[str]:
     """Get runtime schema name for the provided runtime configuration name"""
-    if not runtime_config_name or runtime_config_name == "local":
-        # No runtime configuration was specified or it is local.
+    if not runtime_config_name:
+        # No runtime configuration was specified so treat as local.
         # Cannot use metadata manager to determine the runtime type.
         return "local"
     runtime_config = _get_runtime_config(runtime_config_name)
     if runtime_config:
         return runtime_config.schema_name
     return None
-
-
-def _get_runtime_display_name(schema_name: Optional[str]) -> Optional[str]:
-    """Return the display name for the specified runtime schema_name"""
-    if not schema_name or schema_name == "local":
-        # No schame name was  specified or it is local.
-        # Cannot use metadata manager to determine the display name.
-        return schema_name
-
-    try:
-        schema_manager = SchemaManager.instance()
-        schema = schema_manager.get_schema(Runtimes.RUNTIMES_SCHEMASPACE_NAME, schema_name)
-        return schema["display_name"]
-    except Exception as e:
-        raise click.ClickException(f"Invalid runtime configuration: {schema_name}\n {e}")
 
 
 def _get_pipeline_runtime_type(pipeline_definition: dict) -> Optional[str]:
@@ -295,7 +279,7 @@ def pipeline():
 @click.command()
 @click.option("--runtime-config", required=False, help="Runtime config where the pipeline should be processed")
 @click.argument("pipeline_path", type=Path, callback=validate_pipeline_path)
-def validate(pipeline_path, runtime_config="local"):
+def validate(pipeline_path: str, runtime_config: Optional[str] = None):
     """
     Validate pipeline
     """
@@ -475,7 +459,7 @@ def run(json_option, pipeline_path):
 
     print_banner("Elyra Pipeline Local Run")
 
-    pipeline_definition = _preprocess_pipeline(pipeline_path, runtime="local", runtime_config="local")
+    pipeline_definition = _preprocess_pipeline(pipeline_path, runtime="local")
 
     try:
         _validate_pipeline_definition(pipeline_definition)
@@ -501,7 +485,7 @@ def describe(json_option, pipeline_path):
     Display pipeline summary and dependencies.
     """
 
-    pipeline_definition = _preprocess_pipeline(pipeline_path, runtime="local", runtime_config="local")
+    pipeline_definition = _preprocess_pipeline(pipeline_path, runtime="local")
 
     primary_pipeline = PipelineDefinition(pipeline_definition=pipeline_definition).primary_pipeline
 

--- a/elyra/pipeline/parser.py
+++ b/elyra/pipeline/parser.py
@@ -49,8 +49,6 @@ class PipelineParser(LoggingConfigurable):
         if not runtime:
             raise ValueError("Invalid pipeline: Missing runtime.")
         runtime_config = primary_pipeline.runtime_config
-        if not runtime_config:
-            raise ValueError("Invalid pipeline: Missing runtime configuration.")
 
         source = primary_pipeline.source
 

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -338,7 +338,7 @@ class Pipeline(object):
         id: str,
         name: str,
         runtime: str,
-        runtime_config: str,
+        runtime_config: Optional[str] = None,
         source: Optional[str] = None,
         description: Optional[str] = None,
         pipeline_parameters: Optional[Dict[str, Any]] = None,
@@ -358,8 +358,6 @@ class Pipeline(object):
             raise ValueError("Invalid pipeline: Missing pipeline name.")
         if not runtime:
             raise ValueError("Invalid pipeline: Missing runtime.")
-        if not runtime_config:
-            raise ValueError("Invalid pipeline: Missing runtime configuration.")
 
         self._id = id
         self._name = name
@@ -432,7 +430,6 @@ class Pipeline(object):
                 and self.source == other.source
                 and self.description == other.description
                 and self.runtime == other.runtime
-                and self.runtime_config == other.runtime_config
                 and self.operations == other.operations
             )
 

--- a/elyra/pipeline/validation.py
+++ b/elyra/pipeline/validation.py
@@ -142,19 +142,17 @@ class PipelineValidationManager(SingletonConfigurable):
             return response
 
         # Validation can be driven from runtime_config since both runtime and pipeline_type can
-        # be derived from that and we should not use the 'runtime' and 'runtime_type' fields in
+        # be derived from that, and we should not use the 'runtime' and 'runtime_type' fields in
         # the pipeline.
         # Note: validation updates the pipeline definition with the correct values
         # of 'runtime' and 'runtime_type' obtained from 'runtime_config'.  We may want to move this
         # into PipelineDefinition, but then parsing tests have issues because parsing (tests) assume
         # no validation has been applied to the pipeline.
         runtime_config = primary_pipeline.runtime_config
-        if runtime_config is None:
-            runtime_config = "local"
 
         pipeline_runtime = PipelineValidationManager._determine_runtime(runtime_config)
         if PipelineProcessorManager.instance().is_supported_runtime(pipeline_runtime):
-            # Set the runtime since its derived from runtime_config and valid
+            # Set the runtime since it's derived from runtime_config and valid
             primary_pipeline.set("runtime", pipeline_runtime)
         else:
             response.add_message(
@@ -179,7 +177,7 @@ class PipelineValidationManager(SingletonConfigurable):
         if response.has_fatal:
             return response
 
-        # Set runtime_type since its derived from runtime_config, in case its needed
+        # Set runtime_type since it's derived from runtime_config, in case it's needed
         primary_pipeline.set("runtime_type", pipeline_type)
 
         await self._validate_node_properties(
@@ -192,21 +190,21 @@ class PipelineValidationManager(SingletonConfigurable):
         return response
 
     @staticmethod
-    def _determine_runtime(runtime_config: str) -> str:
+    def _determine_runtime(runtime_config: Optional[str]) -> str:
         """Derives the runtime (processor) from the runtime_config."""
-        # If not present or 'local', treat as special case.
-        if not runtime_config or runtime_config.upper() == RuntimeProcessorType.LOCAL.name:
+        # If runtime_config is not specified, treat as LOCAL.
+        if not runtime_config:
             return RuntimeProcessorType.LOCAL.name.lower()
 
         runtime_metadata = MetadataManager(schemaspace=Runtimes.RUNTIMES_SCHEMASPACE_ID).get(runtime_config)
         return runtime_metadata.schema_name
 
     @staticmethod
-    def _determine_runtime_type(runtime_config: str) -> str:
+    def _determine_runtime_type(runtime_config: Optional[str]) -> str:
         """Derives the runtime type (platform) from the runtime_config."""
-        # Pull the runtime_type (platform) from the runtime_config
-        # Need to special case 'local' runtime_config instances
-        if runtime_config.lower() == "local":
+        # Pull the runtime_type (platform) from the runtime_config.
+        # If not set, use LOCAL
+        if not runtime_config:
             runtime_type = RuntimeProcessorType.LOCAL
         else:
             runtime_metadata = MetadataManager(schemaspace=Runtimes.RUNTIMES_SCHEMASPACE_ID).get(runtime_config)

--- a/elyra/tests/pipeline/test_pipeline_constructor.py
+++ b/elyra/tests/pipeline/test_pipeline_constructor.py
@@ -307,11 +307,6 @@ def test_fail_create_pipeline_missing_runtime():
         Pipeline(id="Random-UUID-123123123123123", name="test-pipeline", runtime_config="default_kfp")
 
 
-def test_fail_create_pipeline_missing_runtime_config():
-    with pytest.raises(TypeError):
-        Pipeline(id="Random-UUID-123123123123123", name="test-pipeline", runtime="kfp")
-
-
 def test_pipelines_are_equal(good_pipeline):
     compare_pipeline = Pipeline(
         id="Random-UUID-123123123123123", name="test-pipeline", runtime="kfp", runtime_config="default_kfp"

--- a/elyra/tests/pipeline/test_pipeline_parser.py
+++ b/elyra/tests/pipeline/test_pipeline_parser.py
@@ -192,11 +192,12 @@ def test_missing_pipeline_runtime():
 def test_missing_pipeline_runtime_configuration():
     pipeline_json = _read_pipeline_resource("resources/sample_pipelines/pipeline_valid.json")
     pipeline_json["pipelines"][0]["app_data"].pop("runtime_config")
+    # emulate what validation will do when there's no value for runtime_config...
+    pipeline_json["pipelines"][0]["app_data"]["runtime"] = "local"
 
-    with pytest.raises(ValueError) as e:
-        PipelineParser().parse(pipeline_json)
-
-    assert "Invalid pipeline: Missing runtime configuration" in str(e.value)
+    pipeline = PipelineParser().parse(pipeline_json)
+    assert pipeline.runtime == "local"
+    assert pipeline.runtime_config is None
 
 
 def test_missing_operation_id():

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -759,7 +759,7 @@ const PipelineWrapper: React.FC<IProps> = ({
 
       // Runtime info
       pipelineJson.pipelines[0].app_data.runtime_config =
-        configDetails?.id ?? 'local';
+        configDetails?.id ?? null;
 
       // Export info
       const pipeline_dir = PathExt.dirname(contextRef.current.path);


### PR DESCRIPTION
When submitting pipelines to Kubeflow or Airflow runtimes, Elyra runs the pipeline locally if the corresponding runtime configuration is named "local" as described in #2964.  This is because the server looks at the runtime_config field in the pipeline for either no value (`None`) or the name `"local"`.  This pull request implements changes such that only invocations for local processing will submit pipelines with no value for `runtime_config`.

Should we decide to _promote_ the LOCAL runtime to a full-fledged runtime (where there's an associated schema and support for runtime configuration instances), most of these changes should still work since there _will_ be a value for `runtime_config` in these cases, which will then determine the target pipeline processor from the referenced schema name within the runtime configuration instance.  We should only then need to make changes where we set the `runtime_config` to `None` during submission (and in both the UI and CLI applications).

Still to do:
- [x] Set `runtime_config` to `null` (or `None`) in the UI when submitting pipelines for local execution

Resolves: #2964

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
