### PR TITLE
Skip version check for incompatible version strings in `bootstrapper.py`

### DIFF
--- a/elyra/airflow/bootstrapper.py
+++ b/elyra/airflow/bootstrapper.py
@@ -343,21 +343,20 @@ class OpUtil(object):
                         "editable package. This may conflict with the required version: "
                         f"{ver} . Skipping..."
                     )
-                elif "git+" in current_packages[package]:
+                    continue
+                try:
+                    version.Version(current_packages[package])
+                except version.InvalidVersion:  # current version is not PEP-440 compliant
                     logger.warning(
                         f"WARNING: Source package '{package}' found already installed from "
                         f"{current_packages[package]}. This may conflict with the required "
                         f"version: {ver} . Skipping..."
                     )
-                elif isinstance(version.parse(current_packages[package]), version.LegacyVersion):
-                    logger.warning(
-                        f"WARNING: Package '{package}' found with unsupported Legacy version "
-                        f"scheme {current_packages[package]} already installed. Skipping..."
-                    )
-                elif version.parse(ver) > version.parse(current_packages[package]):
+                    continue
+                if version.Version(ver) > version.Version(current_packages[package]):
                     logger.info(f"Updating {package} package from version {current_packages[package]} to {ver}...")
                     to_install_list.append(f"{package}=={ver}")
-                elif version.parse(ver) < version.parse(current_packages[package]):
+                elif version.Version(ver) < version.Version(current_packages[package]):
                     logger.info(
                         f"Newer {package} package with version {current_packages[package]} "
                         f"already installed. Skipping..."

--- a/elyra/kfp/bootstrapper.py
+++ b/elyra/kfp/bootstrapper.py
@@ -556,18 +556,18 @@ class OpUtil(object):
                     )
                     continue
                 try:
-                    version.parse(current_packages[package])
-                except version.InvalidVersion:
+                    version.Version(current_packages[package])
+                except version.InvalidVersion:  # current version is not PEP-440 compliant
                     logger.warning(
                         f"WARNING: Source package '{package}' found already installed from "
                         f"{current_packages[package]}. This may conflict with the required "
                         f"version: {ver} . Skipping..."
                     )
                     continue
-                if version.parse(ver) > version.parse(current_packages[package]):
+                if version.Version(ver) > version.Version(current_packages[package]):
                     logger.info(f"Updating {package} package from version {current_packages[package]} to {ver}...")
                     to_install_list.append(f"{package}=={ver}")
-                elif version.parse(ver) < version.parse(current_packages[package]):
+                elif version.Version(ver) < version.Version(current_packages[package]):
                     logger.info(
                         f"Newer {package} package with version {current_packages[package]} "
                         f"already installed. Skipping..."

--- a/elyra/kfp/bootstrapper.py
+++ b/elyra/kfp/bootstrapper.py
@@ -554,13 +554,17 @@ class OpUtil(object):
                         "editable package. This may conflict with the required version: "
                         f"{ver} . Skipping..."
                     )
-                elif "git+" in current_packages[package]:
+                    continue
+                try:
+                    version.parse(current_packages[package])
+                except version.InvalidVersion:
                     logger.warning(
                         f"WARNING: Source package '{package}' found already installed from "
                         f"{current_packages[package]}. This may conflict with the required "
                         f"version: {ver} . Skipping..."
                     )
-                elif version.parse(ver) > version.parse(current_packages[package]):
+                    continue
+                if version.parse(ver) > version.parse(current_packages[package]):
                     logger.info(f"Updating {package} package from version {current_packages[package]} to {ver}...")
                     to_install_list.append(f"{package}=={ver}")
                 elif version.parse(ver) < version.parse(current_packages[package]):


### PR DESCRIPTION
Signed-off-by: cjackal <juhn3707@gmail.com>

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->
Current runtime dependency version check routine for elyra pipeline is less robust on source packages not installed via pypi. 
E.g. one may struggle to run elyra pipeline on clean-installed miniconda base environment, which pip freeze to `file://` protocol:

in 24b445e
```
juhn3@vscode-0:~$ miniconda3/bin/python git/elyra/elyra/kfp/bootstrapper.py -e aaa -b aaa -d aaa -t aaa -f aaa -n aaa
[D 02:55:13.869] Parsing Arguments.....
[I 02:55:13.870] 'aaa':'aaa' - starting operation 
[I 02:55:13.870] 'aaa':'aaa' - Installing packages 
[I 02:55:13.870] Package not found. Installing ipykernel package with version 6.13.0...
[I 02:55:13.870] Package not found. Installing ipython package with version 8.3.0...
[I 02:55:13.870] Package not found. Installing ipython-genutils package with version 0.2.0...
[I 02:55:13.870] Package not found. Installing jinja2 package with version 3.0.3...
[I 02:55:13.870] Package not found. Installing jupyter-client package with version 7.3.1...
[I 02:55:13.870] Package not found. Installing jupyter-core package with version 4.11.2...
[I 02:55:13.870] Package not found. Installing MarkupSafe package with version 2.1.1...
[I 02:55:13.870] Package not found. Installing minio package with version 7.1.8...
[I 02:55:13.870] Package not found. Installing nbclient package with version 0.6.3...
[I 02:55:13.870] Package not found. Installing nbconvert package with version 6.5.1...
[I 02:55:13.871] Package not found. Installing nbformat package with version 5.4.0...
[I 02:55:13.871] Package not found. Installing papermill package with version 2.3.4...
[I 02:55:13.871] Package not found. Installing pyzmq package with version 24.0.1...
[I 02:55:13.871] Package not found. Installing prompt-toolkit package with version 3.0.29...
Traceback (most recent call last):
  File "/home/juhn3/git/elyra/elyra/kfp/bootstrapper.py", line 742, in <module>
    main()
  File "/home/juhn3/git/elyra/elyra/kfp/bootstrapper.py", line 725, in main
    OpUtil.package_install(user_volume_path=input_params.get("user-volume-path"))
  File "/home/juhn3/git/elyra/elyra/kfp/bootstrapper.py", line 563, in package_install
    elif version.parse(ver) > version.parse(current_packages[package]):
  File "/home/juhn3/miniconda3/lib/python3.10/site-packages/packaging/version.py", line 52, in parse
    return Version(version)
  File "/home/juhn3/miniconda3/lib/python3.10/site-packages/packaging/version.py", line 197, in __init__
    raise InvalidVersion(f"Invalid version: '{version}'")
packaging.version.InvalidVersion: Invalid version: 'file:///opt/conda/conda-bld/requests_1657734628632/work'
```

This PR suggests to skip version check for every source packages without proper version information by screening `packaging.version.InvalidVersion` exception.

### How was this pull request tested?
<!--
Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases, if possible.

If changes were tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added e.g. documentation only, GH workflow updates, etc.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
