### PR TITLE
Skip DisableNodeCaching instance conversion on subsequent attempts

### DIFF
--- a/elyra/pipeline/component_parameter.py
+++ b/elyra/pipeline/component_parameter.py
@@ -295,6 +295,8 @@ class DisableNodeCaching(ElyraProperty):
 
     @classmethod
     def get_single_instance(cls, value: Optional[Any] = None) -> ElyraProperty | None:
+        if isinstance(value, ElyraProperty):
+            return value  # value is already a single instance, no further action required
         return DisableNodeCaching(selection=value)
 
     @classmethod


### PR DESCRIPTION
Fixes #2979

### What changes were proposed in this pull request?
For pipeline export and submit, a `PipelineDefinition` object is initialized multiple times. Any property that is converted to an `ElyraProperty`, however, only needs to be converted once. An attempt to convert what is already an `ElyraProperty` will result in unexpected behavior, as seen in #2979. This case is already covered for all properties besides `DisableNodeCaching` [here](https://github.com/elyra-ai/elyra/blob/682f0ffa6ef7a2a6191d77faf8a5e6243bd0c71b/elyra/pipeline/component_parameter.py#L160-L161).

Because `DisableNodeCaching` currently requires special handling (until #2969 is closed), the same `if` statement linked previously is also added to it's one-off `get_single_instance` method.

### How was this pull request tested?
Tested manually, confirming that `pipelines.kubeflow.org/max_cache_staleness: P0D` appears in the YAML.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
