### PR TITLE
RFileOp PythonFileOp NotebookFileOp log stdout and stderr output to stdout always, S3 file put for run log output file made configurable

### DIFF
--- a/elyra/kfp/bootstrapper.py
+++ b/elyra/kfp/bootstrapper.py
@@ -46,6 +46,11 @@ F = TypeVar("F", bound="FileOpBase")
 
 logger = logging.getLogger("elyra")
 enable_pipeline_info = os.getenv("ELYRA_ENABLE_PIPELINE_INFO", "true").lower() == "true"
+# not only log File Operations output of NotebookFileOp, RFileOp, PythonFileOp to stdout so it appears
+# in runtime / container logs and also Airflow and KFP GUI logs, but also put output to S3 storage
+enable_generic_node_script_output_to_s3 = (
+    os.getenv("ELYRA_GENERIC_NODES_ENABLE_SCRIPT_OUTPUT_TO_S3", "true").lower() == "true"
+)
 pipeline_name = None  # global used in formatted logging
 operation_name = None  # global used in formatted logging
 
@@ -376,21 +381,32 @@ class NotebookFileOp(FileOpBase):
 
             import papermill
 
-            papermill.execute_notebook(notebook, notebook_output, kernel_name=kernel_name, **kwargs)
+            logger.info("Processing file: %s", notebook)
+            papermill.execute_notebook(
+                notebook,
+                notebook_output,
+                kernel_name=kernel_name,
+                log_output=True,
+                stdout_file=sys.stdout,
+                stderr_file=sys.stderr,
+                **kwargs,
+            )
             duration = time.time() - t0
             OpUtil.log_operation_info("notebook execution completed", duration)
 
             NotebookFileOp.convert_notebook_to_html(notebook_output, notebook_html)
-            self.put_file_to_object_storage(notebook_output, notebook)
-            self.put_file_to_object_storage(notebook_html)
+            if enable_generic_node_script_output_to_s3:
+                self.put_file_to_object_storage(notebook_output, notebook)
+                self.put_file_to_object_storage(notebook_html)
             self.process_outputs()
         except Exception as ex:
             # log in case of errors
             logger.error(f"Unexpected error: {sys.exc_info()[0]}")
 
             NotebookFileOp.convert_notebook_to_html(notebook_output, notebook_html)
-            self.put_file_to_object_storage(notebook_output, notebook)
-            self.put_file_to_object_storage(notebook_html)
+            if enable_generic_node_script_output_to_s3:
+                self.put_file_to_object_storage(notebook_output, notebook)
+                self.put_file_to_object_storage(notebook_html)
             raise ex
 
     @staticmethod
@@ -483,20 +499,33 @@ class PythonFileOp(FileOpBase):
             if self.parameter_pass_method == "env":
                 self.set_parameters_in_env()
 
-            with open(python_script_output, "w") as log_file:
-                subprocess.run(run_args, stdout=log_file, stderr=subprocess.STDOUT, check=True)
+            logger.info("Processing file: %s", python_script)
+            try:
+                result = subprocess.run(run_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+                output = result.stdout.decode("utf-8")
+                if enable_generic_node_script_output_to_s3:
+                    with open(python_script_output, "w") as log_file:
+                        log_file.write(output)
+                logger.info("Output: %s", output)
+                logger.info("Return code: %s", result.returncode)
+            except subprocess.CalledProcessError as e:
+                logger.error("Output: %s", e.output.decode("utf-8"))
+                logger.error("Return code: %s", e.returncode)
+                raise subprocess.CalledProcessError(e.returncode, run_args)
 
             duration = time.time() - t0
             OpUtil.log_operation_info("python script execution completed", duration)
 
-            self.put_file_to_object_storage(python_script_output, python_script_output)
+            if enable_generic_node_script_output_to_s3:
+                self.put_file_to_object_storage(python_script_output, python_script_output)
             self.process_outputs()
         except Exception as ex:
             # log in case of errors
             logger.error(f"Unexpected error: {sys.exc_info()[0]}")
             logger.error(f"Error details: {ex}")
 
-            self.put_file_to_object_storage(python_script_output, python_script_output)
+            if enable_generic_node_script_output_to_s3:
+                self.put_file_to_object_storage(python_script_output, python_script_output)
             raise ex
 
 
@@ -517,20 +546,33 @@ class RFileOp(FileOpBase):
             if self.parameter_pass_method == "env":
                 self.set_parameters_in_env()
 
-            with open(r_script_output, "w") as log_file:
-                subprocess.run(run_args, stdout=log_file, stderr=subprocess.STDOUT, check=True)
+            logger.info("Processing file: %s", r_script)
+            try:
+                result = subprocess.run(run_args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True)
+                output = result.stdout.decode("utf-8")
+                if enable_generic_node_script_output_to_s3:
+                    with open(r_script_output, "w") as log_file:
+                        log_file.write(output)
+                logger.info("Output: %s", output)
+                logger.info("Return code: %s", result.returncode)
+            except subprocess.CalledProcessError as e:
+                logger.error("Output: %s", e.output.decode("utf-8"))
+                logger.error("Return code: %s", e.returncode)
+                raise subprocess.CalledProcessError(e.returncode, run_args)
 
             duration = time.time() - t0
             OpUtil.log_operation_info("R script execution completed", duration)
 
-            self.put_file_to_object_storage(r_script_output, r_script_output)
+            if enable_generic_node_script_output_to_s3:
+                self.put_file_to_object_storage(r_script_output, r_script_output)
             self.process_outputs()
         except Exception as ex:
             # log in case of errors
             logger.error(f"Unexpected error: {sys.exc_info()[0]}")
             logger.error(f"Error details: {ex}")
 
-            self.put_file_to_object_storage(r_script_output, r_script_output)
+            if enable_generic_node_script_output_to_s3:
+                self.put_file_to_object_storage(r_script_output, r_script_output)
             raise ex
 
 
@@ -726,6 +768,9 @@ def main():
     input_params = OpUtil.parse_arguments(sys.argv[1:])
     OpUtil.log_operation_info("starting operation")
     t0 = time.time()
+    # must be commented out in airgapped images if packages from
+    # https://github.com/elyra-ai/elyra/blob/main/etc/generic/requirements-elyra.txt
+    # already installed via central pip env during container build
     OpUtil.package_install(user_volume_path=input_params.get("user-volume-path"))
 
     # Create the appropriate instance, process dependencies and execute the operation


### PR DESCRIPTION
/fixes #3222 

Change as it is now already does solve the issue of no logs appearing in Airflow or KFP for R and Python and iPython Notebook generic pipeline nodes. Also, success or failed (exit code) status of any file run now ripples through correctly to Airflow GUI and task and dag metadata.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?

Hello! I have a problem with my elyra pipelines not showing logs.
I have looked for issues on github but couldn't find anything related, and i am not sure if I am missing some needed config or if this is a bug.
When I run an elyra pipeline with two nodes, one a jupyter notebook and one a python script, only the jupyter notebook one shows the logging. I am not sure why this is the case as they are both managed the same way.

This error happens in both kfp and airflow pipeline runs. It is related to the bootstrapper.py file that executes the scripts behind generic pipeline nodes, in this case pythonFileOp and RFileOp have similar syntax, subprocess.run, in both kfp and airflow bootstrapper.py

https://github.com/elyra-ai/elyra/blob/main/elyra/kfp/bootstrapper.py#L521
https://github.com/elyra-ai/elyra/blob/main/elyra/airflow/bootstrapper.py#L332

i.e.
`with open(r_script_output, "w") as log_file: subprocess.run(run_args, stdout=log_file, stderr=subprocess.STDOUT, check=True)`

We only see the name of the processed file in stdout and no logs in case of python or r nodes.
This change uses the subprocess.run mechanism in such as way that all stderr and stdout output is written to a variable whose content (i.e. the script run output) is then logged.

Added new env variable for runtime tasks `ELYRA_GENERIC_NODES_ENABLE_SCRIPT_OUTPUT_TO_S3` with default `true` if not set explicitely.
For users that do not want log output in a file on S3, those can set the env to false.


### How was this pull request tested?
Added changed bootstrapper.py file for airflow to a runtime image and used it in conjunction with Elyra and Airflow 2.8.2 to see whether the logs appear now in the container log output / in Airflow Logs tab.
Results positive and as intended, documented here
https://github.com/elyra-ai/elyra/issues/3222#issuecomment-2075054836

There was an issue with log output for ipynb not showing in all cases, only when log level was set to debug.
That has been fixed here in papermill.execute as well.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
