### PR TITLE
Fix some properties not being added in the Pipeline Properties tab

### DIFF
--- a/tests/integration/pipeline.ts
+++ b/tests/integration/pipeline.ts
@@ -318,6 +318,109 @@ describe('Pipeline Editor tests', () => {
     cy.readFile('build/cypress-tests/simple.pipeline').matchesSnapshot();
   });
 
+  it('should fill up all properties in the Pipeline Properties tab', () => {
+    cy.createPipeline({
+      name: 'pipeline-properties.pipeline',
+      emptyPipeline
+    });
+
+    cy.get('#jp-main-dock-panel').within(() => {
+      cy.get('button[aria-label="Open Panel"]').click();
+      cy.get('form.elyra-formEditor').within(() => {
+        // Pipeline Description
+        cy.get('textarea#root_description').type('Test description');
+        // Object Storage path prefix
+        cy.get('input#root_pipeline_defaults_cos_object_prefix').type(
+          'foo/bar'
+        );
+        // Node Defaults > Kubernetes Pod Labels
+        cy.get('#root_pipeline_defaults_kubernetes_pod_labels')
+          .scrollIntoView()
+          .within(() => {
+            form_addItem();
+            form_typeTextOnInputByLabel('Key', 'KPD_key');
+            form_typeTextOnInputByLabel('Value', 'KPD_value');
+          });
+        // Node Defaults > Data Volumes
+        cy.get('#root_pipeline_defaults_mounted_volumes')
+          .scrollIntoView()
+          .within(() => {
+            form_addItem();
+            form_typeTextOnInputByLabel('Mount Path', '/mount/path');
+            form_typeTextOnInputByLabel(
+              'Persistent Volume Claim Name',
+              'pvc-name'
+            );
+            form_typeTextOnInputByLabel('Sub Path', 'sub/path');
+            cy.get(
+              'input#root_pipeline_defaults_mounted_volumes_0_read_only'
+            ).click({ force: true });
+          });
+        // Node Defaults > Shared Memory Size
+        cy.get('#root_pipeline_defaults_kubernetes_shared_mem_size_size')
+          .scrollIntoView()
+          .within(() => {
+            form_typeTextOnInputByLabel('Memory Size (GB)', '1');
+          });
+        // Node Defaults > Kubernetes Tolerations
+        cy.get('#root_pipeline_defaults_kubernetes_tolerations')
+          .scrollIntoView()
+          .within(() => {
+            form_addItem();
+            form_typeTextOnInputByLabel('Key', 'KT_key');
+            form_typeTextOnInputByLabel('Value', 'KT_value');
+            cy.get('#root_pipeline_defaults_kubernetes_tolerations_0_effect')
+              .scrollIntoView()
+              .find('select')
+              .should('be.visible')
+              .select('NoExecute', { force: true });
+            cy.get('#root_pipeline_defaults_kubernetes_tolerations_0_operator')
+              .scrollIntoView()
+              .find('select')
+              .should('be.visible')
+              .select('Exists', { force: true });
+          });
+        // Node Defaults > Kubernetes Pod Annotations
+        cy.get('#root_pipeline_defaults_kubernetes_pod_annotations')
+          .scrollIntoView()
+          .within(() => {
+            form_addItem();
+            form_typeTextOnInputByLabel('Key', 'KPA_key');
+            form_typeTextOnInputByLabel('Value', 'KPA_value');
+          });
+        // Generic Node Defaults > Runtime Image
+        cy.get('#root_pipeline_defaults_runtime_image')
+          .scrollIntoView()
+          .find('select')
+          .should('be.visible')
+          .select('continuumio/anaconda3:2024.02-1', { force: true });
+        // Generic Node Defaults > Kubernetes Secrets
+        cy.get('#root_pipeline_defaults_kubernetes_secrets')
+          .scrollIntoView()
+          .within(() => {
+            form_addItem();
+            form_typeTextOnInputByLabel('Environment Variable', 'KS_envvar');
+            form_typeTextOnInputByLabel('Secret Name', 'KS_name');
+            form_typeTextOnInputByLabel('Secret Key', 'KS_ket');
+          });
+        // Generic Node Defaults > Environment Variables
+        cy.get('#root_pipeline_defaults_env_vars')
+          .scrollIntoView()
+          .within(() => {
+            form_addItem();
+            form_typeTextOnInputByLabel('Environment Variable', 'EV_envvar');
+            form_typeTextOnInputByLabel('Value', 'EV_value');
+          });
+        // Custom Node Defaults > Disable node caching
+        cy.get('#root_pipeline_defaults_disable_node_caching')
+          .scrollIntoView()
+          .find('select')
+          .should('be.visible')
+          .select('True', { force: true });
+      });
+    });
+  });
+
   // Flaky test: Sometimes cannot create/open files
   it.skip('should open notebook on double-clicking the node', () => {
     // Open a pipeline in root directory
@@ -835,4 +938,18 @@ const checkDisabledToolbarButtons = (buttons: RegExp[]): void => {
   for (const button of buttons) {
     cy.findByRole('jp-button', { name: button }).should('be.disabled');
   }
+};
+
+const form_typeTextOnInputByLabel = (label: string, text: string): void => {
+  cy.get(`input[label="${label}"]`)
+    .should('be.visible')
+    .type(text)
+    .should('have.value', text);
+};
+
+const form_addItem = (): void => {
+  cy.get('button.jp-mod-styled.jp-mod-reject')
+    .contains('Add')
+    .should('be.visible')
+    .click({ force: true });
 };

--- a/tests/snapshots/pipeline-editor-tests/matches-complex-pipeline-snapshot.1.snap
+++ b/tests/snapshots/pipeline-editor-tests/matches-complex-pipeline-snapshot.1.snap
@@ -34,7 +34,6 @@
               "filename": "producer.ipynb",
               "runtime_image": "continuumio/anaconda3:2024.02-1"
             },
-            "label": "",
             "ui_data": {
               "label": "producer.ipynb",
               "image": "/static/elyra/notebook.svg",
@@ -91,7 +90,6 @@
               "filename": "consumer.ipynb",
               "runtime_image": "continuumio/anaconda3:2024.02-1"
             },
-            "label": "",
             "ui_data": {
               "label": "consumer.ipynb",
               "image": "/static/elyra/notebook.svg",
@@ -150,7 +148,6 @@
               "filename": "../scripts/setup.py",
               "runtime_image": "continuumio/anaconda3:2024.02-1"
             },
-            "label": "",
             "ui_data": {
               "label": "setup.py",
               "image": "/static/elyra/python.svg",
@@ -210,7 +207,6 @@
               "filename": "create-source-files.py",
               "runtime_image": "continuumio/anaconda3:2024.02-1"
             },
-            "label": "",
             "ui_data": {
               "label": "create-source-files.py",
               "image": "/static/elyra/python.svg",
@@ -270,7 +266,6 @@
               "filename": "producer-script.py",
               "runtime_image": "continuumio/anaconda3:2024.02-1"
             },
-            "label": "",
             "ui_data": {
               "label": "producer-script.py",
               "image": "/static/elyra/python.svg",

--- a/tests/snapshots/pipeline-editor-tests/matches-simple-pipeline-snapshot.1.snap
+++ b/tests/snapshots/pipeline-editor-tests/matches-simple-pipeline-snapshot.1.snap
@@ -13,7 +13,6 @@
           "type": "execution_node",
           "op": "execute-notebook-node",
           "app_data": {
-            "label": "",
             "component_parameters": {
               "dependencies": [],
               "include_subdirectories": false,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

The issue is in the `PipelineEditorWidget.tsx::onChange` callback. Every time the pipeline source changes, it calls a function called `removeNullValues`. Despite the name, such a function also removes empty strings. Thus, when users click on the Add button of some properties, the form creates an object like `{"key": "", "value": ""}` but `removeNullValues` is triggered in sequence and removes it. Since it's fast, it gives the impression that the Add button doesn't do anything. This fix is a compromise to have everything working, which avoids some buggy scenarios that have been previously fixed and already included on `main`.

Cherry-picked from [ODH Elyra](https://github.com/opendatahub-io/elyra):
- https://github.com/opendatahub-io/elyra/pull/88

### How was this pull request tested?
<!--
Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases, if possible.

If changes were tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added e.g. documentation only, GH workflow updates, etc.
-->

This PR includes a test to validate the scenario. Also, manual tests have been performed.

Green CI on my fork: https://github.com/caponetto/opendatahub-io-elyra/actions/runs/12583673808
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
