### PR TITLE
Remove caps in dependencies for kfp-related packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,10 @@ dependencies = [
     "deprecation",
     "entrypoints>=0.3",
     "jinja2>=3",
-    "jsonschema>=3.2.0,<4.0",  # Cap from kfp
+    "jsonschema>=3.2.0",
     "jupyter_core>=4.11.2,<5",  # Cap due to v5 not support python<3.8
     "jupyter_client>=6.1.7",
-    "jupyter-events<0.5.0",  # Cap from kfp from jsonschema
+    "jupyter-events>=0.6.2",
     "jupyter-packaging>=0.10",
     "jupyter_server>=1.7.0",
     "jupyterlab>=3.4.6,<4.0",  # comment out to use local jupyterlab
@@ -38,7 +38,7 @@ dependencies = [
     "networkx>=2.5.1",
     "papermill>=2.3.4",
     "python-lsp-server[all]>=1.1.0",
-    "pyyaml>=5.3.1,<6.0",  # Cap from kfp
+    "pyyaml>=5.3.1",
     "requests>=2.25.1",
     "rfc3986-validator>=0.1.1",
     "tornado>=6.1.0",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,6 +3,7 @@ git-python
 importlib-resources
 pytest>=5.4.1
 pytest-console-scripts
+pytest_jupyter
 pytest-tornasync
 pytest_virtualenv
 requests-mock


### PR DESCRIPTION
This pull request removes caps on `jupyter_events`, `jsonschema`, and `pyyaml` that were originally introduced due to `kfp`.  Since `kfp` introduced _artificial_ caps on `jsonschema<4` and `pyyaml<6`, yet `jupyter_events` required `jsonschema>=4` and `pyyaml>=6` an impossible resolution was introduced.  Fortunately, the floors imposed in `jupyter_events` were aggressive and we were able to contribute the necessary changes to decrease the floors of `jsonschema` and `pyyaml` to `3.2.0` and `5.3`, respectively.  Since those are the floors used by `kfp` the set of packages can be resolved.  

The decrease of the floor in `jsonschema` was non-trivial and its evolution can be found [here](https://github.com/jupyter/jupyter_events/pull/59), if interested.  `jupyter_events 0.6.1` resolved #3070, but then the `pyyaml` resolution issue was encountered once the cap for `jupyter_events` was lifted.  This latter issue was resolved in `jupyter_events 0.6.2` - resulting in its current floor.

The update of `test_requirements.txt` to include `pytest_jupyter` was necessary to get tests to run now that #3070 is resolved.  We should really be using the set of [test dependencies listed in `pyproject.toml`](https://github.com/elyra-ai/elyra/blob/080ebbb26bd864531f961e48be26d18f377a53db/pyproject.toml#L76) and remove that file, but that's another story.  At this moment the two sets of packages are in-sync.

(Note: test failures still occur due to #3072.)

Resolves: #3070

Signed-off-by: Kevin Bates <kbates4@gmail.com>
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
