### PR TITLE
Show validation warnings only after the first form submission

### DIFF
--- a/packages/ui-components/src/FormEditor.tsx
+++ b/packages/ui-components/src/FormEditor.tsx
@@ -22,7 +22,8 @@ import {
   ArrayFieldTemplateProps,
   FieldTemplateProps,
   RegistryFieldsType,
-  RegistryWidgetsType
+  RegistryWidgetsType,
+  RJSFValidationError
 } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import * as React from 'react';
@@ -37,9 +38,9 @@ interface IFormEditorProps {
   schema: any;
 
   /**
-   * Handler to update form data / error state in parent component.
+   * Handler to update form data in parent component.
    */
-  onChange: (formData: any, invalid: boolean) => void;
+  onChange: (formData: any) => void;
 
   /**
    * Editor services to create new editors in code fields.
@@ -70,6 +71,19 @@ interface IFormEditorProps {
    * All existing languages to give as options.
    */
   languageOptions?: string[];
+}
+
+export type FormValidationState =
+  | {
+      isValid: true;
+    }
+  | {
+      isValid: false;
+      errors: RJSFValidationError[];
+    };
+
+export interface IFormEditorRef {
+  validateForm: (data: any) => FormValidationState;
 }
 
 /**
@@ -138,17 +152,24 @@ const CustomFieldTemplate: React.FC<FieldTemplateProps> = (props) => {
  * Creates a uiSchema from given uihints and passes relevant information
  * to the custom renderers.
  */
-export const FormEditor: React.FC<IFormEditorProps> = ({
-  schema,
-  onChange,
-  editorServices,
-  componentRegistry,
-  translator,
-  originalData,
-  allTags,
-  languageOptions
-}) => {
-  const [formData, setFormData] = React.useState(originalData ?? ({} as any));
+const RefForwardingFormEditor: React.ForwardRefRenderFunction<
+  IFormEditorRef,
+  IFormEditorProps
+> = (
+  {
+    schema,
+    onChange,
+    editorServices,
+    componentRegistry,
+    translator,
+    originalData,
+    allTags,
+    languageOptions
+  },
+  forwardedRef
+) => {
+  const [formData, setFormData] = React.useState(originalData ?? {});
+  const [liveValidateEnabled, setLiveValidateEnabled] = React.useState(false);
 
   /**
    * Generate the rjsf uiSchema from uihints in the elyra metadata schema.
@@ -177,6 +198,19 @@ export const FormEditor: React.FC<IFormEditorProps> = ({
       .map(([key, value]) => [key, value.widgetRenderer!])
   );
 
+  React.useImperativeHandle(
+    forwardedRef,
+    (): IFormEditorRef => ({
+      validateForm: (data) => {
+        setLiveValidateEnabled(true);
+        const result = validator.validateFormData(data, schema);
+        return result.errors.length === 0
+          ? { isValid: true }
+          : { isValid: false, errors: result.errors };
+      }
+    })
+  );
+
   return (
     <Form
       schema={schema}
@@ -198,9 +232,9 @@ export const FormEditor: React.FC<IFormEditorProps> = ({
       uiSchema={uiSchema}
       onChange={(e): void => {
         setFormData(e.formData);
-        onChange(e.formData, e.errors.length > 0 || false);
+        onChange(e.formData);
       }}
-      liveValidate={true}
+      liveValidate={liveValidateEnabled}
       noHtml5Validate={
         /** noHtml5Validate is set to true to prevent the html validation from moving the focus when the live validate is called. */
         true
@@ -208,3 +242,5 @@ export const FormEditor: React.FC<IFormEditorProps> = ({
     />
   );
 };
+
+export const FormEditor = React.forwardRef(RefForwardingFormEditor);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

Validation warnings are being shown when, for instance, users create a new Code Snippet or Runtime. Usually, such warnings are shown only after the first form submission to let the user know what is missing/wrong. This PR fixes this issue.

Demo running on the image above:

https://github.com/user-attachments/assets/26aa41d2-633b-48d8-97d1-2c880f31301d 

Cherry-picked from [ODH Elyra](https://github.com/opendatahub-io/elyra):
- https://github.com/opendatahub-io/elyra/pull/87

### How was this pull request tested?
<!--
Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases, if possible.

If changes were tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added e.g. documentation only, GH workflow updates, etc.
-->

This PR includes a test to validate the scenario. Also, manual tests have been performed.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
