### PR TITLE
Skip minio-7.2.1 to avoid urllib version mismatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "jupyterlab-git~=0.32",  # Avoid breaking 1.x changes
     "jupyter-resource-usage>=0.5.1,<1",
     "MarkupSafe>=2.1",
-    "minio>=7.0.0",
+    "minio>=7.0.0,!=7.2.1",
     "nbclient>=0.5.1",
     "nbconvert>=6.5.1",
     "nbdime~=3.1",  # Cap from jupyterlab-git


### PR DESCRIPTION
Fixes #3203 

### What changes were proposed in this pull request?
Skipping minio version `7.2.1` to avoid urllib version conflict. Refer https://github.com/elyra-ai/elyra/issues/3203 for more info.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

### How was this pull request tested?
Tested by running
```
make install
make kf-notebook-image
docker run -p 8888:8888 docker.io/elyra/kf-notebook:dev
```

<!--
Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases, if possible.

If changes were tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added e.g. documentation only, GH workflow updates, etc.
-->

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
