### PR TITLE
Add support for static bearer token authentication for KFP

### DIFF
--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -239,18 +239,19 @@ Authentication type Elyra uses to gain access to Kubeflow Pipelines. This settin
 - No authentication (`NO_AUTHENTICATION`).
 - Kubernetes service account token (`KUBERNETES_SERVICE_ACCOUNT_TOKEN`). This authentication type is only supported if Elyra runs as a pod in Kubernetes, e.g. as a Kubeflow notebook server. You must configure a service account token in Kubernetes, as outlined [here](https://www.kubeflow.org/docs/components/pipelines/sdk/connect-api/#multi-user-mode).
 - DEX configured for static password authentication (`DEX_STATIC_PASSWORDS`). This authentication requires a username and a password.
-- DEX configured for LDAP authentication (`DEX_LDAP`). This authentication requires a username and a  password.
+- DEX configured for LDAP authentication (`DEX_LDAP`). This authentication requires a username and a password.
+- User-provided token (`EXISTING_BEARER_TOKEN`).  Authentication is performed by passing the provided static token value to the Kubeflow server. This authentication requires a password/token.
 - DEX (`DEX_LEGACY`). Use this type only if none of the other authentication types applies or if your Kubeflow deployment is not configured for any other listed type. This authentication requires a username and a password.
 
 ##### Kubeflow Pipelines API endpoint username (api_username)
 
-A username is required for most authentication types. Refer to the Kubeflow authentication type setting for details.
+A username is required for most authentication types. Refer to the [Kubeflow authentication type setting](#kubeflow-authentication-type-auth-type) for details.
 
 Example: `user@example.com`
 
 ##### Kubeflow Pipelines API endpoint password (api_password)
 
-A password is required for most authentication types. Refer to the Kubeflow authentication type setting for details.
+A password or token is required for most authentication types. Refer to the [Kubeflow authentication type setting](#kubeflow-authentication-type-auth-type) for details.
 
 Example: `mypassword`
 

--- a/elyra/metadata/schemas/kfp.json
+++ b/elyra/metadata/schemas/kfp.json
@@ -102,8 +102,8 @@
           }
         },
         "api_password": {
-          "title": "Kubeflow Pipelines API Endpoint Password",
-          "description": "Password for the specified username. This property is required for all authentication types, except NO_AUTHENTICATION and KUBERNETES_SERVICE_ACCOUNT_TOKEN.",
+          "title": "Kubeflow Pipelines API Endpoint Password Or Token",
+          "description": "Password or token to be used for authentication. This property is required for all authentication types, except NO_AUTHENTICATION and KUBERNETES_SERVICE_ACCOUNT_TOKEN.",
           "type": "string",
           "uihints": {
             "ui:field": "password",

--- a/elyra/pipeline/kfp/kfp_authentication.py
+++ b/elyra/pipeline/kfp/kfp_authentication.py
@@ -325,7 +325,7 @@ class AbstractAuthenticator(ABC):
     _type = None  # unique authenticator id
 
     @abstractmethod
-    def authenticate(self, kf_endpoint: str, runtime_config_name: str) -> Optional[SupportedAuthProviders]:
+    def authenticate(self, kf_endpoint: str, runtime_config_name: str) -> Optional[Any]:
         """
         Attempt to authenticate with the specified Kubeflow endpoint. The caller
         expects the implementing method to behave as follows:
@@ -352,7 +352,7 @@ class NoAuthenticationAuthenticator(AbstractAuthenticator):
 
     _type = SupportedAuthProviders.NO_AUTHENTICATION
 
-    def authenticate(self, kf_endpoint: str, runtime_config_name: str) -> Optional[SupportedAuthProviders]:
+    def authenticate(self, kf_endpoint: str, runtime_config_name: str) -> Optional[str]:
         """
         Confirms that the specified kf_endpoint can be accessed
         without authentication.
@@ -789,7 +789,7 @@ class ExistingBearerTokenAuthenticator(AbstractAuthenticator):
 
     _type = SupportedAuthProviders.EXISTING_BEARER_TOKEN
 
-    def authenticate(self, kf_endpoint: str, runtime_config_name: str, token: str) -> Optional[str]:
+    def authenticate(self, kf_endpoint: str, runtime_config_name: str, token: str = None) -> Optional[str]:
         """
         Authenticate using static bearer token. Authentication ensures that the token
         is a string that is not None/empty/whitespaces only.

--- a/elyra/pipeline/kfp/kfp_authentication.py
+++ b/elyra/pipeline/kfp/kfp_authentication.py
@@ -70,6 +70,8 @@ class SupportedAuthProviders(Enum):
     # Supports multiple authentication mechanisms
     # (See DEXLegacyAuthenticator implementation)
     DEX_LEGACY = "DEX (legacy)"
+    # Supports authentication that relies on a static bearer token value
+    EXISTING_BEARER_TOKEN = "Token authentication"
 
     @staticmethod
     def get_default_provider() -> "SupportedAuthProviders":
@@ -272,7 +274,6 @@ class KFPAuthenticator:
                 )
                 if auth_info.get("cookies") is not None:
                     auth_info["kf_secured"] = True
-
             elif auth_type == SupportedAuthProviders.DEX_LDAP:
                 # DEX/LDAP authentication; the authenticator returns
                 # a cookie value
@@ -286,6 +287,12 @@ class KFPAuthenticator:
                 # a ServiceAccountTokenVolumeCredentials
                 auth_info["credentials"] = K8sServiceAccountTokenAuthenticator().authenticate(
                     kf_url, runtime_config_name
+                )
+                auth_info["kf_secured"] = True
+            elif auth_type == SupportedAuthProviders.EXISTING_BEARER_TOKEN:
+                # the authenticator returns a bearer token
+                auth_info["existing_token"] = ExistingBearerTokenAuthenticator().authenticate(
+                    kf_url, runtime_config_name, token=auth_parm_2
                 )
                 auth_info["kf_secured"] = True
             else:
@@ -773,3 +780,38 @@ class DEXLegacyAuthenticator(AbstractAuthenticator):
 
         # The endpoint is not secured.
         return None
+
+
+class ExistingBearerTokenAuthenticator(AbstractAuthenticator):
+    """
+    This authenticator uses a user-provided bearer token value for authentication.
+    """
+
+    _type = SupportedAuthProviders.EXISTING_BEARER_TOKEN
+
+    def authenticate(self, kf_endpoint: str, runtime_config_name: str, token: str) -> Optional[str]:
+        """
+        Authenticate using static bearer token. Authentication ensures that the token
+        is a string that is not None/empty/whitespaces only.
+
+        :param kf_endpoint: Kubeflow API endpoint to verify
+        :type kf_endpoint: str
+        :param runtime_config_name: Runtime configuration name where kf_endpoint is specified
+        :type runtime_config_name: str
+        :param token: Bearer token to be used for authentication
+        :type password: str
+        :raises AuthenticationError: Authentication failed due to the specified error.
+        :return: A bearer token value
+        """
+
+        # This code can be removed after the kfp runtime schema enforces that the values
+        # for password/token are valid
+        if _empty_or_whitespaces_only(token):
+            raise AuthenticationError(
+                f"A token/password is required to perform this type of authentication. "
+                f"Update runtime configuration '{runtime_config_name}' and try again.",
+                provider=self._type,
+            )
+
+        # Return the bearer token
+        return token

--- a/elyra/tests/pipeline/kfp/test_kfp_authentication.py
+++ b/elyra/tests/pipeline/kfp/test_kfp_authentication.py
@@ -1,0 +1,110 @@
+#
+# Copyright 2018-2023 Elyra Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from elyra.pipeline.kfp.kfp_authentication import AuthenticationError
+from elyra.pipeline.kfp.kfp_authentication import ExistingBearerTokenAuthenticator
+from elyra.pipeline.kfp.kfp_authentication import KFPAuthenticator
+from elyra.pipeline.kfp.kfp_authentication import SupportedAuthProviders
+
+# ---------------------------------------------------
+# Tests for class KFPAuthenticator
+# ---------------------------------------------------
+
+
+def test_KFPAuthenticator_authenticate_valid_input():
+    """
+    Verify that authenticate(...) returns the expected results for valid input
+    """
+    dummy_kfp_endpoint = "https://localhost:8888"
+    dummy_runtime_config_name = "bearer_runtime_config"
+    dummy_auth_parm_1 = None
+    dummy_auth_parm_2 = "sha256~pl3as3l3tm31n"
+
+    # test EXISTING_BEARER_TOKEN invocation
+    auth_output = KFPAuthenticator().authenticate(
+        api_endpoint=dummy_kfp_endpoint,
+        auth_type_str="EXISTING_BEARER_TOKEN",
+        runtime_config_name=dummy_runtime_config_name,
+        auth_parm_1=dummy_auth_parm_1,
+        auth_parm_2=dummy_auth_parm_2,
+    )
+    assert auth_output.get("api_endpoint") == dummy_kfp_endpoint
+    assert auth_output.get("auth_type") == SupportedAuthProviders.EXISTING_BEARER_TOKEN.value
+    assert auth_output.get("kf_secured") is True
+    assert auth_output.get("cookies") is None
+    assert auth_output.get("credentials") is None
+    assert auth_output.get("existing_token") == dummy_auth_parm_2
+
+
+def test_KFPAuthenticator_authenticate_invalid_input():
+    """
+    Verify that authenticate(...) returns the expected results for an invalid
+    authentication type
+    """
+    dummy_kfp_endpoint = "https://localhost:8888"
+    dummy_runtime_config_name = "a_kfp_runtime_config"
+    dummy_auth_type_str = "NO_SUCH_AUTH_TYPE"
+    dummy_auth_parm_1 = None
+    dummy_auth_parm_2 = None
+
+    # authentication type is invalid
+    with pytest.raises(AuthenticationError) as exc_error:
+        KFPAuthenticator().authenticate(
+            api_endpoint=dummy_kfp_endpoint,
+            auth_type_str=dummy_auth_type_str,
+            runtime_config_name=dummy_runtime_config_name,
+            auth_parm_1=dummy_auth_parm_1,
+            auth_parm_2=dummy_auth_parm_2,
+        )
+    assert exc_error.value._provider is None
+    assert f"Authentication type '{dummy_auth_type_str}' is not supported." in exc_error.value._message
+
+
+# ---------------------------------------------------
+# Tests for class ExistingBearerTokenAuthenticator
+# ---------------------------------------------------
+
+
+def test_ExistingBearerTokenAuthenticator_authenticate_valid_input():
+    """
+    Verify that authenticate(...) returns the expected result for input that meets the enforced
+    constraints. Note that this test does not actually validate tokens.
+    """
+    dummy_kfp_endpoint = "https://localhost:8888"
+    dummy_runtime_config_name = "bearer_runtime_config"
+    dummy_token = "sha256~pl3as3l3tm31n"
+    token = ExistingBearerTokenAuthenticator().authenticate(dummy_kfp_endpoint, dummy_runtime_config_name, dummy_token)
+    assert token is not None
+
+
+def test_ExistingBearerTokenAuthenticator_authenticate_invalid_input():
+    """
+    Verify that authenticate(...) returns the expected result for input that does not
+    meet the enforced constraints. Note that this test does not actually validate tokens.
+    """
+    dummy_kfp_endpoint = "https://localhost:8888"
+    dummy_runtime_config_name = "bearer_runtime_config"
+    # valid token values are strings that are not None, empty, or comprise of whitespaces only
+    for invalid_token in [None, "", "   "]:
+        with pytest.raises(AuthenticationError) as exc_error:
+            ExistingBearerTokenAuthenticator().authenticate(
+                dummy_kfp_endpoint, dummy_runtime_config_name, invalid_token
+            )
+        assert exc_error.value._provider == SupportedAuthProviders.EXISTING_BEARER_TOKEN
+        assert "A token/password is required to perform this type of authentication." in exc_error.value._message
+        assert f"Update runtime configuration '{dummy_runtime_config_name}'" in exc_error.value._message

--- a/elyra/tests/pipeline/kfp/test_kfp_authentication.py
+++ b/elyra/tests/pipeline/kfp/test_kfp_authentication.py
@@ -89,7 +89,7 @@ def test_ExistingBearerTokenAuthenticator_authenticate_valid_input():
     dummy_runtime_config_name = "bearer_runtime_config"
     dummy_token = "sha256~pl3as3l3tm31n"
     token = ExistingBearerTokenAuthenticator().authenticate(dummy_kfp_endpoint, dummy_runtime_config_name, dummy_token)
-    assert token is not None
+    assert token == dummy_token
 
 
 def test_ExistingBearerTokenAuthenticator_authenticate_invalid_input():


### PR DESCRIPTION
This PR extends the existing Kubeflow authentication support. The new `EXISTING_BEARER_TOKEN` authentication type enables users to authenticate using a static token value. Elyra passes the specified token as-is to the server.

A [Kubeflow Pipelines runtime configuration](https://elyra.readthedocs.io/en/latest/user_guide/runtime-conf.html#kubeflow-pipelines-configuration-settings) must be configured as follows to utilize this authentication type: 
 - select `EXISTING_BEARER_TOKEN` as _Authentication Type_
 - specify a token value as _Kubeflow Pipelines API Endpoint Password Or Token_
 - if a value for username is specified it is ignored

The token input field is masked by default.

![image](https://user-images.githubusercontent.com/13068832/224123660-acf38ab1-0428-41a5-9c3d-50b4ec1392a0.png)


Closes #3107 
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
- Add support for new Kubeflow Pipelines authentication type 
- Update _runtime configuration_ topic in the _user guide_
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
- Reviewed output of `make docs`
- Added new authentication tests (`elyra/tests/pipeline/kfp/test_kfp_authentication.py`)
- Manual testing using RHOS deployment
   -   Set up RH DSP test environment using  instructions in https://github.com/HumairAK/odh-manifests/blob/odh-dsp-auth-demo/data-science-pipelines/base/auth/AUTH_NOTES.md
   - Created and submitted pipeline and confirmed that the API calls were successful
<!--
Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases, if possible.

If changes were tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added e.g. documentation only, GH workflow updates, etc.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
