### PR TITLE
[WIP] Airflow package catalog connector for Airflow 2.x wheel, make import of all core operators possible, parsing changes

### DIFF
--- a/elyra/pipeline/airflow/package_catalog_connector/airflow_package_catalog_connector.py
+++ b/elyra/pipeline/airflow/package_catalog_connector/airflow_package_catalog_connector.py
@@ -161,7 +161,7 @@ class AirflowPackageCatalogConnector(ComponentCatalogConnector):
 
             #
             # Identify Python scripts that define classes that extend the
-            # airflow.models.BaseOperator class
+            # BaseOperator abstract class in module airflow.models.baseoperator
             #
             scripts_with_operator_class: List[str] = []  # Python scripts that contain operator definitions
             extends_baseoperator: List[str] = []  # Classes that extend BaseOperator
@@ -188,7 +188,10 @@ class AirflowPackageCatalogConnector(ComponentCatalogConnector):
                         elif isinstance(node, ast.ImportFrom):
                             node_module = node.module
                             for name in node.names:
-                                if "airflow.models" == node_module and name.name == "BaseOperator":
+                                if (
+                                    node_module in ["airflow.models", "airflow.models.baseoperator"]
+                                    and name.name == "BaseOperator"
+                                ):
                                     imported_operator_classes.append(name.name)
                         elif isinstance(node, ast.ClassDef):
                             # determine whether this class extends the BaseOperator class


### PR DESCRIPTION
fixes #2124 

@nanaones unsure if [airflow package catalog connector](https://medium.com/ibm-data-ai/getting-started-with-apache-airflow-operators-in-elyra-aae882f80c4a) was a feature in 2021 already, it is now ... still, even on package catalog connector initial setup and import, i.e. from

https://archive.apache.org/dist/airflow/2.6.2/apache_airflow-2.6.2-py3-none-any.whl

when importing the wheel file containing the airflow 2.x core operators, import is incomplete. For example, the BashOperator and Email Operator are missing. Looked like the detection logic needed fixes, something that @ianonavy fixed in a fork.

the message is as follows in Elyra container:

```
I 2024-01-05 10:52:38.508 ElyraApp] Analysis of 'https://archive.apache.org/dist/airflow/2.6.2/apache_airflow-2.6.2-py3-none-any.whl' completed. Located 9 operator classes in 4 Python scripts.
[W 2024-01-05 10:52:38.521 ServerApp] Operator 'BranchPythonOperator' associated with identifier '{'airflow_package': 'apache_airflow-2.6.2-py3-none-any.whl', 'file': 'airflow/operators/python.py'}' does not have an __init__ function. Skipping...
```

package catalog connector code needs fixes, this PR is based on work in a fork by @ianonavy for package catalog connector, so that bash operator and in general the provided base airflow operators work.

Concept behind the airflow package catalog connector in elyra main source: https://github.com/elyra-ai/elyra/tree/main/elyra/pipeline/airflow/package_catalog_connector

[work done in fork outside community elyra but never tested and discussed for far here](https://github.com/elyra-ai/elyra/commit/78fefe747329669243ae085647b65e614597c6c7) 

I am including this change here so it makes it into community Elyra.

Cause as it is now, only an incomplete subset of operators is made available by the airflow package catalog connector with Airflow 2.x wheel file.

![Bildschirmfoto 2024-01-12 um 17 48 41](https://github.com/elyra-ai/elyra/assets/21118431/7cb2505b-8dbf-410e-aa71-1958f1d1fb05)

The fix in this PR commit, BaseOperator reference location being compatible with Airflow 2.x

https://airflow.apache.org/docs/apache-airflow/2.6.2/_api/airflow/models/baseoperator/index.html#

It's been in this new location ranging all the way back to 2.0.0.

https://airflow.apache.org/docs/apache-airflow/2.0.0/_api/airflow/models/baseoperator/index.html

change in this PR leads to all operators being available finally in Elyra pipeline editor:

https://airflow.apache.org/docs/apache-airflow/2.6.2/operators-and-hooks-ref.html

after I do the changes, I get a different log on Elyra start when evaluating the wheel file, looking much better, more operator classes (16 instead of 9) detected.

```
[I 2024-01-12 22:25:00.524 ElyraApp] Analysis of ''https://archive.apache.org/dist/airflow/2.6.2/apache_airflow-2.6.2-py3-none-any.whl'' completed. Located 16 operator classes in 11 Python scripts.
[W 2024-01-12 22:25:00.568 ServerApp] Operator 'BaseBranchOperator' associated with identifier '{'airflow_package': 'apache_airflow-2.6.2-py3-none-any.whl', 'file': 'airflow/operators/branch.py'}' does not have an __init__ function. Skipping...
[W 2024-01-12 22:25:00.571 ServerApp] Operator 'EmptyOperator' associated with identifier '{'airflow_package': 'apache_airflow-2.6.2-py3-none-any.whl', 'file': 'airflow/operators/empty.py'}' does not have an __init__ function. Skipping...
[W 2024-01-12 22:25:00.587 ServerApp] Operator 'BranchPythonOperator' associated with identifier '{'airflow_package': 'apache_airflow-2.6.2-py3-none-any.whl', 'file': 'airflow/operators/python.py'}' does not have an __init__ function. Skipping...
[W 2024-01-12 22:25:00.592 ServerApp] Operator 'LatestOnlyOperator' associated with identifier '{'airflow_package': 'apache_airflow-2.6.2-py3-none-any.whl', 'file': 'airflow/operators/latest_only.py'}' does not have an __init__ function. Skipping...
```
The 3 operators now not imported and usable are ones that are pipeline-related, but not via the mechanisms offered by KubernetesPodOperator and IBM pipelines, so they and should be skipped from a use case perspective, and also because they init themselves not on their own. Besides that, the EmptyOperator is kind of a placeholder dummy operator anyways, no functionality. 

let's check the GUI after the wheel file import and the change in this PR

I can now for example see and use the BashOperator, with Airflow 2.x.

![Bildschirmfoto 2024-01-12 um 23 31 57](https://github.com/elyra-ai/elyra/assets/21118431/d024ec72-d09d-4033-8071-e7c17cc6915b)

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
no code refactoring, just a small operator detection logic change for Airflow 2.0.0 and higher

It's been in this new location ranging all the way back to 2.0.0.

https://airflow.apache.org/docs/apache-airflow/2.0.0/_api/airflow/models/baseoperator/index.html

Add package connector support for Airflow 2.x The check for subclasses of BaseOperator uses an outdated package name. This commit and PR adds the new one from Airflow 2.

### How was this pull request tested?

no changes in any existing Elyra unit tests.
However, flow of importing Airflow 2.x core operators explained above, with result before and after the change in this PR.
Import worked fine, operators visible in left palette of Elyra pipeline editor.
Tested with: Airflow 2.6.2

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
