### PR TITLE
Remove obsolete read_entry_data method from class ComponentCatalogConnector

### DIFF
--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -382,6 +382,7 @@ class ComponentCatalogConnector(LoggingConfigurable):
                             f"with identifying information {catalog_entry_data}. "
                             f"The connector does not implement method 'get_entry_data'."
                         )
+                        catalog_entry_q.task_done()
                         continue
 
                     # Ignore this entry if no definition content is returned

--- a/elyra/pipeline/catalog_connector.py
+++ b/elyra/pipeline/catalog_connector.py
@@ -30,7 +30,6 @@ from typing import List
 from typing import Optional
 from urllib.parse import urlparse
 
-from deprecation import deprecated
 from jupyter_core.paths import ENV_JUPYTER_PATH
 from requests.auth import HTTPBasicAuth
 from requests.sessions import Session
@@ -38,7 +37,6 @@ from traitlets.config import LoggingConfigurable
 from traitlets.traitlets import default
 from traitlets.traitlets import Integer
 
-from elyra._version import __version__
 from elyra.metadata.metadata import Metadata
 from elyra.pipeline.component import Component
 from elyra.pipeline.properties import ComponentProperty
@@ -221,39 +219,6 @@ class ComponentCatalogConnector(LoggingConfigurable):
         """
         raise NotImplementedError("abstract method 'get_catalog_entries()' must be implemented")
 
-    @deprecated(
-        deprecated_in="3.7.0",
-        removed_in="4.0",
-        current_version=__version__,
-        details="Implement the get_entry_data function instead",
-    )
-    def read_catalog_entry(self, catalog_entry_data: Dict[str, Any], catalog_metadata: Dict[str, Any]) -> Optional[str]:
-        """
-        DEPRECATED. Will be removed in 4.0. get_entry_data() must be implemented instead.
-
-        Reads a component definition for a single catalog entry using the catalog_entry_data returned
-        from get_catalog_entries() and, if needed, the catalog metadata.
-
-        :param catalog_entry_data: a dictionary that contains the information needed to read the content
-                                   of the component definition; below is an example data structure returned
-                                   from get_catalog_entries()
-
-                example:
-                    {
-                        "directory_path": "/Users/path/to/directory",
-                        "relative_path": "subdir/file.py"
-                    }
-
-        :param catalog_metadata: the metadata associated with the catalog in which this catalog entry is
-                                 stored; this is the same dictionary that is passed into get_catalog_entries();
-                                 in addition to catalog_entry_data, catalog_metadata may also be
-                                 needed to read the component definition for certain types of catalogs
-
-        :returns: the content of the given catalog entry's definition in string form, if found, or None;
-                  if None is returned, this catalog entry is skipped and a warning message logged
-        """
-        raise NotImplementedError("abstract method 'read_catalog_entry()' must be implemented")
-
     def get_entry_data(
         self, catalog_entry_data: Dict[str, Any], catalog_metadata: Dict[str, Any]
     ) -> Optional[EntryData]:
@@ -407,18 +372,17 @@ class ComponentCatalogConnector(LoggingConfigurable):
                     )
 
                     try:
-                        # Attempt to get an EntryData object from get_entry_data first
+                        # Attempt to get an EntryData object from get_entry_data
                         entry_data: EntryData = self.get_entry_data(
                             catalog_entry_data=catalog_entry_data, catalog_metadata=catalog_metadata
                         )
                     except NotImplementedError:
-                        # Connector class does not implement get_catalog_definition and we must
-                        # manually coerce this entry's returned values into a EntryData object
-                        definition = self.read_catalog_entry(
-                            catalog_entry_data=catalog_entry_data, catalog_metadata=catalog_metadata
+                        self.log.error(
+                            f"Component catalog connector {self.__class__.__name__} cannot process catalog entry "
+                            f"with identifying information {catalog_entry_data}. "
+                            f"The connector does not implement method 'get_entry_data'."
                         )
-
-                        entry_data: EntryData = EntryData(definition=definition)
+                        continue
 
                     # Ignore this entry if no definition content is returned
                     if not entry_data or not entry_data.definition:


### PR DESCRIPTION
Closes #2514 
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
- Remove deprecated method
- None of the built-in component catalog connectors are impacted because they don't utilize the deprecated method
- This change breaks https://github.com/ptitzler/examples/tree/main/component-catalog-connectors/airflow-example-components-connector. The connector will not be fixed because it is no longer supported.
- This change breaks https://github.com/ptitzler/examples/tree/main/component-catalog-connectors/kfp-example-components-connector. The connector will be marked as no longer supported in Elyra v4+.
- See related changes in https://github.com/elyra-ai/examples/pull/118
- TODO: fix failing server tests
- - TODO: fix failing integration tests
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
1. Installed https://github.com/ptitzler/examples/tree/main/component-catalog-connectors/kfp-example-components-connector, which only implements the obsolete method. (`elyra-examples-kfp-catalog==0.1.0`)
1. Created an instance of that catalog connector in Elyra.
1. Confirmed that the expected error is logged.
<!--
Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases, if possible.

If changes were tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added e.g. documentation only, GH workflow updates, etc.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
