### PR TITLE
Fix Python formatting to get rid of linter errors from `make lint-server`

### DIFF
--- a/elyra/tests/metadata/test_metadata.py
+++ b/elyra/tests/metadata/test_metadata.py
@@ -704,7 +704,7 @@ def test_validation_performance():
     print(
         f"\nMemory: {diff:,} kb, Start: {memory_start.rss / 1024 / 1024:,.3f} mb, "
         f"End: {memory_end.rss / 1024 / 1024:,.3f} mb., "
-        f"Elapsed time: {t1-t0:.3f}s over {iterations} iterations."
+        f"Elapsed time: {t1 - t0:.3f}s over {iterations} iterations."
     )
 
 

--- a/elyra/tests/util/test_kubernetes.py
+++ b/elyra/tests/util/test_kubernetes.py
@@ -87,7 +87,7 @@ def test_is_valid_label_key_invalid_input():
     assert not is_valid_label_key(key="/n")  # prefix too short
     assert not is_valid_label_key(key="p/")  # name too short
     assert not is_valid_label_key(key="a" * 254)  # name too long
-    assert not is_valid_label_key(key=f"d/{'b'*64}")  # name too long
+    assert not is_valid_label_key(key=f"d/{'b' * 64}")  # name too long
     # test first character violations (not alphanum)
     assert not is_valid_label_key(key="-a")
     assert not is_valid_label_key(key=".b")
@@ -116,7 +116,7 @@ def test_is_valid_label_key_valid_input():
     assert is_valid_label_key(key="p/n")
     assert is_valid_label_key(key="prefix/you.2")
     assert is_valid_label_key(key="how.sad/to-see")
-    assert is_valid_label_key(key=f"{'d'*253}/{'n'*63}")
+    assert is_valid_label_key(key=f"{'d' * 253}/{'n' * 63}")
 
 
 def test_is_valid_label_value_invalid_input():
@@ -175,7 +175,7 @@ def test_is_valid_annotation_key_invalid_input():
     assert not is_valid_annotation_key(key="/n")  # prefix too short
     assert not is_valid_annotation_key(key="p/")  # name too short
     assert not is_valid_annotation_key(key="a" * 254)  # name too long
-    assert not is_valid_annotation_key(key=f"d/{'b'*64}")  # name too long
+    assert not is_valid_annotation_key(key=f"d/{'b' * 64}")  # name too long
     # test first character violations (not alphanum)
     assert not is_valid_annotation_key(key="-a")
     assert not is_valid_annotation_key(key=".b")
@@ -204,7 +204,7 @@ def test_is_valid_annotation_key_valid_input():
     assert is_valid_annotation_key(key="p/n")
     assert is_valid_annotation_key(key="prefix/you.2")
     assert is_valid_annotation_key(key="how.sad/to-see")
-    assert is_valid_annotation_key(key=f"{'d'*253}/{'n'*63}")
+    assert is_valid_annotation_key(key=f"{'d' * 253}/{'n' * 63}")
 
 
 def test_is_valid_annotation_value_invalid_input():


### PR DESCRIPTION
### What changes were proposed in this pull request?

This fixes the following errors, that were previously reported

```
make lint-server
python3 -m flake8 elyra .github
elyra/tests/metadata/test_metadata.py:707:28: E226 missing whitespace around arithmetic operator
elyra/tests/util/test_kubernetes.py:90:47: E226 missing whitespace around arithmetic operator
elyra/tests/util/test_kubernetes.py:119:41: E226 missing whitespace around arithmetic operator
elyra/tests/util/test_kubernetes.py:119:51: E226 missing whitespace around arithmetic operator
elyra/tests/util/test_kubernetes.py:178:52: E226 missing whitespace around arithmetic operator
elyra/tests/util/test_kubernetes.py:207:46: E226 missing whitespace around arithmetic operator
elyra/tests/util/test_kubernetes.py:207:56: E226 missing whitespace around arithmetic operator
make: *** [lint-server] Error 1
```

### How was this pull request tested?

Run the command that was previously failing in CI

* https://github.com/jiridanek/elyra/actions/runs/12473128947/job/34813104334#step:3:1

```
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
```