### PR TITLE
Update pytorch runtime to fix validate images check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,20 +345,20 @@ validate-runtime-image: # Validate that runtime image meets minimum criteria
 	fi; \
 	for cmd in $$required_commands ; do \
         echo "=> Checking container image $$image for $$cmd..." ; \
-		docker run --rm $$image which $$cmd > /dev/null 2>&1 ; \
+		docker run --rm --entrypoint /bin/bash $$image -c "which $$cmd" > /dev/null 2>&1 ; \
 		if [ $$? -ne 0 ]; then \
 			echo "ERROR: Container image $$image does not meet criteria for command: $$cmd" ; \
 			fail=1; \
 			continue; \
 		fi; \
 		if [ $$cmd == "python3" ]; then \
-			IMAGE_PYTHON3_MINOR_VERSION=`docker run --rm $$image $$cmd --version | cut -d' ' -f2 | cut -d'.' -f2` ; \
+			IMAGE_PYTHON3_MINOR_VERSION=`docker run --rm --entrypoint /bin/bash $$image "$$cmd --version" | cut -d' ' -f2 | cut -d'.' -f2` ; \
 			if [[ $$IMAGE_PYTHON3_MINOR_VERSION -lt 8 ]]; then \
 				echo "WARNING: Container image $$image requires Python 3.8 or greater for latest generic component dependency installation" ; \
 				fail=1; \
 			elif [[ $$IMAGE_PYTHON3_MINOR_VERSION -ge 8 ]]; then \
 				echo "=> Checking notebook execution..." ; \
-				docker run -v $$(pwd)/etc/generic:/opt/elyra/ --rm $$image /bin/bash -c "python3 -m pip install -r /opt/elyra/requirements-elyra.txt && \
+				docker run -v $$(pwd)/etc/generic:/opt/elyra/ --rm --entrypoint /bin/bash $$image -c "python3 -m pip install -r /opt/elyra/requirements-elyra.txt && \
 							   curl https://raw.githubusercontent.com/nteract/papermill/main/papermill/tests/notebooks/simple_execute.ipynb --output simple_execute.ipynb && \
 							   python3 -m papermill simple_execute.ipynb output.ipynb > /dev/null" ; \
 				if [ $$? -ne 0 ]; then \

--- a/Makefile
+++ b/Makefile
@@ -352,7 +352,7 @@ validate-runtime-image: # Validate that runtime image meets minimum criteria
 			continue; \
 		fi; \
 		if [ $$cmd == "python3" ]; then \
-			IMAGE_PYTHON3_MINOR_VERSION=`docker run --rm --entrypoint /bin/bash $$image "$$cmd --version" | cut -d' ' -f2 | cut -d'.' -f2` ; \
+			IMAGE_PYTHON3_MINOR_VERSION=`docker run --rm --entrypoint /bin/bash $$image -c "$$cmd --version" | cut -d' ' -f2 | cut -d'.' -f2` ; \
 			if [[ $$IMAGE_PYTHON3_MINOR_VERSION -lt 8 ]]; then \
 				echo "WARNING: Container image $$image requires Python 3.8 or greater for latest generic component dependency installation" ; \
 				fail=1; \

--- a/etc/config/metadata/runtime-images/pytorch-runtime.json
+++ b/etc/config/metadata/runtime-images/pytorch-runtime.json
@@ -2,7 +2,7 @@
   "display_name": "Pytorch 1.12 with CUDA-runtime",
   "metadata": {
     "description": "PyTorch 1.12 (with GPU support)",
-    "image_name": "pytorch/pytorch@sha256:0bc0971dc8ae319af610d493aced87df46255c9508a8b9e9bc365f11a56e7b75",
+    "image_name": "nvcr.io/nvidia/pytorch@sha256:b6080b287f79ba34c392730566a8903361453c15c3b3beff032d11a05e08f7c3",
     "tags": ["gpu", "pytorch"]
   },
   "schema_name": "runtime-image"

--- a/etc/config/metadata/runtime-images/pytorch-runtime.json
+++ b/etc/config/metadata/runtime-images/pytorch-runtime.json
@@ -1,8 +1,8 @@
 {
-  "display_name": "Pytorch 1.4 with CUDA-runtime",
+  "display_name": "Pytorch 1.12 with CUDA-runtime",
   "metadata": {
-    "description": "PyTorch 1.4 (with GPU support)",
-    "image_name": "pytorch/pytorch@sha256:ee783a4c0fccc7317c150450e84579544e171dd01a3f76cf2711262aced85bf7",
+    "description": "PyTorch 1.12 (with GPU support)",
+    "image_name": "pytorch/pytorch@sha256:0bc0971dc8ae319af610d493aced87df46255c9508a8b9e9bc365f11a56e7b75",
     "tags": ["gpu", "pytorch"]
   },
   "schema_name": "runtime-image"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,9 @@ dependencies = [
     "watchdog>=2.1.3",
     "websocket-client",
     "yaspin",
-    "requests_toolbelt==0.10.1",
-    "kfp>=1.7.0,<2.0,!=1.7.2,!=1.8.21",  # We cap the SDK to <2.0 due to possible breaking changes
+    # see: https://stackoverflow.com/questions/76175487/sudden-importerror-cannot-import-name-appengine-from-requests-packages-urlli
+    "appengine-python-standard",
+    "kfp>=1.7.0,<2.0,!=1.7.2",  # We cap the SDK to <2.0 due to possible breaking changes
     "pygithub",
     "black>=22.8.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ dependencies = [
     "watchdog>=2.1.3",
     "websocket-client",
     "yaspin",
-    "kfp>=1.7.0,<2.0,!=1.7.2",  # We cap the SDK to <2.0 due to possible breaking changes
+    "requests_toolbelt==0.10.1",
+    "kfp>=1.7.0,<2.0,!=1.7.2,!=1.8.21",  # We cap the SDK to <2.0 due to possible breaking changes
     "pygithub",
     "black>=22.8.0",
 ]


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Since Python 3.7 runtime image support is removed, this PR updates default pytorch cuda runtime image version to fix the "validate images" check in github actions.
2. Python 3.10.11 reported `ImportError: cannot import name 'appengine' from 'urllib3.contrib' ` at current main branch CI jobs, adding `appengine-python-standard` can fix this, see: https://stackoverflow.com/questions/76175487/sudden-importerror-cannot-import-name-appengine-from-requests-packages-urlli
