### PR TITLE
Allow for custom export file name

### DIFF
--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -711,6 +711,7 @@ const PipelineWrapper: React.FC<IProps> = ({
                 runtimeData={runtimeData}
                 runtimeTypeInfo={runtimeTypes}
                 pipelineType={type}
+                exportName={pipelineName}
               />
             ),
             buttons: [Dialog.cancelButton(), Dialog.okButton()],
@@ -766,7 +767,8 @@ const PipelineWrapper: React.FC<IProps> = ({
       const pipeline_dir = PathExt.dirname(contextRef.current.path);
       const basePath = pipeline_dir ? `${pipeline_dir}/` : '';
       const exportType = dialogResult.value.pipeline_filetype;
-      const exportPath = `${basePath}${pipelineName}.${exportType}`;
+      const exportName = dialogResult.value.export_name;
+      const exportPath = `${basePath}${exportName}.${exportType}`;
 
       switch (actionType) {
         case 'run':

--- a/packages/pipeline-editor/src/PipelineExportDialog.tsx
+++ b/packages/pipeline-editor/src/PipelineExportDialog.tsx
@@ -60,15 +60,6 @@ export const PipelineExportDialog: React.FC<IProps> = ({
 }) => {
   return (
     <form className="elyra-dialog-form">
-      <label htmlFor="export_name">Export Name:</label>
-      <br />
-      <input
-        type="text"
-        id="export_name"
-        name="export_name"
-        defaultValue={exportName}
-        data-form-required
-      />
       <RuntimeConfigSelect
         runtimeData={runtimeData}
         pipelineType={pipelineType}
@@ -78,6 +69,17 @@ export const PipelineExportDialog: React.FC<IProps> = ({
           return <FileTypeSelect fileTypes={info?.export_file_types ?? []} />;
         }}
       </RuntimeConfigSelect>
+      <label htmlFor="export_name">Export Filename:</label>
+      <br />
+      <input
+        type="text"
+        id="export_name"
+        name="export_name"
+        defaultValue={exportName}
+        data-form-required
+      />
+      <br />
+      <br />
       <input
         type="checkbox"
         className="elyra-Dialog-checkbox"

--- a/packages/pipeline-editor/src/PipelineExportDialog.tsx
+++ b/packages/pipeline-editor/src/PipelineExportDialog.tsx
@@ -49,15 +49,26 @@ interface IProps {
   runtimeData: IRuntimeData;
   runtimeTypeInfo: IRuntimeType[];
   pipelineType?: string;
+  exportName: string;
 }
 
 export const PipelineExportDialog: React.FC<IProps> = ({
   runtimeData,
   runtimeTypeInfo,
-  pipelineType
+  pipelineType,
+  exportName
 }) => {
   return (
     <form className="elyra-dialog-form">
+      <label htmlFor="export_name">Export Name:</label>
+      <br />
+      <input
+        type="text"
+        id="export_name"
+        name="export_name"
+        defaultValue={exportName}
+        data-form-required
+      />
       <RuntimeConfigSelect
         runtimeData={runtimeData}
         pipelineType={pipelineType}


### PR DESCRIPTION
Fixes #1417 

### What changes were proposed in this pull request?
Added functionality that allows the user to change the export file name to their own custom name if needed, if not, keeps it as the export path name


This shows the default export name: 
![export_pt1](https://user-images.githubusercontent.com/94708230/200068018-53b789be-d906-459e-9ab0-3fb1cdbfac19.png)

This shows that it allows you to customize the export name to whatever you want:  
![export_pt2](https://user-images.githubusercontent.com/94708230/200068039-d8b81fd2-dfe1-42f5-ab1b-b9518b86d885.png)

This shows that the file exports and saves successfully with the custom export name:  
![export_pt3](https://user-images.githubusercontent.com/94708230/200068052-8d4bfd4e-85b4-4792-927c-a03195554007.png)


<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->


### How was this pull request tested?
Tested manually, see screenshots shown above. After the integration tests run, we will add a test to make sure this functionality works. 
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases if possible.

If it was tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
