### PR TITLE
Fix CI Build by temporarily disabling Python 3.11 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -113,7 +113,7 @@ jobs:
           node-version: "*"
       - uses: actions/setup-python@v4
         with:
-          python-version: "*"
+          python-version: "3.10"
       - uses: actions/cache@v3
         with:
           path: |
@@ -141,7 +141,7 @@ jobs:
           node-version: "*"
       - uses: actions/setup-python@v4
         with:
-          python-version: "*"
+          python-version: "3.10"
       - uses: actions/cache@v3
         with:
           path: |
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Validate image environment


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix CI Build by temporarily disabling Python 3.11 build

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
