### PR TITLE
Decrease jupyter_core floor, cap nbclient for 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "entrypoints>=0.3",
     "jinja2>=3",
     "jsonschema>=3.2.0,<4.0",  # Cap from kfp
-    "jupyter_core>=4.11.2,<5",  # Cap due to v5 not support python<3.8
+    "jupyter_core>=4.11.0",  # Do not increase floor past 4.11.1 until Python 3.7 EOL
     "jupyter_client>=6.1.7",
     "jupyter-events<0.5.0",  # Cap from kfp from jsonschema
     "jupyter-packaging>=0.10",
@@ -32,6 +32,7 @@ dependencies = [
     "MarkupSafe>=2.1",
     "minio>=7.0.0",
     "nbclient>=0.5.1",
+    "nbclient>=0.5.1,<=0.7.0;python_version=='3.7'",  # nbclient > 0.7 requires jupyter_core >= 4.12 which doesn't exist in conda for 3.7
     "nbconvert>=6.5.1",
     "nbdime~=3.1",  # Cap from jupyterlab-git
     "nbformat>=5.1.2",


### PR DESCRIPTION
As discussed in #3069, **conda** installs of Elyra will fail because the dependency of `jupyter_core >= 4.11.2` cannot be resolved.  This is because [conda removed support for Python 3.7 last August](https://conda-forge.org/docs/user/announcements.html#dropping-python-3-7).  

This pull request will allow for conda installations of Elyra to succeed, albeit supporting versions of `jupyter_core <= 4.11.1`.  This change also resulted in capping `nbclient <= 0.7.0` for Python 3.7 since more recent versions of `nbclient` require `jupyter_core >= 4.12`.

Resolves: #3069 
Signed-off-by: Kevin Bates <kbates4@gmail.com>


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
