### PR TITLE
Replace hard coded docker command to environment variable for support…

### DIFF
--- a/docs/source/recipes/creating-a-custom-runtime-image.md
+++ b/docs/source/recipes/creating-a-custom-runtime-image.md
@@ -90,6 +90,11 @@ The [Elyra `Makefile`](https://github.com/elyra-ai/elyra/blob/main/Makefile) inc
    ```bash
    $ make validate-runtime-image image=my-runtime-image
    ```
+   If using `podman`, ensure the following environmental variables are set prior to running the release script:
+```bash
+    CONTAINER_EXEC=podman
+    CONTAINER_OUTPUT_OPTION="--format docker"
+```
 
    If no problems were detected the output should look as follows:
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is related to https://github.com/elyra-ai/elyra/pull/3082
I found a problem where docker is hard coded in the validate-runtime-image method of the Makefile and podman cannot be used.
In a previous PR, it was implemented to switch between docker and podman using the CONTAINER_EXEC environment variable, so I followed that and fixed it.

### How was this pull request tested?

```
❯ CONTAINER_EXEC=podman make validate-runtime-image image=localhost/test:v3
WARNING: You are using pip version 21.2.4; however, version 24.0 is available.
You should consider upgrading via the '/Applications/Xcode.app/Contents/Developer/usr/bin/python3 -m pip install --upgrade pip' command.
***********************************************************
Validating container image localhost/test:v3
-----------------------------------------------------------
=> Loading container image ...
=> Checking container image localhost/test:v3 for curl...
=> Checking container image localhost/test:v3 for python3...
=> Checking notebook execution...
=== SNIP ===
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   910  100   910    0     0   3137      0 --:--:-- --:--:-- --:--:--  3148
Input Notebook:  simple_execute.ipynb
Output Notebook: output.ipynb
Executing:   0%|          | 0/3 [00:00<?, ?cell/s]Executing notebook with kernel: python3
Executing DESC: 100%|██████████| 3/3 [00:00<00:00,  3.40cell/s]
-----------------------------------------------------------
=> Container image localhost/test:v3 is a suitable Elyra runtime image
``` 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
