### PR TITLE
Fix KFP code generation issues for pipeline parameters

### DIFF
--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -729,9 +729,10 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                 pipeline.pipeline_properties.get(pipeline_constants.COS_OBJECT_PREFIX), pipeline_instance_id
             )
             # - load the generic component definition template
-            generic_component_template = Environment(
-                loader=PackageLoader("elyra", "templates/kubeflow/v1")
-            ).get_template("generic_component_definition_template.jinja2")
+            template_env = Environment(loader=PackageLoader("elyra", "templates/kubeflow/v1"))
+            generic_component_template = template_env.get_template("generic_component_definition_template.jinja2")
+            # Add filter that escapes the " character in strings
+            template_env.filters["string_delimiter_safe"] = lambda string: re.sub('"', '\\\\\\\\"', string)
             # Determine whether we are executing in a CRI-O runtime environment
             is_crio_runtime = os.getenv("CRIO_RUNTIME", "False").lower() == "true"
 

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -573,7 +573,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
         template_env.filters["string_delimiter_safe"] = lambda string: re.sub('"', '\\"', string)
         # Add filter that converts a value to a python variable value (e.g. puts quotes around strings)
         template_env.filters["param_val_to_python_var"] = (
-            lambda p: json.dumps(p.value) if p.input_type.base_type == "String" else p.value
+            lambda p: "None" if p.value is None else (f'"{p.value}"' if p.input_type.base_type == "String" else p.value)
         )
         template = template_env.get_template("python_dsl_template.jinja2")
 

--- a/elyra/pipeline/properties.py
+++ b/elyra/pipeline/properties.py
@@ -1269,10 +1269,13 @@ class PipelineParameter(ElyraPropertyListItem):
         self.selected_type = default_value.get("type") if isinstance(default_value, dict) else None
 
         # Assign default value, if given
-        self.default_value = default_value.get("value") if isinstance(default_value, dict) else None
+        self.default_value = None
+        if isinstance(default_value, dict):
+            if default_value.get("value") not in [None, ""]:
+                self.default_value = default_value.get("value")
 
         # Assign value, if set; use default_value if not
-        self.value = value if value is not None else self.default_value
+        self.value = value if value not in [None, ""] else self.default_value
 
     def get_value_for_dict_entry(self) -> Union[str, Dict[str, Any]]:
         """

--- a/elyra/templates/kubeflow/v1/generic_component_definition_template.jinja2
+++ b/elyra/templates/kubeflow/v1/generic_component_definition_template.jinja2
@@ -3,7 +3,7 @@ description: Run a Jupyter notebook or Python/R script
 {% if task_parameters %}
 inputs:
 {%- for parameter in task_parameters %}
-- {name: {{ parameter.name }}, type: {{ parameter.input_type.component_input_type }}{% if parameter.description %}, description: "{{ parameter.description | string_delimiter_safe}}"{% endif %}{% if parameter.default_value %}, default: {{ parameter.default_value|string_delimiter_safe }}{% endif %}, optional: {{ (not parameter.required)|tojson }}}
+- {name: {{ parameter.name }}, type: {{ parameter.input_type.component_input_type }}{% if parameter.description %}, description: "{{ parameter.description | string_delimiter_safe}}"{% endif %}{% if parameter.default_value is not none %}, default: {% if parameter.selected_type == 'String' %} "{{ parameter.default_value|string_delimiter_safe }}"{% else %}{{ parameter.default_value }}{% endif %}{% endif %}, optional: {{ (not parameter.required)|tojson }}}
 {%- endfor %}
 {% endif %}
 implementation:

--- a/elyra/templates/kubeflow/v1/generic_component_definition_template.jinja2
+++ b/elyra/templates/kubeflow/v1/generic_component_definition_template.jinja2
@@ -3,7 +3,7 @@ description: Run a Jupyter notebook or Python/R script
 {% if task_parameters %}
 inputs:
 {%- for parameter in task_parameters %}
-- {name: {{ parameter.name }}, type: {{ parameter.input_type.component_input_type }}{% if parameter.description %}, description: '{{ parameter.description }}'{% endif %}{% if parameter.default_value %}, default: {{ parameter.default_value|tojson }}{% endif %}, optional: {{ (not parameter.required)|tojson }}}
+- {name: {{ parameter.name }}, type: {{ parameter.input_type.component_input_type }}{% if parameter.description %}, description: "{{ parameter.description | string_delimiter_safe}}"{% endif %}{% if parameter.default_value %}, default: {{ parameter.default_value|string_delimiter_safe }}{% endif %}, optional: {{ (not parameter.required)|tojson }}}
 {%- endfor %}
 {% endif %}
 implementation:

--- a/elyra/templates/kubeflow/v1/python_dsl_template.jinja2
+++ b/elyra/templates/kubeflow/v1/python_dsl_template.jinja2
@@ -26,7 +26,7 @@ factory_{{ hash | python_safe }} = kfp.components.load_component_from_text(compo
 def generated_pipeline(
 {% if pipeline_parameters %}
 {% for parameter in pipeline_parameters %}
-    {{ parameter.name }}{% if parameter.input_type.type_hint %}: {{ parameter.input_type.type_hint }} = {% else %}={% endif %}{{ parameter|param_val_to_python_var }},
+    {{ parameter.name }}{% if parameter.input_type.type_hint %}: {{ parameter.input_type.type_hint }}{% endif %} = {{ parameter|param_val_to_python_var }},
 {% endfor %}
 {% endif %}
 ):

--- a/elyra/tests/pipeline/test_properties.py
+++ b/elyra/tests/pipeline/test_properties.py
@@ -1,0 +1,86 @@
+#
+# Copyright 2018-2023 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from elyra.pipeline.properties import PipelineParameter
+
+# ---------------------------------------------------
+# Tests for PipelineParameter
+# ---------------------------------------------------
+
+
+def test_pipelineparameter_constructor():
+    """
+    Verify that the PipelineParameter constructor behaves as expected
+    """
+
+    # Test behavior when value and default is empty string or None AND no custom
+    # value is provided. Expected: value and default value are always returned as None
+    parm_name = "parm1"
+    parm_description = "parm1 description"
+    for parm_required in [True, False]:
+        for parm_value in ["", None]:
+            for parm_default_type in ["String", "Integer", "Float", "Bool"]:
+                for parm_default_value in ["", None]:
+                    default_value = {"type": parm_default_type, "value": parm_default_value}
+                    pp = PipelineParameter(parm_name, parm_description, parm_value, default_value, parm_required)
+                    assert pp.name == parm_name
+                    assert pp.description == parm_description
+                    assert pp.value is None
+                    assert pp.default_value is None
+                    assert pp.required == parm_required
+
+    # Test behavior when default value is empty string or None AND a custom value is provided.
+    # Expected: custom value is used.
+    parm_name = "parm2"
+    parm_description = "parm2 description"
+    for parm_required in [True, False]:
+        for parm_default_value in ["", None]:
+            # Test 'String' parameter type
+            parm_value = "a string parameter value"
+            default_value = {"type": "String", "value": parm_default_value}
+            pp = PipelineParameter(parm_name, parm_description, parm_value, default_value, parm_required)
+            assert pp.name == parm_name
+            assert pp.description == parm_description
+            assert pp.value == parm_value
+            assert pp.default_value is None
+            assert pp.required == parm_required
+            # Test 'Integer' parameter type
+            for parm_value in [0, 42]:
+                default_value = {"type": "Integer", "value": parm_default_value}
+                pp = PipelineParameter(parm_name, parm_description, parm_value, default_value, parm_required)
+                assert pp.name == parm_name
+                assert pp.description == parm_description
+                assert pp.value == parm_value
+                assert pp.default_value is None
+                assert pp.required == parm_required
+            # Test 'Float' parameter type
+            for parm_value in [0, 3.14]:
+                default_value = {"type": "Float", "value": parm_default_value}
+                pp = PipelineParameter(parm_name, parm_description, parm_value, default_value, parm_required)
+                assert pp.name == parm_name
+                assert pp.description == parm_description
+                assert pp.value == parm_value
+                assert pp.default_value is None
+                assert pp.required == parm_required
+            # Test 'Bool' parameter type
+            for parm_value in [True, False]:
+                default_value = {"type": "Bool", "value": parm_default_value}
+                pp = PipelineParameter(parm_name, parm_description, parm_value, default_value, parm_required)
+                assert pp.name == parm_name
+                assert pp.description == parm_description
+                assert pp.value == parm_value
+                assert pp.default_value is None
+                assert pp.required == parm_required


### PR DESCRIPTION
Code generation produces incorrect results (and in some scenarios fails) for some pipeline parameter scenarios. Examples below, as observed in the generated Python DSL:

 - the parameter description contains the `"` character (YAML parser chokes)
   ```
    - {name: a_quote, type: String, description: 'description with a "', default: "string default contains \" anywhere", optional: true}
   ```
 - the parameter value contains the `"` character for parameter type `String`
 - no default values are specified, e.g.
    ```
     i2: int = ,
    ```
 - a default value of zero is defined for numeric parameter types (input spec is missing this value), e.g.
    ```
      - {name: i3, type: Integer, description: 'an int with default value of 0', optional: true}
    ```
 - a default value of `False` for `Bool`-typed parameters is missing , e.g. 
    ```
    - {name: b1, type: Boolean, description: 'a boolean with default value False', optional: true}
    ```

Some of the problems were caused by the fact that `0` and `<empty-string>` were considered to be equivalent (or not equivalent) to `None`. To avoid these issues the `PipelineParameter` class now explicitly assigns `None` to parameter values and default values that are set to the empty string by the UI. 

Signed-off-by: Patrick Titzler <ptitzler@us.ibm.com>

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?

- Fix incorrect implementation

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?

To test create and export a KFP pipeline that utilizes pipeline parameters, covering the scenarios listed in the problem description. The generated Python DSL code  should properly reflect the pipeline parameters, their values, and types.
<!--
Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases, if possible.

If changes were tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added e.g. documentation only, GH workflow updates, etc.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
