### PR TITLE
Allow users to include ssl_sa_certs via env vars for kfp_tekton client

### DIFF
--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -221,6 +221,9 @@ The KubeFlow Pipelines API endpoint you want to utilize. This setting is require
 
 Example: `https://kubernetes-service.domain.com/pipeline`
 
+*Note*: In setups where the Kubeflow Pipeline server is secured with a custom certificate, users can specify this certificate path by setting the environment variable `KF_PIPELINES_SSL_SA_CERT` in the jupyter environment. This variable directs the Kubeflow Pipelines SDK client to use the provided certificate for accessing the Kubeflow Pipeline server. For more information, see the [ssl_ca_cert](https://kubeflow-pipelines.readthedocs.io/en/stable/source/client.html#kfp.client.Client.__init__.ssl_ca_cert) attribute in the `kfp` SDK documentation.  
+Ex: `KF_PIPELINES_SSL_SA_CERT:/path/to/certs`
+
 
 ##### Public Kubeflow Pipelines API endpoint (public_api_endpoint)
 

--- a/elyra/pipeline/kfp/kfp_authentication.py
+++ b/elyra/pipeline/kfp/kfp_authentication.py
@@ -230,6 +230,7 @@ class KFPAuthenticator:
         """
 
         kf_url = urlsplit(api_endpoint)._replace(path="").geturl()
+        kf_pipelines_ssl_sa_cert = os.getenv("KF_PIPELINES_SSL_SA_CERTS", None)
 
         # return data structure for successful requests
         auth_info = {
@@ -239,6 +240,7 @@ class KFPAuthenticator:
             "cookies": None,  # passed to KFP SDK client as "cookies" param value
             "credentials": None,  # passed to KFP SDK client as "credentials" param value
             "existing_token": None,  # passed to KFP SDK client as "existing_token" param value
+            "ssl_ca_cert": kf_pipelines_ssl_sa_cert,  # passed to KFP SDK Client as "ssl_ca_cert" param value
         }
 
         try:

--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -213,6 +213,7 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
                     credentials=auth_info.get("credentials", None),
                     existing_token=auth_info.get("existing_token", None),
                     namespace=user_namespace,
+                    ssl_ca_cert=auth_info.get("ssl_ca_cert", None),
                 )
             else:
                 client = ArgoClient(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

As the pipeline editor fails to connect to an unsecured pipeline server due to a certs issue, this PR includes an environment variable that can be pointed to the ssl_cert, which would be used for setting up the connection.

`KF_PIPELINES_SSL_SA_CERTS` can be set with cert path.

and `ssl_ca_cert` var would be set with the value and passed to [kfp SDK](https://github.com/kubeflow/kfp-tekton/blob/2d7cc156d131c66c9274a6c62a4235e3d575a88b/sdk/python/kfp_tekton/_client.py#L103).

Fixes: #3149 

### How was this pull request tested?
<!--
Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases, if possible.

If changes were tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added e.g. documentation only, GH workflow updates, etc.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
