### PR TITLE
Address warnings produced by tests

### DIFF
--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -32,8 +32,8 @@ from urllib.parse import urlparse
 
 from deprecation import deprecated
 from jupyter_core.paths import ENV_JUPYTER_PATH
-from requests import session
 from requests.auth import HTTPBasicAuth
+from requests.sessions import Session
 from traitlets.config import LoggingConfigurable
 from traitlets.traitlets import default
 from traitlets.traitlets import Integer
@@ -659,7 +659,7 @@ class UrlComponentCatalogConnector(ComponentCatalogConnector):
                 return None
 
         try:
-            requests_session = session()
+            requests_session = Session()
             if pr.scheme == "file":
                 requests_session.mount("file://", FileTransportAdapter())
             res = requests_session.get(

--- a/elyra/pipeline/elyra_engine.py
+++ b/elyra/pipeline/elyra_engine.py
@@ -59,7 +59,7 @@ class ElyraEngine(NBClientEngine):
         """
 
         # Exclude parameters that named differently downstream
-        safe_kwargs = remove_args(["timeout", "startup_timeout", "kernel_env", "kernel_cwd"], **kwargs)
+        safe_kwargs = remove_args(["timeout", "startup_timeout", "kernel_env", "kernel_cwd", "input_path"], **kwargs)
 
         # Nicely handle preprocessor arguments prioritizing values set by engine
         final_kwargs = merge_kwargs(

--- a/elyra/tests/metadata/test_metadata.py
+++ b/elyra/tests/metadata/test_metadata.py
@@ -689,10 +689,6 @@ def test_manager_hierarchy_remove(tests_hierarchy_manager, factory_location, sha
     assert byo_1.resource.startswith(str(factory_location))
 
 
-@pytest.mark.skipif(
-    os.getenv("TEST_VALIDATION_PERFORMANCE", "0") != "1",
-    reason="test_validation_performance - enable via env TEST_VALIDATION_PERFORMANCE=1",
-)
 def test_validation_performance():
     import psutil
 
@@ -714,7 +710,7 @@ def test_validation_performance():
     memory_end = process.memory_info()
     diff = (memory_end.rss - memory_start.rss) / 1024
     print(
-        f"Memory: {diff:,} kb, Start: {memory_start.rss / 1024 / 1024:,.3f} mb, "
+        f"\nMemory: {diff:,} kb, Start: {memory_start.rss / 1024 / 1024:,.3f} mb, "
         f"End: {memory_end.rss / 1024 / 1024:,.3f} mb., "
         f"Elapsed time: {t1-t0:.3f}s over {iterations} iterations."
     )

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -62,8 +62,8 @@ async def test_modify_component_catalogs(component_cache, metadata_manager_with_
 
     # Create new registry instance with a single URL-based component
     urls = [
-        "https://raw.githubusercontent.com/elyra-ai/elyra/main/elyra/tests/pipeline/resources/components/"
-        "airflow_test_operator.py"
+        "https://raw.githubusercontent.com/elyra-ai/elyra/main/elyra/tests/pipeline/"
+        "resources/components/airflow_test_operator.py"
     ]
 
     instance_metadata = {
@@ -378,7 +378,10 @@ def test_parse_airflow_component_url():
     reader = UrlComponentCatalogConnector(airflow_supported_file_types)
 
     # Read contents of given path
-    url = "https://raw.githubusercontent.com/elyra-ai/elyra/main/elyra/tests/pipeline/resources/components/airflow_test_operator.py"  # noqa: E501
+    url = (
+        "https://raw.githubusercontent.com/elyra-ai/elyra/main/elyra/tests/pipeline/"
+        "resources/components/airflow_test_operator.py"
+    )
     catalog_entry_data = {"url": url}
 
     # Construct a catalog instance
@@ -459,9 +462,9 @@ def test_parse_airflow_component_file_no_inputs():
 @pytest.mark.parametrize(
     "invalid_url",
     [
-        "https://nourl.py",  # test an invalid host
-        "https://raw.githubusercontent.com/elyra-ai/elyra/main/elyra/\
-     pipeline/tests/resources/components/invalid_file.py",  # test an invalid file
+        "https://non-existent-host.py",  # test an invalid host
+        "https://raw.githubusercontent.com/elyra-ai/elyra/main/elyra/"
+        "tests/pipeline/resources/components/missing_file.py",  # test an invalid file
     ],
     indirect=True,
 )

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -301,8 +301,8 @@ def test_parse_airflow_component_file():
 
     # Ensure that a long description with line wrapping and a backslash escape has rendered
     # (and hence did not raise an error during json.loads in the properties API request)
-    parsed_description = """a string parameter with a very long description
-        that wraps lines and also has an escaped underscore in it, as shown here: (\_)  # noqa W605"""
+    parsed_description = r"""a string parameter with a very long description
+        that wraps lines and also has an escaped underscore in it, as shown here: (\_)"""  # noqa W605
     modified_description = parsed_description.replace("\n", " ") + " (type: str)"  # modify desc acc. to parser rules
     assert get_parameter_description("long_description_property") == modified_description
 

--- a/elyra/tests/pipeline/airflow/test_processor_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_processor_airflow.py
@@ -194,7 +194,8 @@ def test_create_file(monkeypatch, processor, parsed_pipeline, parsed_ordered_dic
         assert export_pipeline_output_path == response
         assert os.path.isfile(export_pipeline_output_path)
 
-        file_as_lines = open(response).read().splitlines()
+        with open(response) as f:
+            file_as_lines = f.read().splitlines()
 
         assert "from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator" in file_as_lines
 
@@ -300,7 +301,8 @@ def test_create_file_custom_components(
         assert export_pipeline_output_path == response
         assert os.path.isfile(export_pipeline_output_path)
 
-        file_as_lines = open(response).read().splitlines()
+        with open(response) as f:
+            file_as_lines = f.read().splitlines()
 
         pipeline_description = pipeline_json["pipelines"][0]["app_data"]["properties"]["description"]
         escaped_description = pipeline_description.replace('"""', '\\"\\"\\"')

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -896,7 +896,7 @@ def test_generate_pipeline_dsl_compile_pipeline_dsl_workflow_engine_test(
     monkeypatch.setattr(processor, "_upload_dependencies_to_object_store", lambda w, x, y, prefix: True)
     monkeypatch.setattr(processor, "_verify_cos_connectivity", lambda x: True)
 
-    compiled_output_file = Path(tmpdir) / os.path.basename(test_pipeline_file.with_suffix(".yaml"))
+    compiled_output_file = Path(tmpdir) / test_pipeline_file.with_suffix(".yaml").name
     compiled_output_file_name = str(compiled_output_file.absolute())
 
     # generate Python DSL for the specified workflow engine
@@ -992,7 +992,7 @@ def test_generate_pipeline_dsl_compile_pipeline_dsl_one_generic_node_pipeline_te
     monkeypatch.setattr(processor, "_upload_dependencies_to_object_store", lambda w, x, y, prefix: True)
     monkeypatch.setattr(processor, "_verify_cos_connectivity", lambda x: True)
 
-    compiled_argo_output_file = Path(tmpdir) / os.path.basename(test_pipeline_file.with_suffix(".yaml"))
+    compiled_argo_output_file = Path(tmpdir) / test_pipeline_file.with_suffix(".yaml").name
     compiled_argo_output_file_name = str(compiled_argo_output_file.absolute())
 
     # generate Python DSL for the Argo workflow engine
@@ -1212,7 +1212,7 @@ def test_generate_pipeline_dsl_compile_pipeline_dsl_generic_component_crio(
 
     # Test begins here
 
-    compiled_output_file = Path(tmpdir) / os.path.basename(test_pipeline_file.with_suffix(".yaml"))
+    compiled_output_file = Path(tmpdir) / test_pipeline_file.with_suffix(".yaml").name
     compiled_output_file_name = str(compiled_output_file.absolute())
 
     # generate Python DSL for the specified workflow engine
@@ -1371,7 +1371,7 @@ def test_generate_pipeline_dsl_compile_pipeline_dsl_optional_elyra_properties(
 
     # Test begins here
 
-    compiled_output_file = Path(tmpdir) / os.path.basename(test_pipeline_file.with_suffix(".yaml"))
+    compiled_output_file = Path(tmpdir) / test_pipeline_file.with_suffix(".yaml").name
     compiled_output_file_name = str(compiled_output_file.absolute())
 
     # generate Python DSL
@@ -1600,7 +1600,7 @@ def test_generate_pipeline_dsl_compile_pipeline_dsl_generic_components_pipeline_
 
     # Test begins here
 
-    compiled_output_file = Path(tmpdir) / os.path.basename(test_pipeline_file.with_suffix(".yaml"))
+    compiled_output_file = Path(tmpdir) / test_pipeline_file.with_suffix(".yaml").name
     compiled_output_file_name = str(compiled_output_file.absolute())
 
     # generate Python DSL for the specified workflow engine

--- a/elyra/tests/pipeline/kfp/test_processor_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_processor_kfp.py
@@ -896,7 +896,7 @@ def test_generate_pipeline_dsl_compile_pipeline_dsl_workflow_engine_test(
     monkeypatch.setattr(processor, "_upload_dependencies_to_object_store", lambda w, x, y, prefix: True)
     monkeypatch.setattr(processor, "_verify_cos_connectivity", lambda x: True)
 
-    compiled_output_file = Path(tmpdir) / test_pipeline_file.with_suffix(".yaml")
+    compiled_output_file = Path(tmpdir) / os.path.basename(test_pipeline_file.with_suffix(".yaml"))
     compiled_output_file_name = str(compiled_output_file.absolute())
 
     # generate Python DSL for the specified workflow engine
@@ -992,7 +992,7 @@ def test_generate_pipeline_dsl_compile_pipeline_dsl_one_generic_node_pipeline_te
     monkeypatch.setattr(processor, "_upload_dependencies_to_object_store", lambda w, x, y, prefix: True)
     monkeypatch.setattr(processor, "_verify_cos_connectivity", lambda x: True)
 
-    compiled_argo_output_file = Path(tmpdir) / test_pipeline_file.with_suffix(".yaml")
+    compiled_argo_output_file = Path(tmpdir) / os.path.basename(test_pipeline_file.with_suffix(".yaml"))
     compiled_argo_output_file_name = str(compiled_argo_output_file.absolute())
 
     # generate Python DSL for the Argo workflow engine
@@ -1212,7 +1212,7 @@ def test_generate_pipeline_dsl_compile_pipeline_dsl_generic_component_crio(
 
     # Test begins here
 
-    compiled_output_file = Path(tmpdir) / test_pipeline_file.with_suffix(".yaml")
+    compiled_output_file = Path(tmpdir) / os.path.basename(test_pipeline_file.with_suffix(".yaml"))
     compiled_output_file_name = str(compiled_output_file.absolute())
 
     # generate Python DSL for the specified workflow engine
@@ -1371,7 +1371,7 @@ def test_generate_pipeline_dsl_compile_pipeline_dsl_optional_elyra_properties(
 
     # Test begins here
 
-    compiled_output_file = Path(tmpdir) / test_pipeline_file.with_suffix(".yaml")
+    compiled_output_file = Path(tmpdir) / os.path.basename(test_pipeline_file.with_suffix(".yaml"))
     compiled_output_file_name = str(compiled_output_file.absolute())
 
     # generate Python DSL
@@ -1600,7 +1600,7 @@ def test_generate_pipeline_dsl_compile_pipeline_dsl_generic_components_pipeline_
 
     # Test begins here
 
-    compiled_output_file = Path(tmpdir) / test_pipeline_file.with_suffix(".yaml")
+    compiled_output_file = Path(tmpdir) / os.path.basename(test_pipeline_file.with_suffix(".yaml"))
     compiled_output_file_name = str(compiled_output_file.absolute())
 
     # generate Python DSL for the specified workflow engine

--- a/elyra/tests/pipeline/resources/components/airflow_test_operator.py
+++ b/elyra/tests/pipeline/resources/components/airflow_test_operator.py
@@ -55,11 +55,11 @@ class TestOperator(BaseOperator):
     :param unusual_type_list: a list parameter with the phrase 'string' in type description
     :type unusual_type_list: a list of strings
     :param long_description_property: a string parameter with a very long description
-        that wraps lines and also has an escaped underscore in it, as shown here: (\_)  # noqa W605
+        that wraps lines and also has an escaped underscore in it, as shown here: (\_)
     :type long_description_property: str
     :param: mounted_volumes: a property with the same name as an Elyra system property
     :type: str
-    """
+    """  # noqa W605
 
     def __init__(
         self,

--- a/elyra/tests/pipeline/resources/components/airflow_test_operator.py
+++ b/elyra/tests/pipeline/resources/components/airflow_test_operator.py
@@ -23,7 +23,7 @@ from airflow.operators.imported_operator import ImportedOperator  # noqa TODO
 
 
 class TestOperator(BaseOperator):
-    """
+    r"""
     Operator derives from BaseOperator and mimics Airflow v1 Operator structure.
     Note that some parameters have been intentionally omitted from the docstring
     in order to test that fallback types are assigned appropriately.

--- a/pytest.ini
+++ b/pytest.ini
@@ -48,3 +48,7 @@ filterwarnings =
   # networkx will use pandas and numpy if available, otherwise, it produces these ImportWarning
   ignore:pandas not found, skipping conversion test:ImportWarning
   ignore:numpy not found, skipping conversion test:ImportWarning
+
+  # minio/api.py produces these warnings - tests show urllib3==1.26.x in use
+  ignore:HTTPResponse.getheader\(\) is deprecated and will be removed in urllib3 v2.1.0.:DeprecationWarning
+  ignore:HTTPResponse.getheaders\(\) is deprecated and will be removed in urllib3 v2.1.0.:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -25,3 +25,4 @@ filterwarnings =
   ignore:make_current is deprecated:DeprecationWarning
   ignore:clear_current is deprecated:DeprecationWarning
   ignore:There is no current event loop:DeprecationWarning
+  ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,3 +19,9 @@ markers =
     script_launch_mode
 
 script_launch_mode = subprocess
+
+filterwarnings =
+  error
+  ignore:make_current is deprecated:DeprecationWarning
+  ignore:clear_current is deprecated:DeprecationWarning
+  ignore:There is no current event loop:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -25,4 +25,8 @@ filterwarnings =
   ignore:make_current is deprecated:DeprecationWarning
   ignore:clear_current is deprecated:DeprecationWarning
   ignore:There is no current event loop:DeprecationWarning
+  ignore:Passing unrecognized arguments to super\(PapermillNotebookClient\):DeprecationWarning
   ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning
+  ignore:`dsl.ContainerOp.image` will be removed in future releases:PendingDeprecationWarning
+  ignore:`dsl.ContainerOp.add_env_variable` will be removed in future releases:PendingDeprecationWarning
+  ignore:Creating a LegacyVersion has been deprecated:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,12 +21,30 @@ markers =
 script_launch_mode = subprocess
 
 filterwarnings =
-  error
+  # We should get to a place where 'error' is NOT commented out.  This will allow us to
+  # catch warnings when they occur and take action, either by adjusting the code or ignoring
+  # the warning.
+  # error
+
+  # These are produced by upstream (server and tornado) dependencies
   ignore:make_current is deprecated:DeprecationWarning
   ignore:clear_current is deprecated:DeprecationWarning
   ignore:There is no current event loop:DeprecationWarning
+
+  # Papermill has included a parameter into a configurable's init and traitlets detects when
+  # no attributes match the argument
   ignore:Passing unrecognized arguments to super\(PapermillNotebookClient\):DeprecationWarning
+
+  # jupyter_core 5.x changes how it locates platform dirs and produces this warning
   ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning
+
+  # These are probably deprecated in the next KFP release
   ignore:`dsl.ContainerOp.image` will be removed in future releases:PendingDeprecationWarning
   ignore:`dsl.ContainerOp.add_env_variable` will be removed in future releases:PendingDeprecationWarning
+
+  # The bootstrapper currently looks for version instances of `LegacyVersion`
   ignore:Creating a LegacyVersion has been deprecated:DeprecationWarning
+
+  # networkx will use pandas and numpy if available, otherwise, it produces these ImportWarning
+  ignore:pandas not found, skipping conversion test:ImportWarning
+  ignore:numpy not found, skipping conversion test:ImportWarning


### PR DESCRIPTION
This pull request takes a look at removing/ignoring a majority of the warnings that are produced by the server tests (via `make test-server`).  Many of these warnings are ignored as they stem from upstream modules.  That said, there are a number that have been resolved via code changes (primarily in tests) where things like file descriptors were not closed, etc.  

We should strive to get to a place where all warnings (except those explicitly handled) are treated as errors.  This will enable their capture in a timely manner so things like `DeprecationWarning` can be handled and adjusted (if necessary) or added to the list of ignored warnings (if appropriate).

This PR adds a number of warnings that are now ignored where, like caps on dependencies, a comment is provided indicating why the warning is ignored and/or additional context about the warning.  At this point, the `error` filter is disabled.  We could also consider ignoring these warnings using [decorators](https://docs.pytest.org/en/stable/how-to/capture-warnings.html#pytest-mark-filterwarnings) in the test files themselves.

It looks like the number of warnings varies based on which version of Python is in use, but I'm seeing the warnings decrease from thousands of warnings to these 15:
```
================================================================================= warnings summary =================================================================================
elyra/tests/pipeline/test_pipeline_definition.py: 2 warnings
elyra/tests/pipeline/test_pipeline_parser.py: 1 warning
elyra/tests/pipeline/test_validation.py: 1 warning
elyra/tests/pipeline/airflow/test_component_parser_airflow.py: 9 warnings
elyra/tests/pipeline/airflow/test_processor_airflow.py: 2 warnings
  <unknown>:26: DeprecationWarning: invalid escape sequence '\_'

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================ slowest durations =================================================================================

(1714 durations < 60s hidden.  Use -vv to show these durations.)
============================================================= 570 passed, 2 skipped, 15 warnings in 347.53s (0:05:47) ==============================================================
```
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
