### PR TITLE
Fix handling of `cos_object_prefix` pipeline property

### DIFF
--- a/elyra/pipeline/airflow/processor_airflow.py
+++ b/elyra/pipeline/airflow/processor_airflow.py
@@ -187,7 +187,7 @@ be fully qualified (i.e., prefixed with their package names).
             if pipeline.contains_generic_operations():
                 object_storage_url = f"{cos_endpoint}"
                 os_path = join_paths(
-                    pipeline.pipeline_parameters.get(pipeline_constants.COS_OBJECT_PREFIX), pipeline_instance_id
+                    pipeline.pipeline_properties.get(pipeline_constants.COS_OBJECT_PREFIX), pipeline_instance_id
                 )
                 object_storage_path = f"/{cos_bucket}/{os_path}"
             else:
@@ -252,7 +252,7 @@ be fully qualified (i.e., prefixed with their package names).
 
         pipeline_instance_id = pipeline_instance_id or pipeline_name
         artifact_object_prefix = join_paths(
-            pipeline.pipeline_parameters.get(pipeline_constants.COS_OBJECT_PREFIX), pipeline_instance_id
+            pipeline.pipeline_properties.get(pipeline_constants.COS_OBJECT_PREFIX), pipeline_instance_id
         )
 
         self.log_pipeline_info(

--- a/elyra/pipeline/component_parameter.py
+++ b/elyra/pipeline/component_parameter.py
@@ -138,11 +138,28 @@ class ElyraProperty(ABC):
         cls._subclass_property_map = {sc.property_id: sc for sc in cls.all_subclasses() if hasattr(sc, "property_id")}
 
     @classmethod
+    def get_class_for_property(cls, prop_id) -> type | None:
+        """Returns the ElyraProperty subclass corresponding to the given property id."""
+        if not cls._subclass_property_map:
+            cls.build_property_map()
+        return cls._subclass_property_map.get(prop_id)
+
+    @classmethod
+    def subclass_exists_for_property(cls, prop_id: str) -> bool:
+        """
+        Returns a boolean indicating whether a corresponding ElyraProperty subclass
+        exists for the given property id.
+        """
+        return cls.get_class_for_property(prop_id) is not None
+
+    @classmethod
     def get_single_instance(cls, value: Optional[Dict[str, Any]] = None) -> ElyraProperty | None:
         """Unpack values from dictionary object and instantiate a class instance."""
+        if isinstance(value, ElyraProperty):
+            return value  # value is already a single instance, no further action required
+
         if not isinstance(value, dict):
             value = {}
-
         params = {attr.id: cls.strip_if_string(value.get(attr.id)) for attr in cls.property_attributes}
         instance = getattr(import_module(cls.__module__), cls.__name__)(**params)
         return None if instance.should_discard() else instance
@@ -150,10 +167,10 @@ class ElyraProperty(ABC):
     @classmethod
     def create_instance(cls, prop_id: str, value: Optional[Any]) -> ElyraProperty | ElyraPropertyList | None:
         """Create an instance of a class with the given property id using the user-entered values."""
-        if not cls._subclass_property_map:
-            cls.build_property_map()
+        sc = cls.get_class_for_property(prop_id)
+        if sc is None:
+            return None
 
-        sc = cls._subclass_property_map.get(prop_id)
         if issubclass(sc, ElyraPropertyListItem):
             if not isinstance(value, list):
                 return None
@@ -161,7 +178,6 @@ class ElyraProperty(ABC):
             return ElyraPropertyList(instances).deduplicate()  # convert to ElyraPropertyList and de-dupe
         elif issubclass(sc, ElyraProperty):
             return sc.get_single_instance(value)
-
         return None
 
     @classmethod

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -378,7 +378,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
         if pipeline.contains_generic_operations():
             object_storage_url = f"{cos_public_endpoint}"
             os_path = join_paths(
-                pipeline.pipeline_parameters.get(pipeline_constants.COS_OBJECT_PREFIX), pipeline_instance_id
+                pipeline.pipeline_properties.get(pipeline_constants.COS_OBJECT_PREFIX), pipeline_instance_id
             )
             object_storage_path = f"/{cos_bucket}/{os_path}"
         else:
@@ -484,7 +484,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
         pipeline_instance_id = pipeline_instance_id or pipeline_name
 
         artifact_object_prefix = join_paths(
-            pipeline.pipeline_parameters.get(pipeline_constants.COS_OBJECT_PREFIX), pipeline_instance_id
+            pipeline.pipeline_properties.get(pipeline_constants.COS_OBJECT_PREFIX), pipeline_instance_id
         )
 
         self.log_pipeline_info(

--- a/elyra/pipeline/parser.py
+++ b/elyra/pipeline/parser.py
@@ -63,7 +63,7 @@ class PipelineParser(LoggingConfigurable):
             runtime_config=runtime_config,
             source=source,
             description=description,
-            pipeline_parameters=primary_pipeline.pipeline_parameters,
+            pipeline_properties=primary_pipeline.get_pipeline_default_properties(),
         )
 
         nodes = primary_pipeline.nodes

--- a/elyra/pipeline/pipeline.py
+++ b/elyra/pipeline/pipeline.py
@@ -341,7 +341,7 @@ class Pipeline(object):
         runtime_config: str,
         source: Optional[str] = None,
         description: Optional[str] = None,
-        pipeline_parameters: Optional[Dict[str, Any]] = None,
+        pipeline_properties: Optional[Dict[str, Any]] = None,
     ):
         """
         :param id: Generated UUID, 128 bit number used as a unique identifier
@@ -351,7 +351,7 @@ class Pipeline(object):
         :param runtime_config: Runtime configuration that should be used to submit the pipeline to execution
         :param source: The pipeline source, e.g. a pipeline file or a notebook.
         :param description: Pipeline description
-        :param pipeline_parameters: Key/value pairs representing the parameters of this pipeline
+        :param pipeline_properties: Key/value pairs representing the properties of this pipeline
         """
 
         if not name:
@@ -367,7 +367,7 @@ class Pipeline(object):
         self._source = source
         self._runtime = runtime
         self._runtime_config = runtime_config
-        self._pipeline_parameters = pipeline_parameters or {}
+        self._pipeline_properties = pipeline_properties or {}
         self._operations = {}
 
     @property
@@ -397,11 +397,11 @@ class Pipeline(object):
         return self._runtime_config
 
     @property
-    def pipeline_parameters(self) -> Dict[str, Any]:
+    def pipeline_properties(self) -> Dict[str, Any]:
         """
-        The dictionary of global parameters associated with each node of the pipeline
+        The dictionary of global properties associated with this pipeline
         """
-        return self._pipeline_parameters
+        return self._pipeline_properties
 
     @property
     def operations(self) -> Dict[str, Operation]:

--- a/elyra/pipeline/pipeline_constants.py
+++ b/elyra/pipeline/pipeline_constants.py
@@ -23,6 +23,4 @@ KUBERNETES_TOLERATIONS = "kubernetes_tolerations"
 KUBERNETES_POD_ANNOTATIONS = "kubernetes_pod_annotations"
 KUBERNETES_POD_LABELS = "kubernetes_pod_labels"
 DISABLE_NODE_CACHING = "disable_node_caching"
-PIPELINE_META_PROPERTIES = ["name", "description", "runtime"]
-# optional static prefix to be used when generating an object name for object storage
-COS_OBJECT_PREFIX = "cos_object_prefix"
+COS_OBJECT_PREFIX = "cos_object_prefix"  # optional static prefix to be used when generating object name for cos storage

--- a/elyra/pipeline/pipeline_definition.py
+++ b/elyra/pipeline/pipeline_definition.py
@@ -31,10 +31,11 @@ from elyra.pipeline.component_parameter import ComponentParameter
 from elyra.pipeline.component_parameter import ElyraProperty
 from elyra.pipeline.component_parameter import ElyraPropertyList
 from elyra.pipeline.pipeline import Operation
-from elyra.pipeline.pipeline_constants import ENV_VARIABLES, RUNTIME_IMAGE
+from elyra.pipeline.pipeline_constants import COS_OBJECT_PREFIX
+from elyra.pipeline.pipeline_constants import ENV_VARIABLES
 from elyra.pipeline.pipeline_constants import KUBERNETES_SECRETS
 from elyra.pipeline.pipeline_constants import PIPELINE_DEFAULTS
-from elyra.pipeline.pipeline_constants import PIPELINE_META_PROPERTIES
+from elyra.pipeline.pipeline_constants import RUNTIME_IMAGE
 from elyra.pipeline.runtime_type import RuntimeProcessorType
 
 
@@ -183,23 +184,16 @@ class Pipeline(AppDataBase):
         """
         return self._node["app_data"]["ui_data"].get("comments", [])
 
-    @property
-    def pipeline_parameters(self) -> Dict[str, Any]:
-        """
-        Retrieve pipeline parameters, which are defined as all
-        key/value pairs in the 'properties' stanza that are not
-        either pipeline meta-properties (e.g. name, description,
-        and runtime) or the pipeline defaults dictionary
-        """
-        all_properties = self._node["app_data"].get("properties", {})
-        excluded_properties = PIPELINE_META_PROPERTIES + [PIPELINE_DEFAULTS]
+    def get_pipeline_default_properties(self) -> Dict[str, Any]:
+        """Retrieve the dictionary of pipeline default properties"""
+        pipeline_defaults = self.get_property(PIPELINE_DEFAULTS, {})
 
-        pipeline_parameters = {}
-        for property_name, value in all_properties.items():
-            if property_name not in excluded_properties:
-                pipeline_parameters[property_name] = value
+        # TODO remove the block below when a pipeline migration is appropriate (after 3.13)
+        cos_prefix = self._node["app_data"].get("properties", {}).pop(COS_OBJECT_PREFIX, None)
+        if cos_prefix:
+            self._node["app_data"]["properties"][PIPELINE_DEFAULTS] = cos_prefix
 
-        return pipeline_parameters
+        return pipeline_defaults
 
     def get_property(self, key: str, default_value=None) -> Any:
         """
@@ -233,18 +227,16 @@ class Pipeline(AppDataBase):
         Convert select pipeline-level properties to their corresponding dataclass
         object type. No validation is performed.
         """
-        pipeline_defaults = self.get_property(PIPELINE_DEFAULTS, {})
-        for param_id, param_value in list(pipeline_defaults.items()):
-            if param_id == RUNTIME_IMAGE:
-                continue  # runtime image is the only pipeline default that does not need to be converted
-            if isinstance(param_value, (ElyraProperty, ElyraPropertyList)) or param_value is None:
-                continue  # property has already been properly converted or cannot be converted
+        pipeline_defaults = self.get_pipeline_default_properties()
+        for prop_id, value in list(pipeline_defaults.items()):
+            if not ElyraProperty.subclass_exists_for_property(prop_id):
+                continue
 
-            converted_value = ElyraProperty.create_instance(param_id, param_value)
-            if converted_value is not None:
-                pipeline_defaults[param_id] = converted_value
+            converted_value = ElyraProperty.create_instance(prop_id, value)
+            if converted_value is None:
+                pipeline_defaults.pop(prop_id)
             else:
-                del pipeline_defaults[param_id]
+                pipeline_defaults[prop_id] = converted_value
 
 
 class Node(AppDataBase):
@@ -314,9 +306,7 @@ class Node(AppDataBase):
 
     @property
     def is_generic(self) -> True:
-        """
-        A property that denotes whether this node is a generic component
-        """
+        """A property that denotes whether this node is a generic component"""
         if Operation.is_generic_operation(self.op):
             return True
         return False
@@ -400,9 +390,7 @@ class Node(AppDataBase):
         return self._node["app_data"]["component_parameters"].pop(key, default)
 
     def get_all_component_parameters(self) -> Dict[str, Any]:
-        """
-        Retrieve all component parameter key-value pairs.
-        """
+        """Retrieve all component parameter key-value pairs."""
         return self._node["app_data"]["component_parameters"]
 
     def remove_env_vars_with_matching_secrets(self):
@@ -421,16 +409,15 @@ class Node(AppDataBase):
         Convert select node-level list properties to their corresponding dataclass
         object type. No validation is performed.
         """
-        for param_id in self.elyra_owned_properties:
-            param_value = self.get_component_parameter(param_id)
-            if isinstance(param_value, (ElyraProperty, ElyraPropertyList)) or param_value is None:
-                continue  # property has already been properly converted or cannot be converted
+        for prop_id in self.elyra_owned_properties:
+            if not ElyraProperty.subclass_exists_for_property(prop_id):
+                continue
 
-            converted_value = ElyraProperty.create_instance(param_id, param_value)
-            if converted_value is not None:
-                self.set_component_parameter(param_id, converted_value)
+            converted_value = ElyraProperty.create_instance(prop_id, value=self.get_component_parameter(prop_id))
+            if converted_value is None:
+                self.pop_component_parameter(prop_id)
             else:
-                self.pop_component_parameter(param_id)
+                self.set_component_parameter(prop_id, converted_value)
 
 
 class PipelineDefinition(object):

--- a/elyra/pipeline/pipeline_definition.py
+++ b/elyra/pipeline/pipeline_definition.py
@@ -191,7 +191,10 @@ class Pipeline(AppDataBase):
         # TODO remove the block below when a pipeline migration is appropriate (after 3.13)
         cos_prefix = self._node["app_data"].get("properties", {}).pop(COS_OBJECT_PREFIX, None)
         if cos_prefix:
-            self._node["app_data"]["properties"][PIPELINE_DEFAULTS] = cos_prefix
+            if PIPELINE_DEFAULTS in self._node["app_data"]["properties"]:
+                self._node["app_data"]["properties"][PIPELINE_DEFAULTS][COS_OBJECT_PREFIX] = cos_prefix
+            else:
+                self._node["app_data"]["properties"][PIPELINE_DEFAULTS] = {COS_OBJECT_PREFIX: cos_prefix}
 
         return pipeline_defaults
 
@@ -594,7 +597,7 @@ class PipelineDefinition(object):
         """
         self.primary_pipeline.convert_elyra_owned_properties()
 
-        pipeline_default_properties = self.primary_pipeline.get_property(PIPELINE_DEFAULTS, {})
+        pipeline_default_properties = self.primary_pipeline.get_pipeline_default_properties()
         for node in self.pipeline_nodes:
             # Determine which Elyra-owned properties will require dataclass conversion, then convert
             node.set_elyra_owned_properties(self.primary_pipeline.type)

--- a/elyra/tests/pipeline/airflow/test_processor_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_processor_airflow.py
@@ -31,7 +31,8 @@ from elyra.pipeline.airflow.processor_airflow import AirflowPipelineProcessor
 from elyra.pipeline.component_parameter import ElyraProperty
 from elyra.pipeline.parser import PipelineParser
 from elyra.pipeline.pipeline import GenericOperation
-from elyra.pipeline.pipeline_constants import MOUNTED_VOLUMES, COS_OBJECT_PREFIX
+from elyra.pipeline.pipeline_constants import COS_OBJECT_PREFIX
+from elyra.pipeline.pipeline_constants import MOUNTED_VOLUMES
 from elyra.pipeline.runtime_type import RuntimeProcessorType
 from elyra.tests.pipeline.test_pipeline_parser import _read_pipeline_resource
 from elyra.util.github import GithubClient
@@ -153,8 +154,11 @@ def test_pipeline_process(monkeypatch, processor, parsed_pipeline, sample_metada
 
     assert response.run_url == sample_metadata["metadata"]["api_endpoint"]
     assert response.object_storage_url == sample_metadata["metadata"]["cos_endpoint"]
-    # Verifies that only this substring is in the storage path since a timestamp is injected into the name
-    assert "/" + sample_metadata["metadata"]["cos_bucket"] + "/" + "untitled" in response.object_storage_path
+
+    # Verifies cos_object_prefix is added to storage path and that the correct substring is
+    # in the storage path since a timestamp is injected into the name
+    cos_prefix = parsed_pipeline.pipeline_properties.get(COS_OBJECT_PREFIX)
+    assert f"/{sample_metadata['metadata']['cos_bucket']}/{cos_prefix}/untitled" in response.object_storage_path
 
 
 @pytest.mark.parametrize("parsed_pipeline", [PIPELINE_FILE_COMPLEX], indirect=True)
@@ -215,7 +219,7 @@ def test_create_file(monkeypatch, processor, parsed_pipeline, parsed_ordered_dic
                         if "--cos-bucket" in line:
                             assert f"--cos-bucket {sample_metadata['metadata']['cos_bucket']}" in line
                         if "--cos-directory" in line:
-                            assert f"--cos-directory \'{cos_prefix}/some-instance-id\'" in line
+                            assert f"--cos-directory '{cos_prefix}/some-instance-id'" in line
 
                         if "namespace=" in line:
                             assert sample_metadata["metadata"]["user_namespace"] == read_key_pair(line)["value"]

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -15,6 +15,7 @@
 #
 import os
 from pathlib import Path
+import re
 import tarfile
 from unittest import mock
 
@@ -33,10 +34,12 @@ from elyra.pipeline.parser import PipelineParser
 from elyra.pipeline.pipeline import GenericOperation
 from elyra.pipeline.pipeline import Operation
 from elyra.pipeline.pipeline import Pipeline
+from elyra.pipeline.pipeline_constants import COS_OBJECT_PREFIX
 from elyra.tests.pipeline.test_pipeline_parser import _read_pipeline_resource
 
 
 ARCHIVE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "resources", "archive")
+PIPELINE_FILE_COMPLEX = "resources/sample_pipelines/pipeline_dependency_complex.json"
 
 
 @pytest.fixture
@@ -47,9 +50,9 @@ def processor(setup_factory_data):
 
 
 @pytest.fixture
-def pipeline():
-    pipeline_resource = _read_pipeline_resource("resources/sample_pipelines/pipeline_3_node_sample.json")
-    return PipelineParser.parse(pipeline_resource)
+def parsed_pipeline(request):
+    pipeline_resource = _read_pipeline_resource(request.param)
+    return PipelineParser().parse(pipeline_json=pipeline_resource)
 
 
 @pytest.fixture
@@ -62,6 +65,11 @@ def sample_metadata():
         "cos_bucket": "test",
         "engine": "Argo",
         "tags": [],
+        "user_namespace": "default",
+        "cos_auth_type": "USER_CREDENTIALS",
+        "api_username": "user@example.com",
+        "api_password": "12341234",
+        "runtime_type": "KUBEFLOW_PIPELINES",
     }
 
 
@@ -543,3 +551,78 @@ def test_cc_pipeline_component_no_input(monkeypatch, processor, component_cache,
 
     # Compile pipeline and save into pipeline_path
     kfp_argo_compiler.Compiler().compile(constructed_pipeline_function, pipeline_path)
+
+
+@pytest.mark.parametrize("parsed_pipeline", [PIPELINE_FILE_COMPLEX], indirect=True)
+def test_create_yaml_complex_pipeline(monkeypatch, processor, parsed_pipeline, sample_metadata, tmpdir):
+    pipeline_json = _read_pipeline_resource(PIPELINE_FILE_COMPLEX)
+
+    # Ensure the value of COS_OBJECT_PREFIX has been propagated to the Pipeline object appropriately
+    cos_prefix = pipeline_json["pipelines"][0]["app_data"]["properties"]["pipeline_defaults"].get(COS_OBJECT_PREFIX)
+    assert cos_prefix == parsed_pipeline.pipeline_properties.get(COS_OBJECT_PREFIX)
+
+    # Build a mock runtime config for use in _cc_pipeline
+    mocked_runtime = Metadata(name="test-metadata", display_name="test", schema_name="kfp", metadata=sample_metadata)
+    # Build mock runtime images for use in _cc_pipeline
+    image_one_md = {"image_name": "tensorflow/tensorflow:2.0.0-py3", "pull_policy": "IfNotPresent", "tags": []}
+    image_two_md = {"image_name": "elyra/examples:1.0.0-py3", "pull_policy": "Always", "tags": []}
+    mocked_images = [
+        Metadata(name="test-image-metadata", display_name="test-image", schema_name="kfp", metadata=image_one_md),
+        Metadata(name="test-image-metadata2", display_name="test-image2", schema_name="kfp", metadata=image_two_md),
+    ]
+
+    # Mock necessary functions (incl. side effects for each node)
+    mock_side_effects = [mocked_runtime] + [mocked_images for _ in range(len(pipeline_json["pipelines"][0]["nodes"]))]
+    mocked_func = mock.Mock(return_value="default", side_effect=mock_side_effects)
+    monkeypatch.setattr(processor, "_get_metadata_configuration", mocked_func)
+    monkeypatch.setattr(processor, "_upload_dependencies_to_object_store", lambda w, x, y, prefix: True)
+    monkeypatch.setattr(processor, "_get_dependency_archive_name", lambda x: True)
+    monkeypatch.setattr(processor, "_verify_cos_connectivity", lambda x: True)
+
+    inst_id = "test-instance-id"
+    pipeline_func = lambda: processor._cc_pipeline(parsed_pipeline, pipeline_name="test", pipeline_instance_id=inst_id)
+    pipeline_path = str(Path(tmpdir) / "complex_test.yaml")
+
+    # Compile pipeline, save into pipeline_path, then read YAML
+    kfp_argo_compiler.Compiler().compile(pipeline_func, pipeline_path)
+    with open(pipeline_path) as f:
+        pipeline_yaml = yaml.safe_load(f.read())
+
+    def list_to_sorted_str(convert_list):
+        """Helper function to convert a list of files into a semicolon-separated sorted string"""
+        convert_str = ""
+        for item in convert_list:
+            convert_str += f"{item};"
+        return "".join(sorted(convert_str[:-1]))
+
+    # Sort and clean node lists in preparation for direct comparison between YAML and JSON
+    pipeline_nodes = sorted(pipeline_json["pipelines"][0]["nodes"], key=lambda d: d["app_data"]["label"])
+    yaml_nodes = [template for template in pipeline_yaml["spec"]["templates"] if template["name"] != "lambda"]
+
+    for node_yaml, node_json in zip(yaml_nodes, pipeline_nodes):
+        # Check the each node for correctness
+        if "container" not in node_yaml or "args" not in node_yaml["container"]:
+            continue
+
+        node_args = node_yaml["container"]["args"][0]
+
+        # Check that COS values are the same for each node
+        assert f'--cos-directory "{cos_prefix}/{inst_id}"' in node_args
+        assert f"--cos-endpoint {sample_metadata['cos_endpoint']}" in node_args
+        assert f"--cos-bucket {sample_metadata['cos_bucket']}" in node_args
+
+        component_parameters = node_json["app_data"]["component_parameters"]
+        assert f"--file \"{component_parameters.get('filename')}\"" in node_args  # check filename
+        assert node_yaml["container"]["image"] == component_parameters.get("runtime_image")  # check runtime image
+
+        if component_parameters.get("inputs"):  # check inputs
+            args_input = re.search(r' --inputs "([\w.;]+)" ', node_args)
+            assert list_to_sorted_str(component_parameters["inputs"]) in "".join(sorted(args_input[1]))
+        if component_parameters.get("outputs"):  # check outputs
+            args_output = re.search(r' --outputs "([\w.;]+)" ', node_args)
+            assert list_to_sorted_str(component_parameters["outputs"]) in "".join(sorted(args_output[1]))
+        if component_parameters.get("env_vars"):  # check env_vars
+            env_list_from_yaml = node_yaml["container"]["env"]
+            for var_dict in component_parameters["env_vars"]:
+                adjusted_var_dict = {"name": var_dict["env_var"], "value": var_dict["value"]}
+                assert adjusted_var_dict in env_list_from_yaml

--- a/elyra/tests/pipeline/resources/sample_pipelines/pipeline_dependency_complex.json
+++ b/elyra/tests/pipeline/resources/sample_pipelines/pipeline_dependency_complex.json
@@ -632,6 +632,11 @@
         "ui_data": {
           "comments": []
         },
+        "properties": {
+          "pipeline_defaults": {
+            "cos_object_prefix": "test/prefix"
+          }
+        },
         "version": 5,
         "runtime": "kfp",
         "runtime_config": "kfp-yukked1",


### PR DESCRIPTION
Prior to this PR, pipelines with a `cos_object_prefix` defined will fail to run on `main` and the 3.12 release.

### What changes were proposed in this pull request?
This PR does a handful of related things. First, the `pipeline_parameters` property on the `pipeline_definition.py` `Pipeline` object is removed - it is no longer necessary now that `cos_object_prefix` is stored in the `pipeline_defaults` stanza of the pipeline JSON. (Prior to the changes in #2780, `cos_object_prefix` existed as a sibling to the `pipeline_defaults` stanza). The `PIPELINE_META_PROPERTIES` constant is also no longer needed and is removed. A handful of helper methods are added to `component_parameter.py` and, as a result, the `convert_elyra_owned_properties` methods are simplified.

The key-value pairs in the `pipeline_defaults` stanza are passed to the `pipeline.py` `Pipeline` object and accessed by the runtime processors in the same way as before, but now this property is named `pipeline_properties` rather than `pipeline_parameters` (in order to prepare for an implementation of #2936).

Of note here is that no pipeline migration is necessary right now. In order to avoid a migration so soon in 3.13 (3.12 just required migration), a workaround is added to the backend that supports `cos_object_prefix` both as a child of the `pipeline_defaults` and as a sibling. See `pipeline_definition:191:197`.

### How was this pull request tested?
- [x] Airflow - a case was added to an existing test to cover `cos_object_prefix` functionality; existing case that uses the same sample pipeline was also updated accordingly
- [x] KFP -added a new test (`test_create_yaml_complex_pipeline`) to cover `cos_object_prefix` and other functionality; mimics the `create_test_file` test in `test_airflow_processor.py`
- [x] Manual test with `cos_object_prefix` defined in the `pipeline_defaults` stanza of the pipeline json
- [x] Manual test with `cos_object_prefix` defined in the `app_data` stanza of the pipeline json

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
