### PR TITLE
Fix bug with propagation of node caching property

### DIFF
--- a/elyra/pipeline/component_parameter.py
+++ b/elyra/pipeline/component_parameter.py
@@ -294,7 +294,7 @@ class DisableNodeCaching(ElyraProperty):
         self.selection = None
         if selection in ["True", "true", True]:
             self.selection = True
-        elif selection == ["False", "false", False]:
+        elif selection in ["False", "false", False]:
             self.selection = False
 
     @classmethod

--- a/elyra/pipeline/component_parameter.py
+++ b/elyra/pipeline/component_parameter.py
@@ -291,13 +291,18 @@ class DisableNodeCaching(ElyraProperty):
     _json_data_type = "string"
 
     def __init__(self, selection, **kwargs):
-        self.selection = selection == "True"
+        self.selection = None
+        if selection == "True":
+            self.selection = True
+        elif selection == "False":
+            self.selection = False
 
     @classmethod
     def get_single_instance(cls, value: Optional[Any] = None) -> ElyraProperty | None:
         if isinstance(value, ElyraProperty):
             return value  # value is already a single instance, no further action required
-        return DisableNodeCaching(selection=value)
+        instance = DisableNodeCaching(selection=value)
+        return None if instance.should_discard() else instance
 
     @classmethod
     def get_schema(cls) -> Dict[str, Any]:
@@ -317,6 +322,9 @@ class DisableNodeCaching(ElyraProperty):
         """Add DisableNodeCaching info to the execution object for the given runtime processor"""
         runtime_processor.add_disable_node_caching(instance=self, execution_object=execution_object, **kwargs)
 
+    def should_discard(self) -> bool:
+        """Ignore this DisableNodeCaching instance if neither True nor False was selected."""
+        return self.selection is None
 
 class CustomSharedMemorySize(ElyraProperty):
     """An ElyraProperty representing shared memory size for a node."""

--- a/elyra/pipeline/component_parameter.py
+++ b/elyra/pipeline/component_parameter.py
@@ -326,6 +326,7 @@ class DisableNodeCaching(ElyraProperty):
         """Ignore this DisableNodeCaching instance if neither True nor False was selected."""
         return self.selection is None
 
+
 class CustomSharedMemorySize(ElyraProperty):
     """An ElyraProperty representing shared memory size for a node."""
 

--- a/elyra/pipeline/component_parameter.py
+++ b/elyra/pipeline/component_parameter.py
@@ -290,11 +290,11 @@ class DisableNodeCaching(ElyraProperty):
     property_description = "Disable caching to force node re-execution in the target runtime environment."
     _json_data_type = "string"
 
-    def __init__(self, selection, **kwargs):
+    def __init__(self, selection: Union[str, bool], **kwargs):
         self.selection = None
-        if selection == "True":
+        if selection in ["True", "true", True]:
             self.selection = True
-        elif selection == "False":
+        elif selection == ["False", "false", False]:
             self.selection = False
 
     @classmethod

--- a/elyra/tests/pipeline/resources/sample_pipelines/pipeline_valid_with_pipeline_default.json
+++ b/elyra/tests/pipeline/resources/sample_pipelines/pipeline_valid_with_pipeline_default.json
@@ -71,7 +71,8 @@
           "app_data": {
             "label": "{{label}}",
             "component_parameters": {
-              "mounted_volumes": []
+              "mounted_volumes": [],
+              "disable_node_caching": "False"
             },
             "component_source": "{{component_source}}",
             "ui_data": {
@@ -99,7 +100,8 @@
             ],
             "mounted_volumes": [
               { "path": "/mnt/vol2", "pvc_name": "pvc-claim-2" }
-            ]
+            ],
+            "disable_node_caching": "True"
           },
           "runtime": "{{runtime description}}"
         },

--- a/elyra/tests/pipeline/resources/sample_pipelines/pipeline_valid_with_pipeline_default.json
+++ b/elyra/tests/pipeline/resources/sample_pipelines/pipeline_valid_with_pipeline_default.json
@@ -55,7 +55,8 @@
             "component_parameters": {
               "mounted_volumes": [
                 { "path": "/mnt/vol1", "pvc_name": "pvc-claim-1" }
-              ]
+              ],
+              "disable_node_caching": false
             },
             "component_source": "{{component_source}}",
             "ui_data": {

--- a/elyra/tests/pipeline/test_pipeline_definition.py
+++ b/elyra/tests/pipeline/test_pipeline_definition.py
@@ -172,7 +172,7 @@ def test_propagate_pipeline_default_properties(monkeypatch, catalog_instance):
     # Ensure DisableNodeCaching is propagated to all custom components
     assert generic_node.get_component_parameter(DISABLE_NODE_CACHING) is None
     assert custom_node_test.get_component_parameter(DISABLE_NODE_CACHING).selection is True
-    assert custom_node_derive1.get_component_parameter(DISABLE_NODE_CACHING).selection is True
+    assert custom_node_derive1.get_component_parameter(DISABLE_NODE_CACHING).selection is False
     assert custom_node_derive2.get_component_parameter(DISABLE_NODE_CACHING).selection is False
 
 

--- a/elyra/tests/pipeline/test_pipeline_definition.py
+++ b/elyra/tests/pipeline/test_pipeline_definition.py
@@ -23,7 +23,8 @@ from elyra.pipeline.component import Component
 from elyra.pipeline.component_parameter import ElyraProperty
 from elyra.pipeline.component_parameter import ElyraPropertyList
 from elyra.pipeline.component_parameter import KubernetesSecret
-from elyra.pipeline.pipeline_constants import ENV_VARIABLES, DISABLE_NODE_CACHING
+from elyra.pipeline.pipeline_constants import DISABLE_NODE_CACHING
+from elyra.pipeline.pipeline_constants import ENV_VARIABLES
 from elyra.pipeline.pipeline_constants import KUBERNETES_SECRETS
 from elyra.pipeline.pipeline_constants import MOUNTED_VOLUMES
 from elyra.pipeline.pipeline_constants import RUNTIME_IMAGE


### PR DESCRIPTION
Fixes #3010

### What changes were proposed in this pull request?
`DisableNodeCaching` currently requires special handling, as it is our only Elyra-owned property that is not stored and processed as an object. As a result, values weren't being stored in their instances properly and therefore weren't propagating properly. This PR adds a `should_discard` method to `DisableNodeCaching` in order to: 1.) fix the propagation issue now, and 2.) prepare for when this property is finally converted into an object-valued property in the pipeline JSON.

### How was this pull request tested?
I added a case to an existing test because this has unfortunately come up before. We could potentially remove this case if desired once we switch the handling/storage of `DisableNodeCaching` to an object-valued properly. Instead, however, we should probably have a test case for each Elyra-owned property.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
