### PR TITLE
Ensure env stanza is an empty dict if no seed value is given to papermill engine

### DIFF
--- a/elyra/pipeline/elyra_engine.py
+++ b/elyra/pipeline/elyra_engine.py
@@ -73,7 +73,7 @@ class ElyraEngine(NBClientEngine):
             stderr_file=stderr_file,
         )
 
-        kernel_kwargs = {"env": kwargs.get("kernel_env")}
+        kernel_kwargs = {"env": kwargs.get("kernel_env", {})}
         # Only include kernel_name and set path if GatewayKernelManager will be used
         kernel_manager_class = final_kwargs.get("kernel_manager_class")
         if kernel_manager_class == "jupyter_server.gateway.managers.GatewayKernelManager":


### PR DESCRIPTION
I'd like to reference our implementation of a [Papermill Engine](https://papermill.readthedocs.io/en/latest/extending-entry-points.html#developing-a-new-engine) in the documentation for [Gateway Provisioners](https://github.com/gateway-experiments/gateway_provisioners) to demonstrate how a user/developer can use Papermill against a Gateway server.  When attempting to use the Papermill CLI to point at ElyraEngine, the notebook's execution would fail with the following stack (snippet):
```
  File "/opt/miniconda3/envs/elyra-dev/lib/python3.10/site-packages/jupyter_client/manager.py", line 397, in _async_start_kernel
    kernel_cmd, kw = await self._async_pre_start_kernel(**kw)
  File "/opt/miniconda3/envs/elyra-dev/lib/python3.10/site-packages/jupyter_client/manager.py", line 362, in _async_pre_start_kernel
    kw = await self.provisioner.pre_launch(**kw)
  File "/opt/miniconda3/envs/elyra-dev/lib/python3.10/site-packages/jupyter_client/provisioning/local_provisioner.py", line 200, in pre_launch
    return await super().pre_launch(cmd=kernel_cmd, **kwargs)
  File "/opt/miniconda3/envs/elyra-dev/lib/python3.10/site-packages/jupyter_client/provisioning/provisioner_base.py", line 157, in pre_launch
    env = kwargs.pop('env', os.environ).copy()
AttributeError: 'NoneType' object has no attribute 'copy'
```
because, by default, the `env` stanza would be `None` if using our engine directly.

This change enables the use of `ElyraEngine` as a referenceable example.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
