### PR TITLE
feat: allow users to use version suffix pipeline runs

### DIFF
--- a/elyra/pipeline/kfp/processor_kfp.py
+++ b/elyra/pipeline/kfp/processor_kfp.py
@@ -309,7 +309,15 @@ class KfpPipelineProcessor(RuntimePipelineProcessor):
 
                 # Create an instance id that will be used to store
                 # the pipelines' dependencies, if applicable
-                pipeline_instance_id = f"{pipeline_name}-{timestamp}"
+                pipeline_instance_id = ""
+
+                # Use environment variable to set version as suffix instead of timestamp
+                if os.environ.get("KFP_SUFFIX_USE_VERSION") == "true":
+                    # Version is determined by the count of existing pipeline versions
+                    version = client.list_pipeline_versions(pipeline_id=pipeline_id).total_size
+                    pipeline_instance_id = f"{pipeline_name}-v{version}"
+                else:
+                    pipeline_instance_id = f"{pipeline_name}-{timestamp}"
 
                 # Generate Python DSL from workflow
                 pipeline_dsl = self._generate_pipeline_dsl(


### PR DESCRIPTION
### What changes were proposed in this pull request?

Currently, when pipelines are created using elyra from the Notebooks, each additional iteration of the pipeline run creates a new pipeline version identified by timestamp.

The PR will allow user to switch from timestamp identifiers to versions numbers (v1, etc) using an environment variable `KFP_SUFFIX_USE_VERSION`. This will make the pipeline runs easily distinguishable.

Fixes #3182 

### How was this pull request tested?
<!--
Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases, if possible.

If changes were tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added e.g. documentation only, GH workflow updates, etc.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
