### PR TITLE
Convert --valid-only to --include-invalid on list subcommand

### DIFF
--- a/docs/source/user_guide/code-snippets.md
+++ b/docs/source/user_guide/code-snippets.md
@@ -109,7 +109,7 @@ $ elyra-metadata list code-snippets
 The output lists for each code snippet the name and the name of the associated JSON formatted metadata file, which is stored in the JupyterLab data directory in the `metadata/code-snippets` subdirectory.
 
 ```
-Available metadata instances for code-snippets (includes invalid):
+Available metadata instances for code-snippets:
 
 Schema   	Instance		Resource  
 ---------   	--------		--------

--- a/docs/source/user_guide/command-line-interface.md
+++ b/docs/source/user_guide/command-line-interface.md
@@ -45,7 +45,7 @@ By default the `list` command displays the results in a user-friendly format.
 
 ```
 $ elyra-metadata list runtime-images
-Available metadata instances for runtime-images (includes invalid):
+Available metadata instances for runtime-images:
 
 Schema          Instance    Resource
 ------          --------    --------

--- a/docs/source/user_guide/pipeline-components.md
+++ b/docs/source/user_guide/pipeline-components.md
@@ -180,7 +180,7 @@ To list component catalog entries:
 ```bash
 $ elyra-metadata list component-catalogs
 
-Available metadata instances for component-catalogs (includes invalid):
+Available metadata instances for component-catalogs:
 
 Schema               Instance                            Resource
 ------               --------                            --------
@@ -283,7 +283,7 @@ $ elyra-metadata list component-registries
 ```
 In this example, there are three user-defined instances.
 ```bash
-Available metadata instances for component-registries (includes invalid):
+Available metadata instances for component-registries:
 
 Schema               Instance            Resource
 ------               --------            --------
@@ -314,7 +314,7 @@ The following component-registries instances were migrated: ['myoperators', 'air
 Once migrated, these entries should appear in the set of component catalogs.  This can be confirmed by listing the component-catalogs instances:
 ```bash
 $ elyra-metadata list component-catalogs
-Available metadata instances for component-catalogs (includes invalid):
+Available metadata instances for component-catalogs:
 
 Schema                    Instance                            Resource                                                                                                         
 ------                    --------                            --------                                                                                                             

--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -95,7 +95,7 @@ $ elyra-metadata list runtimes
 The output lists for each runtime the name and the name of the associated JSON formatted metadata file, which is stored in the JupyterLab data directory in the `metadata/runtimes` subdirectory.
 
 ```
-Available metadata instances for runtimes (includes invalid):
+Available metadata instances for runtimes:
 
 Schema   Instance  Resource  
 ------   --------  -------- 

--- a/docs/source/user_guide/runtime-image-conf.md
+++ b/docs/source/user_guide/runtime-image-conf.md
@@ -94,7 +94,7 @@ To list runtime image configurations:
 ```bash
 $ elyra-metadata list runtime-images
 
-Available metadata instances for runtime-images (includes invalid):
+Available metadata instances for runtime-images:
 
 Schema          Instance               Resource                                                                                                       
 ------          --------               --------                                                                                                       

--- a/elyra/metadata/metadata_app.py
+++ b/elyra/metadata/metadata_app.py
@@ -65,15 +65,15 @@ class SchemaspaceList(SchemaspaceBase):
 
     json_flag = Flag("--json", name="json", description="List complete instances as JSON", default_value=False)
 
-    valid_only_flag = Flag(
-        "--valid-only",
-        name="valid-only",
-        description="Only list valid instances (default includes invalid instances)",
+    include_invalid_flag = Flag(
+        "--include-invalid",
+        name="include-invalid",
+        description="Include invalid instances (default displays only valid instances)",
         default_value=False,
     )
 
     # 'List' flags
-    options = [json_flag, valid_only_flag]
+    options = [json_flag, include_invalid_flag]
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -82,9 +82,8 @@ class SchemaspaceList(SchemaspaceBase):
     def start(self):
         super().start()  # process options
 
-        include_invalid = not self.valid_only_flag.value
         try:
-            metadata_instances = self.metadata_manager.get_all(include_invalid=include_invalid)
+            metadata_instances = self.metadata_manager.get_all(include_invalid=self.include_invalid_flag.value)
         except MetadataNotFoundError:
             metadata_instances = None
 
@@ -97,11 +96,11 @@ class SchemaspaceList(SchemaspaceBase):
                 print(f"No metadata instances found for {self.schemaspace}")
                 return
 
-            validity_clause = "includes invalid" if include_invalid else "valid only"
-            print(f"Available metadata instances for {self.schemaspace} ({validity_clause}):")
+            validity_clause = " (includes invalid)" if self.include_invalid_flag.value else ""
+            print(f"Available metadata instances for {self.schemaspace}{validity_clause}:")
 
             sorted_instances = sorted(metadata_instances, key=lambda inst: (inst.schema_name, inst.name))
-            # pad to width of longest instance
+            # pad to width of the longest instance
             max_schema_name_len = len("Schema")
             max_name_len = len("Instance")
             max_resource_len = len("Resource")


### PR DESCRIPTION
This pull request replaces the `elyra-metadata list` command's `--valid-only` option with `--include-invalid` to make the command more intuitive.  With this change, invalid instances are not listed by default.  Instead, only valid instances are listed and the user must include option `--include-invalid` to have invalid instances included in the output.

The tests were updated accordingly.

Resolves: #2562