### PR TITLE
Remove deprecated install command from elyra-metadata

### DIFF
--- a/elyra/metadata/metadata_app.py
+++ b/elyra/metadata/metadata_app.py
@@ -19,7 +19,6 @@ import sys
 from typing import Dict
 from typing import List
 
-from deprecation import deprecated
 from jsonschema import ValidationError
 
 from elyra.metadata.error import MetadataExistsError, MetadataNotFoundError
@@ -388,235 +387,6 @@ class SchemaspaceUpdate(SchemaspaceCreate):
     update_mode = True
 
 
-class SchemaspaceInstall(SchemaspaceBase):
-    """DEPRECATED (removed in v4.0):
-    Handles the 'install' subcommand functionality for a specific schemaspace.
-    """
-
-    # Known options, others will be derived from schema based on schema_name...
-
-    replace_flag = Flag("--replace", name="replace", description="Replace an existing instance", default_value=False)
-    name_option = CliOption("--name", name="name", description="The name of the metadata instance to install")
-    file_option = FileOption(
-        "--file",
-        name="file",
-        description="The filename containing the metadata instance to install. "
-        "Can be used to bypass individual property arguments.",
-    )
-    json_option = JSONOption(
-        "--json",
-        name="json",
-        description="The JSON string containing the metadata instance to install. "
-        "Can be used to bypass individual property arguments.",
-    )
-    # 'Install' options
-    options: List[Option] = [replace_flag, file_option, json_option]  # defer name option until after schema
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.complex_properties: List[str] = []
-        self.metadata_manager = MetadataManager(schemaspace=self.schemaspace)
-        # First, process the schema_name option so we can then load the appropriate schema
-        # file to build the schema-based options.  If help is requested, give it to them.
-
-        # As an added benefit, if the schemaspace has one schema, got ahead and default that value.
-        # If multiple, add the list so proper messaging can be applied.  As a result, we need to
-        # to build the option here since this is where we have access to the schemas.
-        schema_list = list(self.schemas.keys())
-        if len(schema_list) == 1:
-            self.schema_name_option = CliOption(
-                "--schema_name",
-                name="schema_name",
-                default_value=schema_list[0],
-                description="The schema_name of the metadata instance to " f"install (defaults to '{schema_list[0]}')",
-                required=True,
-            )
-        else:
-            enum = schema_list
-            self.schema_name_option = CliOption(
-                "--schema_name",
-                name="schema_name",
-                enum=enum,
-                description="The schema_name of the metadata instance to install.  " f"Must be one of: {enum}",
-                required=True,
-            )
-
-        self.options.extend([self.schema_name_option, self.name_option])
-
-        # Since we need to know if the replace option is in use prior to normal option processing,
-        # go ahead and check for its existence on the command-line and process if present.
-        if self.replace_flag.cli_option in self.argv_mappings.keys():
-            self.process_cli_option(self.replace_flag)
-
-        # Determine if --json, --file, or --replace are in use and relax required properties if so.
-        bulk_metadata = self._process_json_based_options()
-        relax_required = bulk_metadata or self.replace_flag.value
-
-        # This needs to occur following json-based options since they may add it as an option
-        self.process_cli_option(self.schema_name_option, check_help=True)
-
-        # Schema appears to be a valid name, convert its properties to options and continue
-        schema = self.schemas[self.schema_name_option.value]
-
-        # Convert schema properties to options, gathering complex property names
-        schema_options = self._schema_to_options(schema, relax_required)
-        self.options.extend(schema_options)
-
-    def start(self):
-        super().start()  # process options
-
-        # Get known options, then gather display_name and build metadata dict.
-        name = self.name_option.value
-        schema_name = self.schema_name_option.value
-        display_name = None
-
-        metadata = {}
-        # Walk the options looking for SchemaProperty instances. Any MetadataSchemaProperty instances go
-        # into the metadata dict.  Note that we process JSONBasedOptions (--json or --file) prior to
-        # MetadataSchemaProperty types since the former will set the base metadata stanza and individual
-        # values can be used to override the former's content (like BYO authentication OVPs, for example).
-        for option in self.options:
-            if isinstance(option, MetadataSchemaProperty):
-                # skip adding any non required properties that have no value (unless its a null type).
-                if not option.required and not option.value and option.type != "null":
-                    continue
-                metadata[option.name] = option.value
-            elif isinstance(option, SchemaProperty):
-                if option.name == "display_name":  # Be sure we have a display_name
-                    display_name = option.value
-                    continue
-            elif isinstance(option, JSONBasedOption):
-                metadata.update(option.metadata)
-
-        if display_name is None and self.replace_flag.value is False:  # Only require on create
-            self.log_and_exit(f"Could not determine display_name from schema '{schema_name}'")
-
-        ex_msg = None
-        new_instance = None
-        try:
-            if self.replace_flag.value:  # if replacing, fetch the instance so it can be updated
-                updated_instance = self.metadata_manager.get(name)
-                updated_instance.schema_name = schema_name
-                if display_name:
-                    updated_instance.display_name = display_name
-                updated_instance.metadata.update(metadata)
-                new_instance = self.metadata_manager.update(name, updated_instance)
-            else:  # create a new instance
-                instance = Metadata(schema_name=schema_name, name=name, display_name=display_name, metadata=metadata)
-                new_instance = self.metadata_manager.create(name, instance)
-        except Exception as ex:
-            ex_msg = str(ex)
-
-        if new_instance:
-            print(
-                f"Metadata instance '{new_instance.name}' for schema '{schema_name}' has been written "
-                f"to: {new_instance.resource}"
-            )
-        else:
-            if ex_msg:
-                self.log_and_exit(
-                    f"The following exception occurred saving metadata instance "
-                    f"for schema '{schema_name}': {ex_msg}",
-                    display_help=False,
-                )
-            else:
-                self.log_and_exit(
-                    f"A failure occurred saving metadata instance '{name}' for " f"schema '{schema_name}'.",
-                    display_help=False,
-                )
-
-    def _process_json_based_options(self) -> bool:
-        """Process the file and json options to see if they have values (and those values can be loaded as JSON)
-        Then check payloads for schema_name, display_name and derive name options and add to argv mappings
-        if currently not specified.
-
-        If either option is set, indicate that the metadata stanza should be skipped (return True)
-        """
-        bulk_metadata = False
-
-        self.process_cli_option(self.file_option, check_help=True)
-        self.process_cli_option(self.json_option, check_help=True)
-
-        # if both are set, raise error
-        if self.json_option.value is not None and self.file_option.value is not None:
-            self.log_and_exit("At most one of '--json' or '--file' can be set at a time.", display_help=True)
-        elif self.json_option.value is not None:
-            bulk_metadata = True
-            self.json_option.transfer_names_to_argvs(self.argv, self.argv_mappings)
-        elif self.file_option.value is not None:
-            bulk_metadata = True
-            self.file_option.transfer_names_to_argvs(self.argv, self.argv_mappings)
-
-        # else, neither is set so metadata stanza will be considered
-        return bulk_metadata
-
-    def _schema_to_options(self, schema: Dict, relax_required: bool = False) -> List[Option]:
-        """Takes a JSON schema and builds a list of SchemaProperty instances corresponding to each
-        property in the schema.  There are two sections of properties, one that includes
-        schema_name and display_name and another within the metadata container - which
-        will be separated by class type - SchemaProperty vs. MetadataSchemaProperty.
-
-        If relax_required is true, a --json or --file option is in use and the primary metadata
-        comes from those options OR the --replace option is in use, in which case the primary
-        metadata comes from the existing instance (being replaced).  In such cases, skip setting
-        required values since most will come from the JSON-based option or already be present
-        (in the case of replace).  This allows CLI-specified metadata properties to override the
-        primary metadata (either in the JSON options or from the existing instance).
-        """
-        options = {}
-        properties = schema["properties"]
-        for name, value in properties.items():
-            if name == "schema_name":  # already have this option, skip
-                continue
-            if name != "metadata":
-                options[name] = SchemaProperty(name, value)
-            else:  # convert first-level metadata properties to options...
-                metadata_properties = properties["metadata"]["properties"]
-                for md_name, md_value in metadata_properties.items():
-                    msp = MetadataSchemaProperty(md_name, md_value)
-                    # skip if this property was not specified on the command line and its a replace/bulk op
-                    if msp.cli_option not in self.argv_mappings and relax_required:
-                        continue
-                    if msp.unsupported_meta_props:  # if this option includes complex meta-props, note that.
-                        self.complex_properties.append(md_name)
-                    options[md_name] = msp
-
-        # Now set required-ness on MetadataProperties, but only when creation is using fine-grained property options
-        if not relax_required:
-            required_props = properties["metadata"].get("required")
-            for required in required_props:
-                options.get(required).required = True
-
-        # ...  and top-level (schema) Properties if we're not replacing (updating)
-        if self.replace_flag.value is False:
-            required_props = set(schema.get("required")) - {"schema_name", "metadata"}  # skip schema_name & metadata
-            for required in required_props:
-                options.get(required).required = True
-        return list(options.values())
-
-    def print_help(self):
-        super().print_help()
-        # If we gathered any complex properties, go ahead and note how behaviors might be affected, etc.
-        if self.complex_properties:
-            print(
-                f"Note: The following properties in this schema contain JSON keywords that are not supported "
-                f"by the tooling: {self.complex_properties}."
-            )
-            print(
-                "This can impact the tool's ability to derive context from the schema, including a property's "
-                "type, description, or behaviors included in complex types like 'oneOf'."
-            )
-            print(
-                "It is recommended that options corresponding to these properties be set after understanding "
-                "the schema or indirectly using `--file` or `--json` options."
-            )
-            print(
-                'If the property is of type "object" it can be set using a file containing only that property\'s '
-                "JSON."
-            )
-            print(f"The following are considered unsupported keywords: {SchemaProperty.unsupported_keywords}")
-
-
 class SchemaspaceMigrate(SchemaspaceBase):
     """Handles the 'migrate' subcommand functionality for a specific schemaspace."""
 
@@ -909,9 +679,6 @@ class List(SubcommandBase):
     subcommand_description = "List installed metadata for {schemaspace}."
     schemaspace_base_class = SchemaspaceList
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
 
 class Remove(SubcommandBase):
     """Removes a metadata instance from a given schemaspace."""
@@ -919,21 +686,6 @@ class Remove(SubcommandBase):
     description = "Remove a metadata instance from a given schemaspace."
     subcommand_description = "Remove a metadata instance from schemaspace '{schemaspace}'."
     schemaspace_base_class = SchemaspaceRemove
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-
-@deprecated(deprecated_in="3.7.0", removed_in="4.0", details="Use Create or Update instead")
-class Install(SubcommandBase):
-    """DEPRECATED. Installs a metadata instance into a given schemaspace."""
-
-    description = "DEPRECATED. Install a metadata instance into a given schemaspace. Use 'create' or 'update' instead."
-    subcommand_description = "DEPRECATED. Install a metadata instance into schemaspace '{schemaspace}'."
-    schemaspace_base_class = SchemaspaceInstall
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
 
 
 class Create(SubcommandBase):
@@ -943,9 +695,6 @@ class Create(SubcommandBase):
     subcommand_description = "Create a metadata instance in schemaspace '{schemaspace}'."
     schemaspace_base_class = SchemaspaceCreate
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
 
 class Update(SubcommandBase):
     """Updates a metadata instance in a given schemaspace."""
@@ -953,9 +702,6 @@ class Update(SubcommandBase):
     description = "Update a metadata instance in a given schemaspace."
     subcommand_description = "Update a metadata instance in schemaspace '{schemaspace}'."
     schemaspace_base_class = SchemaspaceUpdate
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
 
 
 class Migrate(SubcommandBase):
@@ -965,9 +711,6 @@ class Migrate(SubcommandBase):
     subcommand_description = "Migrate metadata instance in schemaspace '{schemaspace}'."
     schemaspace_base_class = SchemaspaceMigrate
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
 
 class Export(SubcommandBase):
     """Exports metadata instances in a given schemaspace."""
@@ -976,9 +719,6 @@ class Export(SubcommandBase):
     subcommand_description = "Export installed metadata in schemaspace '{schemaspace}'."
     schemaspace_base_class = SchemaspaceExport
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
 
 class Import(SubcommandBase):
     """Imports metadata instances into a given schemaspace."""
@@ -986,9 +726,6 @@ class Import(SubcommandBase):
     description = "Import metadata instances into a given schemaspace."
     subcommand_description = "Import metadata instances into schemaspace '{schemaspace}'."
     schemaspace_base_class = SchemaspaceImport
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
 
 
 class MetadataApp(AppBase):
@@ -1001,7 +738,6 @@ class MetadataApp(AppBase):
         "list": (List, List.description.splitlines()[0]),
         "create": (Create, Create.description.splitlines()[0]),
         "update": (Update, Update.description.splitlines()[0]),
-        "install": (Install, Install.description.splitlines()[0]),
         "remove": (Remove, Remove.description.splitlines()[0]),
         "migrate": (Migrate, Migrate.description.splitlines()[0]),
         "export": (Export, Export.description.splitlines()[0]),

--- a/elyra/tests/metadata/test_metadata_app.py
+++ b/elyra/tests/metadata/test_metadata_app.py
@@ -70,7 +70,7 @@ def test_no_opts(script_runner):
     assert ret.success is False
     message = (
         "No subcommand specified.  One of: "
-        "['list', 'create', 'update', 'install', 'remove', 'migrate', 'export', 'import'] "
+        "['list', 'create', 'update', 'remove', 'migrate', 'export', 'import'] "
         "must be specified."
     )
     assert message in ret.stdout
@@ -81,136 +81,12 @@ def test_bad_subcommand(script_runner):
     assert ret.success is False
     assert (
         "Subcommand 'bogus-subcommand' is invalid.  One of: "
-        "['list', 'create', 'update', 'install', 'remove', 'migrate', 'export', 'import'] "
+        "['list', 'create', 'update', 'remove', 'migrate', 'export', 'import'] "
         "must be specified." in ret.stdout
     )
 
 
-def test_install_bad_argument(script_runner):
-    ret = script_runner.run("elyra-metadata", "install", "--bogus-argument")
-    assert ret.success is False
-    assert "Subcommand '--bogus-argument' is invalid." in ret.stdout
-    assert f"Install a metadata instance into schemaspace '{METADATA_TEST_SCHEMASPACE}'." in ret.stdout
-
-
-def test_install_bad_schemaspace(script_runner):
-    ret = script_runner.run("elyra-metadata", "install", "bogus-schemaspace")
-    assert ret.success is False
-    assert "Subcommand 'bogus-schemaspace' is invalid." in ret.stdout
-    assert f"Install a metadata instance into schemaspace '{METADATA_TEST_SCHEMASPACE}'." in ret.stdout
-
-
-def test_install_help(script_runner):
-    ret = script_runner.run("elyra-metadata", "install", METADATA_TEST_SCHEMASPACE, "--help")
-    assert ret.success is False
-    assert f"Install a metadata instance into schemaspace '{METADATA_TEST_SCHEMASPACE}'." in ret.stdout
-
-
-def test_install_no_schema_single(script_runner, mock_data_dir):
-    # Use the runtime-images schemaspace since that is most likely to always be a single-schema schemaspace.
-    # Note: this test will break if it ever supports multiple.
-    ret = script_runner.run("elyra-metadata", "install", "runtime-images")
-    assert ret.success is False
-    assert "ERROR: '--display_name' is a required parameter." in ret.stdout
-
-
-def test_install_no_schema_multiple(script_runner, mock_data_dir):
-    ret = script_runner.run("elyra-metadata", "install", METADATA_TEST_SCHEMASPACE)
-    assert ret.success is False
-    # Since order in dictionaries, where the one-of list is derived, can be random, just check up to the
-    # first known difference in the schema names.
-    assert (
-        "ERROR: '--schema_name' is a required parameter and must be one of the "
-        "following values: ['metadata-test" in ret.stdout
-    )
-
-
-def test_install_bad_schema_multiple(script_runner, mock_data_dir):
-    ret = script_runner.run("elyra-metadata", "install", METADATA_TEST_SCHEMASPACE, "--schema_name=metadata-foo")
-    assert ret.success is False
-    assert "ERROR: Parameter '--schema_name' requires one of the " "following values: ['metadata-test" in ret.stdout
-
-
-def test_install_no_name(script_runner, mock_data_dir):
-    ret = script_runner.run("elyra-metadata", "install", METADATA_TEST_SCHEMASPACE, "--schema_name=metadata-test")
-    assert ret.success is False
-    assert "ERROR: '--display_name' is a required parameter." in ret.stdout
-
-
-def test_install_complex_usage(script_runner, mock_data_dir):
-    ret = script_runner.run("elyra-metadata", "install", METADATA_TEST_SCHEMASPACE, "--schema_name=metadata-test")
-    assert ret.success is False
-    assert "Note: The following properties in this schema contain JSON keywords that are not supported" in ret.stdout
-    assert "*** References unsupported keywords: {'oneOf'}" in ret.stdout
-    assert "*** References unsupported keywords: {'allOf'}" in ret.stdout
-    assert "*** References unsupported keywords: {'$ref'}" in ret.stdout
-
-
-def test_install_only_display_name(script_runner, mock_data_dir):
-    metadata_display_name = "1 teste 'rápido'"
-    metadata_name = "a_1_teste_rpido"
-
-    ret = script_runner.run(
-        "elyra-metadata",
-        "install",
-        METADATA_TEST_SCHEMASPACE,
-        "--schema_name=metadata-test",
-        f"--display_name={metadata_display_name}",
-        "--required_test=required_value",
-    )
-    assert ret.success is True
-    assert f"Metadata instance '{metadata_name}' for schema 'metadata-test' has been written to:" in ret.stdout
-
-    # Ensure it can be fetched by name...
-    metadata_manager = MetadataManager(schemaspace=METADATA_TEST_SCHEMASPACE_ID)
-    resource = metadata_manager.get(metadata_name)
-    assert resource.display_name == metadata_display_name
-
-
-def test_install_invalid_name(script_runner, mock_data_dir):
-    ret = script_runner.run(
-        "elyra-metadata",
-        "install",
-        METADATA_TEST_SCHEMASPACE,
-        "--schema_name=metadata-test",
-        "--name=UPPER_CASE_NOT_ALLOWED",
-        "--display_name=display_name",
-        "--required_test=required_value",
-    )
-    assert ret.success is False
-    assert "The following exception occurred saving metadata instance for schema 'metadata-test'" in ret.stdout
-    assert "Name of metadata must be lowercase alphanumeric" in ret.stdout
-
-
-def test_install_simple(script_runner, mock_data_dir):
-    expected_file = os.path.join(
-        mock_data_dir, "metadata", METADATA_TEST_SCHEMASPACE, "test-metadata_42_valid-name.json"
-    )
-    # Cleanup from any potential previous failures
-    if os.path.exists(expected_file):
-        os.remove(expected_file)
-
-    ret = script_runner.run(
-        "elyra-metadata",
-        "install",
-        METADATA_TEST_SCHEMASPACE,
-        "--schema_name=metadata-test",
-        "--name=test-metadata_42_valid-name",
-        "--display_name=display_name",
-        "--required_test=required_value",
-    )
-    assert ret.success
-    assert "Metadata instance 'test-metadata_42_valid-name' for schema 'metadata-test' has been written" in ret.stdout
-
-    assert os.path.isdir(os.path.join(mock_data_dir, "metadata", METADATA_TEST_SCHEMASPACE))
-    assert os.path.isfile(expected_file)
-
-    with open(expected_file, "r") as fd:
-        instance_json = json.load(fd)
-        assert instance_json["schema_name"] == "metadata-test"
-        assert instance_json["display_name"] == "display_name"
-        assert instance_json["metadata"]["required_test"] == "required_value"
-        assert instance_json["metadata"]["number_default_test"] == 42  # defaults will always persist
+# ---------- begin of 'create' command tests
 
 
 @pytest.mark.parametrize("option_style", ["equals", "sans-equals", "missing"])
@@ -219,7 +95,7 @@ def test_create_from_file(script_runner, mock_data_dir, option_style):
 
     argv: List[str] = [
         "elyra-metadata",
-        "install",
+        "create",
         METADATA_TEST_SCHEMASPACE,
     ]
 
@@ -250,7 +126,7 @@ def test_create_from_json(script_runner, mock_data_dir, option_style):
 
     argv: List[str] = [
         "elyra-metadata",
-        "install",
+        "create",
         METADATA_TEST_SCHEMASPACE,
     ]
 
@@ -273,233 +149,6 @@ def test_create_from_json(script_runner, mock_data_dir, option_style):
     else:  # success expected
         assert ret.success
         assert "Metadata instance 'valid_metadata_instance' for schema 'metadata-test' has been written" in ret.stdout
-
-
-def test_install_and_replace(script_runner, mock_data_dir):
-    expected_file = os.path.join(
-        mock_data_dir, "metadata", METADATA_TEST_SCHEMASPACE, "test-metadata_42_valid-name.json"
-    )
-    # Cleanup from any potential previous failures
-    if os.path.exists(expected_file):
-        os.remove(expected_file)
-
-    # Attempt replace before schemaspace exists and ensure appropriate error message
-    ret = script_runner.run(
-        "elyra-metadata",
-        "install",
-        METADATA_TEST_SCHEMASPACE,
-        "--schema_name=metadata-test",
-        "--name=test-metadata_42_valid-name",
-        "--display_name=display_name",
-        "--required_test=required_value",
-        "--replace",
-    )
-    assert ret.success is False
-    assert (
-        "No such instance named 'test-metadata_42_valid-name' was found in the metadata-tests schemaspace."
-        in ret.stdout
-    )
-
-    ret = script_runner.run(
-        "elyra-metadata",
-        "install",
-        METADATA_TEST_SCHEMASPACE,
-        "--schema_name=metadata-test",
-        "--name=test-metadata_42_valid-name",
-        "--display_name=display_name",
-        "--required_test=required_value",
-        "--number_default_test=24",
-    )
-    assert ret.success
-    assert "Metadata instance 'test-metadata_42_valid-name' for schema 'metadata-test' has been written" in ret.stdout
-    assert expected_file in ret.stdout
-    assert os.path.isdir(os.path.join(mock_data_dir, "metadata", METADATA_TEST_SCHEMASPACE))
-    assert os.path.isfile(expected_file)
-
-    with open(expected_file, "r") as fd:
-        instance_json = json.load(fd)
-        assert instance_json["metadata"]["number_default_test"] == 24  # ensure CLI value is used over default
-
-    # Re-attempt w/o replace flag - failure expected
-    ret = script_runner.run(
-        "elyra-metadata",
-        "install",
-        METADATA_TEST_SCHEMASPACE,
-        "--schema_name=metadata-test",
-        "--name=test-metadata_42_valid-name",
-        "--display_name=display_name",
-        "--required_test=required_value",
-    )
-    assert ret.success is False
-    assert (
-        "An instance named 'test-metadata_42_valid-name' already exists in the metadata-tests "
-        "schemaspace" in ret.stderr
-    )
-
-    # Re-attempt with replace flag but without --name - failure expected
-    ret = script_runner.run(
-        "elyra-metadata",
-        "install",
-        METADATA_TEST_SCHEMASPACE,
-        "--schema_name=metadata-test",
-        "--display_name=display_name",
-        "--required_test=required_value",
-        "--replace",
-    )
-    assert ret.success is False
-    assert "The 'name' parameter requires a value" in ret.stdout
-
-    # Re-attempt with replace flag - success expected
-    ret = script_runner.run(
-        "elyra-metadata",
-        "install",
-        METADATA_TEST_SCHEMASPACE,
-        "--schema_name=metadata-test",
-        "--name=test-metadata_42_valid-name",
-        "--display_name=display_name",
-        "--required_test=required_value",
-        "--replace",
-    )
-    assert ret.success
-    assert "Metadata instance 'test-metadata_42_valid-name' for schema 'metadata-test' has been written" in ret.stdout
-
-    assert os.path.isdir(os.path.join(mock_data_dir, "metadata", METADATA_TEST_SCHEMASPACE))
-    assert os.path.isfile(expected_file)
-
-    with open(expected_file, "r") as fd:
-        instance_json = json.load(fd)
-        assert instance_json["schema_name"] == "metadata-test"
-        assert instance_json["display_name"] == "display_name"
-        assert instance_json["metadata"]["required_test"] == "required_value"
-        assert instance_json["metadata"]["number_default_test"] == 24  # ensure original value is used over default
-
-
-@pytest.mark.parametrize("complex_keyword", ["defs", "oneOf", "allOf"])
-def test_install_and_replace_complex(script_runner, mock_data_dir, complex_keyword):
-    # create and use deep copies of the global one_of_json and one_of_json
-    # to avoid side effects
-    one_of_json_cp = json.loads(json.dumps(one_of_json))
-    all_of_json_cp = json.loads(json.dumps(all_of_json))
-
-    test_file: Optional[str] = None
-    name: str = f"test-complex-{complex_keyword}".lower()
-
-    if complex_keyword == "defs":
-        option = "--json"
-        value = '{ "defs_test": 42 }'
-
-    elif complex_keyword == "oneOf":
-        option = "--file"
-        # Build the file...
-        test_file = os.path.join(mock_data_dir, f"{complex_keyword}.json")
-        with open(test_file, mode="w") as one_of_fd:
-            json.dump(one_of_json_cp, one_of_fd)
-        value = test_file
-    else:  # allOf
-        option = "--allOf_test"  # Use "ovp-from-file" approach
-        # Build the file...
-        test_file = os.path.join(mock_data_dir, f"{complex_keyword}.json")
-        with open(test_file, mode="w") as all_of_fd:
-            json.dump(all_of_json_cp, all_of_fd)
-        value = test_file
-
-    expected_file = os.path.join(mock_data_dir, "metadata", METADATA_TEST_SCHEMASPACE, f"{name}.json")
-    # Cleanup from any potential previous failures (should be rare)
-    if os.path.exists(expected_file):
-        os.remove(expected_file)
-
-    ret = script_runner.run(
-        "elyra-metadata",
-        "install",
-        METADATA_TEST_SCHEMASPACE,
-        "--schema_name=metadata-test",
-        f"--name={name}",
-        f"--display_name=Test Complex {complex_keyword}",
-        "--required_test=required_value",
-        f"{option}={value}",
-    )
-    assert ret.success
-    assert f"Metadata instance '{name}' for schema 'metadata-test' has been written" in ret.stdout
-    assert expected_file in ret.stdout
-    assert os.path.exists(expected_file)
-
-    with open(expected_file) as fd:
-        json_results = json.load(fd)
-
-    # Verify common stuff
-    assert json_results["display_name"] == f"Test Complex {complex_keyword}"
-    assert json_results["metadata"]["required_test"] == "required_value"
-
-    # Verify result and prepare for replace...
-    if complex_keyword == "defs":
-        assert json_results["metadata"]["defs_test"] == 42
-        value = '{ "defs_test": 24 }'
-    elif complex_keyword == "oneOf":
-        assert json_results["metadata"]["oneOf_test"]["obj_switch"] == "obj2"
-        assert json_results["metadata"]["oneOf_test"]["obj2_prop1"] == 42
-        one_of_json_cp["metadata"]["oneOf_test"]["obj2_prop1"] = 24
-        with open(test_file, mode="w+") as one_of_fd:
-            json.dump(one_of_json_cp, one_of_fd)
-    elif complex_keyword == "allOf":
-        assert len(json_results["metadata"]["allOf_test"]) == 9
-        assert json_results["metadata"]["allOf_test"]["obj1_switch"] == "obj1"
-        assert json_results["metadata"]["allOf_test"]["obj1_prop1"] == "allOf-test-val1"
-        assert json_results["metadata"]["allOf_test"]["obj1_prop2"] == "allOf-test-val2"
-        all_of_json_cp["obj1_prop1"] = "allOf-test-val1-replace"
-        assert json_results["metadata"]["allOf_test"]["obj2_switch"] == "obj2"
-        assert json_results["metadata"]["allOf_test"]["obj2_prop1"] == 42
-        assert json_results["metadata"]["allOf_test"]["obj2_prop2"] == 24
-        all_of_json_cp["obj2_prop1"] = 24
-        assert json_results["metadata"]["allOf_test"]["obj3_switch"] == "obj3"
-        assert json_results["metadata"]["allOf_test"]["obj3_prop1"] == 42.7
-        assert json_results["metadata"]["allOf_test"]["obj3_prop2"] is True
-        all_of_json_cp["obj3_prop1"] = 7.24
-
-        with open(test_file, mode="w+") as all_of_fd:
-            json.dump(all_of_json_cp, all_of_fd)
-
-    # Replace the previously-created instance
-    ret = script_runner.run(
-        "elyra-metadata",
-        "install",
-        METADATA_TEST_SCHEMASPACE,
-        "--schema_name=metadata-test",
-        f"--name={name}",
-        f"--display_name=Test Complex {complex_keyword}2",
-        "--required_test=required_value",
-        f"{option}={value}",
-        "--replace",
-    )
-    assert ret.success
-    assert f"Metadata instance '{name}' for schema 'metadata-test' has been written" in ret.stdout
-    assert expected_file in ret.stdout
-    assert os.path.exists(expected_file)
-
-    with open(expected_file) as fd:
-        json_results = json.load(fd)
-
-    # Verify common stuff
-    assert json_results["display_name"] == f"Test Complex {complex_keyword}2"
-    assert json_results["metadata"]["required_test"] == "required_value"
-
-    # Verify result following replace...
-    if complex_keyword == "defs":
-        assert json_results["metadata"]["defs_test"] == 24
-    elif complex_keyword == "oneOf":
-        assert json_results["metadata"]["oneOf_test"]["obj_switch"] == "obj2"
-        assert json_results["metadata"]["oneOf_test"]["obj2_prop1"] == 24
-        assert json_results["metadata"]["oneOf_test"]["obj2_prop2"] == 24
-    elif complex_keyword == "allOf":
-        assert len(json_results["metadata"]["allOf_test"]) == 9
-        assert json_results["metadata"]["allOf_test"]["obj1_prop1"] == "allOf-test-val1-replace"
-        assert json_results["metadata"]["allOf_test"]["obj1_prop2"] == "allOf-test-val2"
-        assert json_results["metadata"]["allOf_test"]["obj2_prop1"] == 24
-        assert json_results["metadata"]["allOf_test"]["obj2_prop2"] == 24
-        assert json_results["metadata"]["allOf_test"]["obj3_prop1"] == 7.24
-        assert json_results["metadata"]["allOf_test"]["obj3_prop2"] is True
-
-
-# ---------- begin of 'create' command tests
 
 
 def test_create_bad_argument(script_runner):
@@ -1913,7 +1562,7 @@ def test_required(script_runner, mock_data_dir):
 
     ret = script_runner.run(
         "elyra-metadata",
-        "install",
+        "create",
         METADATA_TEST_SCHEMASPACE,
         "--schema_name=metadata-test",
         "--name=" + name,
@@ -1925,7 +1574,7 @@ def test_required(script_runner, mock_data_dir):
 
     ret = script_runner.run(
         "elyra-metadata",
-        "install",
+        "create",
         METADATA_TEST_SCHEMASPACE,
         "--schema_name=metadata-test",
         "--name=" + name,
@@ -1947,7 +1596,7 @@ def test_required(script_runner, mock_data_dir):
 
 
 def test_number_default(script_runner, mock_data_dir):
-    # Doesn't use PropertyTester due to its unique test (no failure, needs --replace, etc.)
+    # Doesn't use PropertyTester due to its unique test (no failure, needs update, etc.)
     name = "number_default"
 
     expected_file = os.path.join(mock_data_dir, "metadata", METADATA_TEST_SCHEMASPACE, name + ".json")
@@ -1958,7 +1607,7 @@ def test_number_default(script_runner, mock_data_dir):
     # No negative test here.  First create w/o a value and ensure 42, then create with a value and ensure that value.
     ret = script_runner.run(
         "elyra-metadata",
-        "install",
+        "create",
         METADATA_TEST_SCHEMASPACE,
         "--schema_name=metadata-test",
         "--name=" + name,
@@ -1978,14 +1627,13 @@ def test_number_default(script_runner, mock_data_dir):
         assert instance_json["display_name"] == name
         assert instance_json["metadata"]["number_default_test"] == 42
 
-    # Note that we only include the properties that are changed, along with "identifiers" like name ans schema_name.
+    # Note that we only include the properties that are changed, along with "identifiers" like name and schema_name.
     ret = script_runner.run(
         "elyra-metadata",
-        "install",
+        "update",
         METADATA_TEST_SCHEMASPACE,
         "--schema_name=metadata-test",
         "--name=" + name,
-        "--replace",
         "--number_default_test=7.2",
     )
 

--- a/elyra/tests/metadata/test_utils.py
+++ b/elyra/tests/metadata/test_utils.py
@@ -147,7 +147,7 @@ byo_metadata_json = {
     "metadata": {"required_test": "required_value"},
 }
 
-# Used in test_install_and_replace_complex to test --file option
+# Used in test_update_complex to test --file option
 one_of_json = {
     "schema_name": "metadata-test",
     "display_name": "oneOf Testing",
@@ -157,7 +157,7 @@ one_of_json = {
     },
 }
 
-# Used in test_install_and_replace_complex to test --allOf_test option (i.e., ovp option)
+# Used in test_update_complex to test --allOf_test option (i.e., ovp option)
 all_of_json = {
     "obj1_prop1": "allOf-test-val1",
     "obj1_prop2": "allOf-test-val2",
@@ -239,7 +239,7 @@ class PropertyTester(object):
         # First test
         ret = script_runner.run(
             "elyra-metadata",
-            "install",
+            "create",
             METADATA_TEST_SCHEMASPACE,
             "--schema_name=metadata-test",
             "--name=" + self.name,
@@ -255,7 +255,7 @@ class PropertyTester(object):
         # Second test
         ret = script_runner.run(
             "elyra-metadata",
-            "install",
+            "create",
             METADATA_TEST_SCHEMASPACE,
             "--schema_name=metadata-test",
             "--name=" + self.name,

--- a/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
+++ b/elyra/tests/pipeline/airflow/test_component_parser_airflow.py
@@ -82,7 +82,7 @@ async def test_modify_component_catalogs(component_cache, metadata_manager_with_
         res: CompletedProcess = run(
             [
                 "elyra-metadata",
-                "install",
+                "create",
                 "component-catalogs",
                 f"--schema_name={registry_instance.schema_name}",
                 f"--json={registry_instance.to_json()}",
@@ -157,7 +157,7 @@ async def test_directory_based_component_catalog(component_cache, metadata_manag
         res: CompletedProcess = run(
             [
                 "elyra-metadata",
-                "install",
+                "create",
                 "component-catalogs",
                 f"--schema_name={registry_instance.schema_name}",
                 f"--json={registry_instance.to_json()}",

--- a/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
+++ b/elyra/tests/pipeline/kfp/test_component_parser_kfp.py
@@ -80,7 +80,7 @@ async def test_modify_component_catalogs(jp_environ, component_cache, metadata_m
         res: CompletedProcess = run(
             [
                 "elyra-metadata",
-                "install",
+                "create",
                 "component-catalogs",
                 f"--schema_name={registry_instance.schema_name}",
                 f"--json={registry_instance.to_json()}",
@@ -173,7 +173,7 @@ async def test_directory_based_component_catalog(
         res: CompletedProcess = run(
             [
                 "elyra-metadata",
-                "install",
+                "create",
                 "component-catalogs",
                 f"--schema_name={registry_instance.schema_name}",
                 f"--json={registry_instance.to_json()}",


### PR DESCRIPTION
This pull request formally removes the `install` subcommand from `elyra-metadata`.  "Installs" are performed via the `create` subcommand while updates (previously performed using `install --replace`) are performed via the `update` subcommand.

Resolves: #2580 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
