### PR TITLE
Replace 'any' with correct types in typescript code

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,7 @@
     "@typescript-eslint/no-unused-vars": ["warn", { "args": "none" }],
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/camelcase": "off",
-    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-namespace": "off",
     "header/header": [

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -42,19 +42,19 @@ set -x
 
 # repo2docker clones the Elyra repository before the Docker image is built
 # and uses the cloned directory as "root". The git extension recognizes that
-# the directory is git-enabled and therefore prevents the user from 
+# the directory is git-enabled and therefore prevents the user from
 # cloning other repositories using the UI. Remove the git artifacts in the
-# root directory to work around this issue. 
+# root directory to work around this issue.
 rm -rf ~/.git*
 
 # Add getting started assets to Docker image
 # (1) Clone the examples repository.
-git clone https://github.com/elyra-ai/examples.git 
+git clone https://github.com/elyra-ai/examples.git
 
 EXAMPLES_BASE_DIR=examples
 
 # (2) Copy all getting started assets to the working directory,
-#     which is referenced when binder is invoked, e.g. 
+#     which is referenced when binder is invoked, e.g.
 #     https://mybinder.org/v2/gh/elyra-ai/elyra/main?urlpath=lab/tree/binder-demo
 cp -r $EXAMPLES_BASE_DIR/binder/getting-started/* binder-demo/
 

--- a/cypress/tests/codesnippet.cy.ts
+++ b/cypress/tests/codesnippet.cy.ts
@@ -215,7 +215,9 @@ describe('Code Snippet tests', () => {
     const updatedSnippetItem = getSnippetByName(newSnippetName);
 
     // Check old snippet name does not exist
-    expect(updatedSnippetItem.innerText).not.to.eq(snippetName);
+    updatedSnippetItem.then((element) => {
+      expect(element.text()).not.to.eq(snippetName);
+    });
 
     // Delete updated code snippet
     deleteSnippet(newSnippetName);
@@ -354,11 +356,13 @@ const openCodeSnippetExtension = (): void => {
   cy.get('.jp-SideBar .lm-mod-current[title="Code Snippets"]');
 };
 
-const getSnippetByName = (snippetName: string): any => {
+const getSnippetByName = (
+  snippetName: string
+): Cypress.Chainable<JQuery<HTMLElement>> => {
   return cy.get(`[data-item-id="${snippetName}"]`);
 };
 
-const createInvalidCodeSnippet = (snippetName: string): any => {
+const createInvalidCodeSnippet = (snippetName: string): void => {
   clickCreateNewSnippetButton();
 
   typeCodeSnippetName(snippetName);
@@ -441,7 +445,9 @@ const duplicateSnippet = (snippetName: string): void => {
   item.find('button[title="Duplicate"]').click();
 };
 
-const getActionButtonsElement = (snippetName: string): any => {
+const getActionButtonsElement = (
+  snippetName: string
+): Cypress.Chainable<JQuery<HTMLElement>> => {
   const actionButtonsElement = getSnippetByName(snippetName).find(
     '.elyra-expandableContainer-action-buttons'
   );

--- a/cypress/utils/snapshots/add-commands.ts
+++ b/cypress/utils/snapshots/add-commands.ts
@@ -26,6 +26,7 @@ beforeEach(() => {
   snapshotIndexTracker = {};
 });
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- workaround for snapshot plugin
 const getSnapshotPath = (test: any): string => {
   const names = [];
   for (let k = test; k; k = k.parent) {
@@ -52,6 +53,7 @@ const getSnapshotPath = (test: any): string => {
 };
 
 Cypress.Commands.add('matchesSnapshot', { prevSubject: true }, (value) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- workaround for snapshot plugin
   const test = (Cypress as any).mocha.getRunner().suite.ctx.test;
 
   const path = getSnapshotPath(test);

--- a/cypress/utils/snapshots/plugin.ts
+++ b/cypress/utils/snapshots/plugin.ts
@@ -18,6 +18,7 @@ import fs from 'fs';
 
 import { diffStringsUnified } from 'jest-diff';
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- workaround for snapshot plugin
 const createSnapshot = (value: any): string => {
   let obj = value;
 
@@ -35,6 +36,7 @@ const createSnapshot = (value: any): string => {
 
 interface ISnapshotOptions {
   path: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- workaround for snapshot plugin
   value: any;
 }
 
@@ -57,6 +59,7 @@ interface INewSnapshotResults {
   status: 'new';
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- workaround for snapshot plugin
 export const register = (on: any, _config: any): void => {
   on('task', {
     matchesSnapshot({ path, value }: ISnapshotOptions): ISnapshotResults {

--- a/packages/code-snippet/install.json
+++ b/packages/code-snippet/install.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "python",
   "packageName": "elyra_code_snippet_extension",
   "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package elyra_code_snippet_extension"
 }

--- a/packages/code-snippet/src/CodeSnippetService.ts
+++ b/packages/code-snippet/src/CodeSnippetService.ts
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-import { IMetadata } from '@elyra/metadata-common';
-import { MetadataService } from '@elyra/services';
+import { IMetadataResource, MetadataService } from '@elyra/services';
 
 import { Dialog, showDialog } from '@jupyterlab/apputils';
 
@@ -23,15 +22,15 @@ export const CODE_SNIPPET_SCHEMASPACE = 'code-snippets';
 export const CODE_SNIPPET_SCHEMA = 'code-snippet';
 
 export class CodeSnippetService {
-  static async findAll(): Promise<IMetadata[]> {
-    return MetadataService.getMetadata(CODE_SNIPPET_SCHEMASPACE);
+  static async findAll(): Promise<IMetadataResource[]> {
+    return (await MetadataService.getMetadata(CODE_SNIPPET_SCHEMASPACE)) ?? [];
   }
 
   // TODO: Test this function
-  static async findByLanguage(language: string): Promise<IMetadata[]> {
+  static async findByLanguage(language: string): Promise<IMetadataResource[]> {
     try {
-      const allCodeSnippets: IMetadata[] = await this.findAll();
-      const codeSnippetsByLanguage: IMetadata[] = [];
+      const allCodeSnippets = await this.findAll();
+      const codeSnippetsByLanguage: IMetadataResource[] = [];
 
       for (const codeSnippet of allCodeSnippets) {
         if (codeSnippet.metadata.language === language) {
@@ -54,11 +53,11 @@ export class CodeSnippetService {
    * @returns A boolean promise that is true if the dialog confirmed
    * the deletion, and false if the deletion was cancelled.
    */
-  static deleteCodeSnippet(codeSnippet: IMetadata): Promise<boolean> {
+  static deleteCodeSnippet(codeSnippet: IMetadataResource): Promise<boolean> {
     return showDialog({
       title: `Delete snippet '${codeSnippet.display_name}'?`,
       buttons: [Dialog.cancelButton(), Dialog.okButton()]
-    }).then((result: any) => {
+    }).then((result) => {
       // Do nothing if the cancel button is pressed
       if (result.button.accept) {
         return MetadataService.deleteMetadata(

--- a/packages/code-viewer/src/index.ts
+++ b/packages/code-viewer/src/index.ts
@@ -28,6 +28,14 @@ import { CodeViewerWidget } from './CodeViewerWidget';
 
 const ELYRA_CODE_VIEWER_NAMESPACE = 'elyra-code-viewer-extension';
 
+interface IOpenCodeViewerArgs {
+  content: string;
+  label?: string;
+  mimeType?: string;
+  extension?: string;
+  widgetId?: string;
+}
+
 /**
  * The command IDs used by the code-viewer plugin.
  */
@@ -68,13 +76,9 @@ const extension: JupyterFrontEndPlugin<void> = {
       });
     }
 
-    const openCodeViewer = async (args: {
-      content: string;
-      label?: string;
-      mimeType?: string;
-      extension?: string;
-      widgetId?: string;
-    }): Promise<CodeViewerWidget> => {
+    const openCodeViewer = async (
+      args: IOpenCodeViewerArgs
+    ): Promise<CodeViewerWidget> => {
       const func = editorServices.factoryService.newDocumentEditor;
       const factory: CodeEditor.Factory = (options) => {
         return func(options);
@@ -112,8 +116,8 @@ const extension: JupyterFrontEndPlugin<void> = {
     };
 
     app.commands.addCommand(CommandIDs.openViewer, {
-      execute: (args: any) => {
-        return openCodeViewer(args);
+      execute: (args) => {
+        return openCodeViewer(args as unknown as IOpenCodeViewerArgs);
       }
     });
   }

--- a/packages/metadata-common/install.json
+++ b/packages/metadata-common/install.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "python",
   "packageName": "elyra_metadata_common",
   "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package elyra_metadata_common"
 }

--- a/packages/metadata-common/src/MetadataCommonService.tsx
+++ b/packages/metadata-common/src/MetadataCommonService.tsx
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-import { MetadataService } from '@elyra/services';
-
-import { IMetadata } from './MetadataWidget';
+import { IMetadataResource, MetadataService } from '@elyra/services';
 
 export class MetadataCommonService {
   /**
@@ -31,9 +29,9 @@ export class MetadataCommonService {
    */
   static duplicateMetadataInstance(
     schemaSpace: string,
-    metadataInstance: IMetadata,
-    existingInstances: IMetadata[]
-  ): Promise<boolean> {
+    metadataInstance: IMetadataResource,
+    existingInstances: IMetadataResource[]
+  ): Promise<IMetadataResource | undefined> {
     // iterate through the list of currently defined
     // instance names and find the next available one
     // using '<source-instance-name>-Copy<N>'
@@ -56,9 +54,6 @@ export class MetadataCommonService {
     const duplicated_metadata = JSON.parse(JSON.stringify(metadataInstance));
     duplicated_metadata.display_name = `${base_name}-Copy${count}`;
     delete duplicated_metadata.name;
-    return MetadataService.postMetadata(
-      schemaSpace,
-      JSON.stringify(duplicated_metadata)
-    );
+    return MetadataService.postMetadata(schemaSpace, duplicated_metadata);
   }
 }

--- a/packages/metadata/install.json
+++ b/packages/metadata/install.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "python",
   "packageName": "elyra_metadata_extension",
   "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package elyra_metadata_extension"
 }

--- a/packages/pipeline-editor/install.json
+++ b/packages/pipeline-editor/install.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "python",
   "packageName": "elyra_pipeline_editor_extension",
   "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package elyra_pipeline_editor_extension"
 }

--- a/packages/pipeline-editor/package.json
+++ b/packages/pipeline-editor/package.json
@@ -88,6 +88,7 @@
     "react-redux": "^7.2.0",
     "react-scripts": "4.0.3",
     "react-toastify": "^9.0.8",
+    "redux": "^4.2.0",
     "swr": "^0.5.6",
     "uuid": "^3.4.0"
   },

--- a/packages/pipeline-editor/src/ComponentCatalogsWidget.tsx
+++ b/packages/pipeline-editor/src/ComponentCatalogsWidget.tsx
@@ -17,14 +17,16 @@
 import {
   MetadataWidget,
   IMetadataWidgetProps,
-  IMetadata,
   MetadataDisplay,
   IMetadataDisplayProps,
-  //IMetadataDisplayState,
   IMetadataActionButton
 } from '@elyra/metadata-common';
-import { IDictionary, MetadataService } from '@elyra/services';
-import { RequestErrors } from '@elyra/ui-components';
+import { IMetadataResource, MetadataService } from '@elyra/services';
+import {
+  GenericObjectType,
+  IErrorResponse,
+  RequestErrors
+} from '@elyra/ui-components';
 import { JupyterFrontEnd } from '@jupyterlab/application';
 import { LabIcon, refreshIcon } from '@jupyterlab/ui-components';
 
@@ -36,25 +38,18 @@ export const COMPONENT_CATALOGS_SCHEMASPACE = 'component-catalogs';
 
 const COMPONENT_CATALOGS_CLASS = 'elyra-metadata-component-catalogs';
 
-const handleError = (error: any): void => {
-  // silently eat a 409, the server will log in in the console
-  if (error.status !== 409) {
-    RequestErrors.serverError(error);
-  }
-};
-
 /**
  * A React Component for displaying the component catalogs list.
  */
 class ComponentCatalogsDisplay extends MetadataDisplay<IMetadataDisplayProps> {
-  actionButtons(metadata: IMetadata): IMetadataActionButton[] {
+  actionButtons(metadata: IMetadataResource): IMetadataActionButton[] {
     return [
       {
         title: 'Reload components from catalog',
         icon: refreshIcon,
         onClick: (): void => {
           PipelineService.refreshComponentsCache(metadata.name)
-            .then((response: any): void => {
+            .then((): void => {
               this.props.updateMetadata();
             })
             .catch((error) =>
@@ -70,22 +65,22 @@ class ComponentCatalogsDisplay extends MetadataDisplay<IMetadataDisplayProps> {
   }
 
   //render catalog entries
-  renderExpandableContent(metadata: IDictionary<any>): JSX.Element {
-    let category_output = <li key="No category">No category</li>;
+  renderExpandableContent(metadata: IMetadataResource): JSX.Element {
+    let category_output = [<li key="No category">No category</li>];
     if (metadata.metadata.categories) {
-      category_output = metadata.metadata.categories.map((category: string) => (
-        <li key={category}>{category}</li>
-      ));
+      category_output = (metadata.metadata.categories as string[]).map(
+        (category) => <li key={category}>{category}</li>
+      );
     }
 
     return (
       <div>
         <h6>Runtime Type</h6>
-        {metadata.metadata.runtime_type}
+        {metadata.metadata.runtime_type as string}
         <br />
         <br />
         <h6>Description</h6>
-        {metadata.metadata.description ?? 'No description'}
+        {(metadata.metadata.description as string) ?? 'No description'}
         <br />
         <br />
         <h6>Categories</h6>
@@ -95,11 +90,13 @@ class ComponentCatalogsDisplay extends MetadataDisplay<IMetadataDisplayProps> {
   }
 
   // Allow for filtering by display_name, name, and description
-  matchesSearch(searchValue: string, metadata: IMetadata): boolean {
+  matchesSearch(searchValue: string, metadata: IMetadataResource): boolean {
     searchValue = searchValue.toLowerCase();
     // True if search string is in name or display_name,
     // or if the search string is empty
-    const description = (metadata.metadata.description || '').toLowerCase();
+    const description = (
+      (metadata.metadata.description as string) || ''
+    ).toLowerCase();
     return (
       metadata.name.toLowerCase().includes(searchValue) ||
       metadata.display_name.toLowerCase().includes(searchValue) ||
@@ -139,17 +136,21 @@ export class ComponentCatalogsWidget extends MetadataWidget {
   async getSchemas(): Promise<void> {
     try {
       const schemas = await MetadataService.getSchema(this.props.schemaspace);
+      if (!schemas) {
+        return;
+      }
       this.runtimeTypes = await PipelineService.getRuntimeTypes();
-      const sortedSchema = schemas.sort((a: any, b: any) =>
-        a.title.localeCompare(b.title)
+      const sortedSchema = schemas.sort((a, b) =>
+        (a.title ?? '').localeCompare(b.title ?? '')
       );
-      this.schemas = sortedSchema.filter((schema: any) => {
-        return !!this.runtimeTypes.find(
-          (r) =>
-            schema.properties?.metadata?.properties?.runtime_type?.enum?.includes(
-              r.id
-            ) && r.runtime_enabled
-        );
+      this.schemas = sortedSchema.filter((schema) => {
+        return !!this.runtimeTypes.find((r) => {
+          const metadata = schema.properties?.metadata as GenericObjectType;
+          return (
+            metadata?.properties.runtime_type?.enum?.includes(r.id) &&
+            r.runtime_enabled
+          );
+        });
       });
       if (this.schemas?.length ?? 0 > 1) {
         for (const schema of this.schemas ?? []) {
@@ -163,13 +164,13 @@ export class ComponentCatalogsWidget extends MetadataWidget {
               title: schema.title,
               titleContext: this.props.titleContext,
               appendToTitle: this.props.appendToTitle
-            } as any
+            } as GenericObjectType
           });
         }
       }
       this.update();
     } catch (error) {
-      RequestErrors.serverError(error);
+      await RequestErrors.serverError(error as IErrorResponse);
     }
   }
 
@@ -183,13 +184,18 @@ export class ComponentCatalogsWidget extends MetadataWidget {
 
   refreshMetadata(): void {
     PipelineService.refreshComponentsCache()
-      .then((response: any): void => {
+      .then((): void => {
         this.updateMetadataAndRefresh();
       })
-      .catch((error) => handleError(error));
+      .catch(async (error) => {
+        // silently eat a 409, the server will log in in the console
+        if (error.status !== 409) {
+          await RequestErrors.serverError(error);
+        }
+      });
   }
 
-  renderDisplay(metadata: IMetadata[]): React.ReactElement {
+  renderDisplay(metadata: IMetadataResource[]): React.ReactElement {
     if (Array.isArray(metadata) && !metadata.length) {
       // Empty metadata
       return (

--- a/packages/pipeline-editor/src/ParameterInputForm.tsx
+++ b/packages/pipeline-editor/src/ParameterInputForm.tsx
@@ -20,10 +20,12 @@ const DIALOG_WIDTH = 27;
 export interface IParameterProps {
   parameters?: {
     name: string;
-    default_value?: {
-      type: 'String' | 'Integer' | 'Float' | 'Bool';
-      value: any;
-    };
+    default_value?:
+      | { type: 'String'; value: string }
+      | { type: 'Integer'; value: number }
+      | { type: 'Float'; value: number }
+      | { type: 'Bool'; value: boolean };
+
     type?: string;
     required?: boolean;
     description?: string;
@@ -67,7 +69,7 @@ export const ParameterInputForm: React.FC<IParameterProps> = ({
               <input
                 id={`${param.name}-paramInput`}
                 name={`${param.name}-paramInput`}
-                defaultChecked={param.default_value?.value}
+                defaultChecked={param.default_value?.value as boolean}
                 type="checkbox"
               />
               <label htmlFor={`${param.name}-paramInput`}>{`${param.name}${
@@ -109,7 +111,7 @@ export const ParameterInputForm: React.FC<IParameterProps> = ({
               id={`${param.name}-paramInput`}
               name={`${param.name}-paramInput`}
               type={type}
-              placeholder={param.default_value?.value}
+              placeholder={param.default_value?.value as string | undefined}
               data-form-required={required}
             />
             <br />

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -37,28 +37,30 @@ import {
   Dropzone,
   RequestErrors,
   showFormDialog,
-  componentCatalogIcon
+  componentCatalogIcon,
+  GenericObjectType
 } from '@elyra/ui-components';
-import { ILabShell } from '@jupyterlab/application';
+import { JupyterFrontEnd } from '@jupyterlab/application';
 import { Dialog, ReactWidget, showDialog } from '@jupyterlab/apputils';
 import { PathExt } from '@jupyterlab/coreutils';
 import {
   DocumentRegistry,
   ABCWidgetFactory,
-  DocumentWidget,
-  Context
+  DocumentWidget
 } from '@jupyterlab/docregistry';
 import { IDefaultFileBrowser } from '@jupyterlab/filebrowser';
-import { Contents } from '@jupyterlab/services';
+import { ServiceManager } from '@jupyterlab/services';
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 import 'carbon-components/css/carbon-components.min.css';
 
 import { toArray } from '@lumino/algorithm';
+import { CommandRegistry } from '@lumino/commands';
 import {
   PartialJSONArray,
   PartialJSONObject,
-  PartialJSONValue
+  PartialJSONValue,
+  ReadonlyPartialJSONObject
 } from '@lumino/coreutils';
 import { IDragEvent } from '@lumino/dragdrop';
 import { Signal } from '@lumino/signaling';
@@ -79,6 +81,10 @@ import {
 } from './EmptyPipelineContent';
 import { formDialogWidget } from './formDialogWidget';
 import {
+  IRuntimeComponentNodeType,
+  IRuntimeComponentParameter,
+  IRuntimeComponentsResponse,
+  IRuntimeImage,
   usePalette,
   useRuntimeImages,
   useRuntimesSchema
@@ -88,7 +94,8 @@ import {
   PipelineService,
   RUNTIMES_SCHEMASPACE,
   RUNTIME_IMAGES_SCHEMASPACE,
-  COMPONENT_CATALOGS_SCHEMASPACE
+  COMPONENT_CATALOGS_SCHEMASPACE,
+  IRuntimeSchema
 } from './PipelineService';
 import { PipelineSubmissionDialog } from './PipelineSubmissionDialog';
 import {
@@ -117,7 +124,7 @@ export const commandIDs = {
 
 interface IExtendedThemeProviderProps
   extends React.ComponentProps<typeof ThemeProvider> {
-  children: any;
+  children: React.ReactNode;
 }
 
 //extend ThemeProvider to accept the same props as original but with children prop as one of them.
@@ -128,12 +135,14 @@ const ExtendedThemeProvider: React.FC<IExtendedThemeProviderProps> = ({
   return <ThemeProvider {...props}>{children}</ThemeProvider>;
 };
 
-const getAllPaletteNodes = (palette: any): any[] => {
-  if (palette.categories === undefined) {
+const getAllPaletteNodes = (
+  palette: IRuntimeComponentsResponse | undefined
+): IRuntimeComponentNodeType[] => {
+  if (palette?.categories === undefined) {
     return [];
   }
 
-  const nodes = [];
+  const nodes: IRuntimeComponentNodeType[] = [];
   for (const c of palette.categories) {
     if (c.node_types) {
       nodes.push(...c.node_types);
@@ -155,83 +164,95 @@ const isRuntimeTypeAvailable = (data: IRuntimeData, type?: string): boolean => {
 };
 
 const getDisplayName = (
-  runtimesSchema: any,
+  runtimesSchema?: IRuntimeSchema[],
   type?: string
 ): string | undefined => {
   if (!type) {
     return undefined;
   }
-  const schema = runtimesSchema?.find((s: any) => s.runtime_type === type);
+  const schema = runtimesSchema?.find((s) => s.runtime_type === type);
   return schema?.title;
 };
 
-class PipelineEditorWidget extends ReactWidget {
+interface IPipelineEditorWidgetProps {
+  context: DocumentRegistry.Context;
   browserFactory: IDefaultFileBrowser;
-  shell: ILabShell;
-  commands: any;
-  addFileToPipelineSignal: Signal<this, any>;
-  refreshPaletteSignal: Signal<this, any>;
-  context: Context;
-  settings: ISettingRegistry.ISettings;
+  serviceManager: ServiceManager.IManager;
+  shell: JupyterFrontEnd.IShell;
+  commands: CommandRegistry;
+  settings?: ISettingRegistry.ISettings;
+  widgetId?: string;
   defaultRuntimeType: string;
+}
 
-  constructor(options: any) {
+class PipelineEditorWidget extends ReactWidget {
+  addFileToPipelineSignal: Signal<
+    PipelineEditorWidget,
+    ReadonlyPartialJSONObject
+  >;
+  refreshPaletteSignal: Signal<PipelineEditorWidget, ReadonlyPartialJSONObject>;
+
+  constructor(private readonly args: IPipelineEditorWidgetProps) {
     super();
-    this.browserFactory = options.browserFactory;
-    this.shell = options.shell;
-    this.commands = options.commands;
-    this.addFileToPipelineSignal = options.addFileToPipelineSignal;
-    this.refreshPaletteSignal = options.refreshPaletteSignal;
-    this.context = options.context;
-    this.settings = options.settings;
-    this.defaultRuntimeType = options.defaultRuntimeType;
-    let nullPipeline = this.context.model.toJSON() === null;
+    let nullPipeline = this.args.context.model.toJSON() === null;
 
-    this.context.model.contentChanged.connect(() => {
+    this.addFileToPipelineSignal = new Signal<
+      PipelineEditorWidget,
+      ReadonlyPartialJSONObject
+    >(this);
+
+    this.refreshPaletteSignal = new Signal<
+      PipelineEditorWidget,
+      ReadonlyPartialJSONObject
+    >(this);
+
+    this.args.context.model.contentChanged.connect(() => {
       if (nullPipeline) {
         nullPipeline = false;
         this.update();
       }
     });
-    this.context.fileChanged.connect(() => {
-      if (this.context.model.toJSON() === null) {
-        const pipelineJson = getEmptyPipelineJson(this.defaultRuntimeType);
-        this.context.model.fromString(JSON.stringify(pipelineJson));
+    this.args.context.fileChanged.connect(() => {
+      if (this.args.context.model.toJSON() === null) {
+        const pipelineJson = getEmptyPipelineJson(this.args.defaultRuntimeType);
+        this.args.context.model.fromString(JSON.stringify(pipelineJson));
       }
     });
   }
 
-  render(): any {
-    if (this.context.model.toJSON() === null) {
+  render() {
+    if (this.args.context.model.toJSON() === null) {
       return <div className="elyra-loader"></div>;
     }
     return (
       <PipelineWrapper
-        context={this.context}
-        browserFactory={this.browserFactory}
-        shell={this.shell}
-        commands={this.commands}
+        context={this.args.context}
+        browserFactory={this.args.browserFactory}
+        shell={this.args.shell}
+        commands={this.args.commands}
         addFileToPipelineSignal={this.addFileToPipelineSignal}
         refreshPaletteSignal={this.refreshPaletteSignal}
         widgetId={this.parent?.id}
-        settings={this.settings}
+        settings={this.args.settings}
+        defaultRuntimeType={this.args.defaultRuntimeType}
+        serviceManager={this.args.serviceManager}
       />
     );
   }
 }
 
-interface IProps {
-  context: DocumentRegistry.Context;
-  browserFactory: IDefaultFileBrowser;
-  shell: ILabShell;
-  commands: any;
-  addFileToPipelineSignal: Signal<PipelineEditorWidget, any>;
-  refreshPaletteSignal: Signal<PipelineEditorWidget, any>;
-  settings?: ISettingRegistry.ISettings;
-  widgetId?: string;
-}
-
-const PipelineWrapper: React.FC<IProps> = ({
+const PipelineWrapper: React.FC<
+  IPipelineEditorWidgetProps & {
+    addFileToPipelineSignal: Signal<
+      PipelineEditorWidget,
+      ReadonlyPartialJSONObject
+    >;
+    refreshPaletteSignal: Signal<
+      PipelineEditorWidget,
+      ReadonlyPartialJSONObject
+    >;
+  }
+> = ({
   context,
   browserFactory,
   shell,
@@ -241,9 +262,12 @@ const PipelineWrapper: React.FC<IProps> = ({
   settings,
   widgetId
 }) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- PipelineEditor API not typed
   const ref = useRef<any>(null);
   const [loading, setLoading] = useState(true);
-  const [pipeline, setPipeline] = useState<any>(context.model.toJSON());
+  const [pipeline, setPipeline] = useState<GenericObjectType>(
+    context.model.toJSON() as GenericObjectType
+  );
   const [panelOpen, setPanelOpen] = React.useState(false);
 
   const type: string | undefined =
@@ -258,7 +282,7 @@ const PipelineWrapper: React.FC<IProps> = ({
   const runtimeDisplayName = getDisplayName(runtimesSchema, type) ?? 'Generic';
 
   const filePersistedRuntimeImages = useMemo(() => {
-    const images = [];
+    const images: string[] = [];
     const pipelineDefaultRuntimeImage =
       pipeline?.pipelines?.[0]?.app_data?.properties?.pipeline_defaults
         ?.runtime_image;
@@ -283,7 +307,7 @@ const PipelineWrapper: React.FC<IProps> = ({
         metadata: {
           image_name: imageName
         }
-      };
+      } as IRuntimeImage;
     });
   }, [pipeline]);
 
@@ -295,7 +319,7 @@ const PipelineWrapper: React.FC<IProps> = ({
 
   useEffect(() => {
     const handleMutateSignal = (): void => {
-      mutatePalette();
+      mutatePalette?.();
     };
     refreshPaletteSignal.connect(handleMutateSignal);
     return (): void => {
@@ -313,22 +337,25 @@ const PipelineWrapper: React.FC<IProps> = ({
 
   useEffect(() => {
     if (paletteError) {
-      RequestErrors.serverError(paletteError);
-      shell.currentWidget?.close();
+      RequestErrors.serverError(paletteError).then(() => {
+        shell.currentWidget?.close();
+      });
     }
   }, [paletteError, shell.currentWidget]);
 
   useEffect(() => {
     if (runtimeImagesError) {
-      RequestErrors.serverError(runtimeImagesError);
-      shell.currentWidget?.close();
+      RequestErrors.serverError(runtimeImagesError).then(() => {
+        shell.currentWidget?.close();
+      });
     }
   }, [runtimeImagesError, shell.currentWidget]);
 
   useEffect(() => {
     if (runtimesSchemaError) {
-      RequestErrors.serverError(runtimesSchemaError);
-      shell.currentWidget?.close();
+      RequestErrors.serverError(runtimesSchemaError).then(() => {
+        shell.currentWidget?.close();
+      });
     }
   }, [runtimesSchemaError, shell.currentWidget]);
 
@@ -337,7 +364,7 @@ const PipelineWrapper: React.FC<IProps> = ({
     const currentContext = contextRef.current;
 
     const changeHandler = (): void => {
-      const pipelineJson: any = currentContext.model.toJSON();
+      const pipelineJson = currentContext.model.toJSON() as GenericObjectType;
 
       // map IDs to display names
       const nodes = pipelineJson?.pipelines?.[0]?.nodes;
@@ -380,7 +407,7 @@ const PipelineWrapper: React.FC<IProps> = ({
     };
   }, [runtimeDisplayName]);
 
-  const onChange = useCallback((pipelineJson: any): void => {
+  const onChange = useCallback((pipelineJson: GenericObjectType): void => {
     const isNullOrEmpty = (
       value: PartialJSONValue | null | undefined
     ): boolean => value === null || value === undefined || value === '';
@@ -471,7 +498,8 @@ const PipelineWrapper: React.FC<IProps> = ({
           if (result.button.accept) {
             // proceed with migration
             console.log('migrating pipeline');
-            const pipelineJSON: any = contextRef.current.model.toJSON();
+            const pipelineJSON =
+              contextRef.current.model.toJSON() as GenericObjectType;
             try {
               const migratedPipeline = migrate(pipelineJSON, (pipeline) => {
                 // function for updating to relative paths in v2
@@ -541,7 +569,11 @@ const PipelineWrapper: React.FC<IProps> = ({
     [shell.currentWidget]
   );
 
-  const onFileRequested = async (args: any): Promise<string[] | undefined> => {
+  const onFileRequested = async (args: {
+    filename?: string;
+    propertyID?: string;
+    filters?: { [key: string]: string[] };
+  }): Promise<string[] | undefined> => {
     const pipelineFilePath = contextRef.current.path;
     const contextFilePath = args.filename
       ? PipelineService.getWorkspaceRelativeNodePath(
@@ -552,32 +584,34 @@ const PipelineWrapper: React.FC<IProps> = ({
     const contextFolderPath = PathExt.dirname(contextFilePath);
 
     if (args.propertyID?.includes('dependencies')) {
-      const res = await showBrowseFileDialog(browserFactory.model.manager, {
+      const res = await showBrowseFileDialog({
+        manager: browserFactory.model.manager,
         multiselect: true,
         includeDir: true,
         rootPath: contextFolderPath,
-        filter: (model: any): boolean => {
-          return model.path !== pipelineFilePath;
+        filter: (model) => {
+          return model.path !== pipelineFilePath ? {} : null;
         }
       });
 
-      if (res.button.accept && res.value.length) {
+      if (res.button.accept && res.value?.length) {
         return res.value;
       }
     } else {
-      const res = await showBrowseFileDialog(browserFactory.model.manager, {
+      const res = await showBrowseFileDialog({
+        manager: browserFactory.model.manager,
         startPath: contextFolderPath,
-        filter: (model: Contents.IModel): boolean => {
+        filter: (model) => {
           if (args.filters?.File === undefined || model.type === 'directory') {
-            return true;
+            return {};
           }
 
           const ext = PathExt.extname(model.path);
-          return args.filters.File.includes(ext);
+          return args.filters.File.includes(ext) ? {} : null;
         }
       });
 
-      if (res.button.accept && res.value.length) {
+      if (res.button.accept && res.value?.length) {
         const file = PipelineService.getPipelineRelativeNodePath(
           contextRef.current.path,
           res.value[0]
@@ -589,7 +623,11 @@ const PipelineWrapper: React.FC<IProps> = ({
     return undefined;
   };
 
-  const onPropertiesUpdateRequested = async (args: any): Promise<any> => {
+  const onPropertiesUpdateRequested = async (args: {
+    component_parameters?: IRuntimeComponentParameter;
+  }): Promise<{
+    component_parameters?: IRuntimeComponentParameter;
+  }> => {
     if (!contextRef.current.path || !args.component_parameters?.filename) {
       return args;
     }
@@ -597,19 +635,18 @@ const PipelineWrapper: React.FC<IProps> = ({
       contextRef.current.path,
       args.component_parameters.filename
     );
-    const new_env_vars = await ContentParser.getEnvVars(path).then(
-      (response: any) =>
-        response.map((str: string) => {
-          return { env_var: str };
-        })
+    const new_env_vars = await ContentParser.getEnvVars(path).then((response) =>
+      response.map((str: string) => {
+        return { env_var: str };
+      })
     );
 
     const env_vars = args.component_parameters?.env_vars ?? [];
     const merged_env_vars = [
       ...env_vars,
       ...new_env_vars.filter(
-        (new_var: any) =>
-          !env_vars.some((old_var: any) => {
+        (new_var) =>
+          !env_vars.some((old_var) => {
             return old_var.env_var === new_var.env_var;
           })
       )
@@ -628,7 +665,7 @@ const PipelineWrapper: React.FC<IProps> = ({
     (componentId: string, componentSource: string) => {
       // Show error dialog if the component does not exist
       if (!componentId) {
-        const dialogBody = [];
+        const dialogBody: string[] = [];
         try {
           const componentSourceJson = JSON.parse(componentSource);
           dialogBody.push(`catalog_type: ${componentSourceJson.catalog_type}`);
@@ -668,6 +705,9 @@ const PipelineWrapper: React.FC<IProps> = ({
       }
       return PipelineService.getComponentDef(type, componentId)
         .then((res) => {
+          if (!res) {
+            return;
+          }
           const nodeDef = getAllPaletteNodes(palette).find(
             (n) => n.id === componentId
           );
@@ -677,15 +717,15 @@ const PipelineWrapper: React.FC<IProps> = ({
             label: nodeDef?.label ?? componentId
           });
         })
-        .catch((e) => RequestErrors.serverError(e));
+        .catch(async (e) => await RequestErrors.serverError(e));
     },
     [commands, palette, type]
   );
 
-  const onDoubleClick = (data: any): void => {
+  const onDoubleClick = (data: { selectedObjectIds: string[] }): void => {
     for (let i = 0; i < data.selectedObjectIds.length; i++) {
       const node = pipeline.pipelines[0].nodes.find(
-        (node: any) => node.id === data.selectedObjectIds[i]
+        (node: { id: string }) => node.id === data.selectedObjectIds[i]
       );
       const nodeDef = getAllPaletteNodes(palette).find(
         (n) => n.op === node?.op
@@ -697,20 +737,20 @@ const PipelineWrapper: React.FC<IProps> = ({
             node.app_data.component_parameters.filename
           )
         });
-      } else if (!nodeDef?.app_data?.parameter_refs?.['filehandler']) {
-        handleOpenComponentDef(nodeDef?.id, node?.app_data?.component_source);
+      } else if (nodeDef && !nodeDef.app_data?.parameter_refs?.filehandler) {
+        handleOpenComponentDef(nodeDef.id, node?.app_data?.component_source);
       }
     }
   };
 
   const handleSubmission = useCallback(
     async (actionType: 'run' | 'export'): Promise<void> => {
-      const pipelineJson: any = context.model.toJSON();
+      const pipelineJson = context.model.toJSON() as GenericObjectType;
       // Check that all nodes are valid
       const errorMessages = validate(
         JSON.stringify(pipelineJson),
         getAllPaletteNodes(palette),
-        palette.properties
+        palette?.properties
       );
       if (errorMessages && errorMessages.length > 0) {
         let errorMessage = '';
@@ -747,19 +787,31 @@ const PipelineWrapper: React.FC<IProps> = ({
       const runtimeTypes = await PipelineService.getRuntimeTypes();
       const runtimes = await PipelineService.getRuntimes()
         .then((runtimeList) => {
-          return runtimeList.filter((runtime: any) => {
+          return runtimeList?.filter((runtime) => {
             return (
               !runtime.metadata.runtime_enabled &&
-              !!runtimeTypes.find(
-                (r: any) => runtime.metadata.runtime_type === r.id
-              )
+              !!runtimeTypes.find((r) => runtime.metadata.runtime_type === r.id)
             );
           });
         })
-        .catch((error) => RequestErrors.serverError(error));
-      const schema = await PipelineService.getRuntimesSchema().catch((error) =>
-        RequestErrors.serverError(error)
+        .catch(async (error) => {
+          await RequestErrors.serverError(error);
+        });
+      const schema = await PipelineService.getRuntimesSchema().catch(
+        async (error) => {
+          await RequestErrors.serverError(error);
+        }
       );
+
+      if (!runtimes) {
+        await RequestErrors.noMetadataError('runtime');
+        return;
+      }
+
+      if (!schema) {
+        await RequestErrors.noMetadataError('schema');
+        return;
+      }
 
       const runtimeData = createRuntimeData({
         schema,
@@ -790,24 +842,33 @@ const PipelineWrapper: React.FC<IProps> = ({
       // Capitalize
       title = title.charAt(0).toUpperCase() + title.slice(1);
 
-      let dialogOptions: Partial<Dialog.IOptions<any>>;
+      let dialogOptions: Partial<Dialog.IOptions<GenericObjectType>>;
 
       pipelineJson.pipelines[0].app_data.properties.pipeline_parameters =
         pipelineJson.pipelines[0].app_data.properties.pipeline_parameters?.filter(
-          (param: any) => {
-            return !!pipelineJson.pipelines[0].nodes.find((node: any) => {
-              return (
-                param.name !== '' &&
-                (node.app_data.component_parameters?.pipeline_parameters?.includes(
-                  param.name
-                ) ||
-                  Object.values(node.app_data.component_parameters ?? {}).find(
-                    (property: any) =>
-                      property.widget === 'parameter' &&
-                      property.value === param.name
-                  ))
-              );
-            });
+          (param: { name: string }) => {
+            return !!pipelineJson.pipelines[0].nodes.find(
+              (node: {
+                app_data: {
+                  component_parameters?: {
+                    pipeline_parameters?: GenericObjectType;
+                  };
+                };
+              }) => {
+                return (
+                  param.name !== '' &&
+                  (node.app_data.component_parameters?.pipeline_parameters?.includes(
+                    param.name
+                  ) ||
+                    (node.app_data.component_parameters &&
+                      Object.values(node.app_data.component_parameters).find(
+                        (property) =>
+                          property.widget === 'parameter' &&
+                          property.value === param.name
+                      )))
+                );
+              }
+            );
           }
         );
 
@@ -933,7 +994,9 @@ const PipelineWrapper: React.FC<IProps> = ({
           PipelineService.submitPipeline(
             pipelineJson,
             configDetails?.platform.displayName ?? ''
-          ).catch((error) => RequestErrors.serverError(error));
+          ).catch(async (error) => {
+            await RequestErrors.serverError(error);
+          });
           break;
         case 'export':
           PipelineService.exportPipeline(
@@ -941,14 +1004,16 @@ const PipelineWrapper: React.FC<IProps> = ({
             exportType,
             exportPath,
             dialogResult.value.overwrite
-          ).catch((error) => RequestErrors.serverError(error));
+          ).catch(async (error) => {
+            await RequestErrors.serverError(error);
+          });
           break;
       }
     },
     [context.model, palette, runtimeDisplayName, type, shell]
   );
 
-  const handleClearPipeline = useCallback(async (data: any): Promise<any> => {
+  const handleClearPipeline = useCallback(async (): Promise<void> => {
     return showDialog({
       title: 'Clear Pipeline',
       body: 'Are you sure you want to clear the pipeline?',
@@ -959,7 +1024,8 @@ const PipelineWrapper: React.FC<IProps> = ({
       ]
     }).then((result) => {
       if (result.button.accept) {
-        const newPipeline: any = contextRef.current.model.toJSON();
+        const newPipeline =
+          contextRef.current.model.toJSON() as GenericObjectType;
         if (newPipeline?.pipelines?.[0]?.nodes?.length > 0) {
           newPipeline.pipelines[0].nodes = [];
         }
@@ -983,7 +1049,7 @@ const PipelineWrapper: React.FC<IProps> = ({
   }, []);
 
   const onAction = useCallback(
-    (args: { type: string; payload?: any }) => {
+    (args: { type: string; payload?: GenericObjectType | string }) => {
       switch (args.type) {
         case 'save':
           contextRef.current.save();
@@ -993,7 +1059,7 @@ const PipelineWrapper: React.FC<IProps> = ({
           handleSubmission(args.type);
           break;
         case 'clear':
-          handleClearPipeline(args.payload);
+          handleClearPipeline();
           break;
         case 'toggleOpenPanel':
           setPanelOpen(!panelOpen);
@@ -1013,6 +1079,9 @@ const PipelineWrapper: React.FC<IProps> = ({
           );
           break;
         case 'openFile':
+          if (typeof args.payload !== 'string') {
+            return;
+          }
           commands.execute(commandIDs.openDocManager, {
             path: PipelineService.getWorkspaceRelativeNodePath(
               contextRef.current.path,
@@ -1021,6 +1090,9 @@ const PipelineWrapper: React.FC<IProps> = ({
           });
           break;
         case 'openComponentDef':
+          if (!args.payload || typeof args.payload !== 'object') {
+            return;
+          }
           handleOpenComponentDef(
             args.payload.componentId,
             args.payload.componentSource
@@ -1149,6 +1221,7 @@ const PipelineWrapper: React.FC<IProps> = ({
         };
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- PipelineEditor API not typed
       toArray(fileBrowser.selectedItems()).map((item: any): void => {
         if (PipelineService.isSupportedNode(item)) {
           item.op = PipelineService.getNodeType(item.path);
@@ -1223,7 +1296,6 @@ const PipelineWrapper: React.FC<IProps> = ({
 
   return (
     <ExtendedThemeProvider theme={theme}>
-      z
       <ToastContainer
         position="bottom-center"
         autoClose={30000}
@@ -1267,39 +1339,59 @@ const PipelineWrapper: React.FC<IProps> = ({
 
 export class PipelineEditorFactory extends ABCWidgetFactory<DocumentWidget> {
   browserFactory: IDefaultFileBrowser;
-  shell: ILabShell;
-  commands: any;
-  addFileToPipelineSignal: Signal<this, any>;
-  refreshPaletteSignal: Signal<this, any>;
-  settings: ISettingRegistry.ISettings;
+  shell: JupyterFrontEnd.IShell;
+  commands: CommandRegistry;
+  serviceManager: ServiceManager.IManager;
+  settings: ISettingRegistry.ISettings | undefined;
   defaultRuntimeType: string;
+  content?: PipelineEditorWidget;
 
-  constructor(options: any) {
+  constructor(
+    options: Pick<
+      IPipelineEditorWidgetProps,
+      | 'shell'
+      | 'commands'
+      | 'browserFactory'
+      | 'serviceManager'
+      | 'settings'
+      | 'defaultRuntimeType'
+    > &
+      Pick<
+        DocumentRegistry.IWidgetFactoryOptions<DocumentWidget>,
+        'name' | 'fileTypes' | 'defaultFor'
+      >
+  ) {
     super(options);
     this.browserFactory = options.browserFactory;
     this.shell = options.shell;
     this.commands = options.commands;
-    this.addFileToPipelineSignal = new Signal<this, any>(this);
-    this.refreshPaletteSignal = new Signal<this, any>(this);
     this.settings = options.settings;
+    this.serviceManager = options.serviceManager;
     this.defaultRuntimeType = options.defaultRuntimeType;
+  }
+
+  get addFileToPipelineSignal() {
+    return this.content?.addFileToPipelineSignal;
+  }
+
+  get refreshPaletteSignal() {
+    return this.content?.refreshPaletteSignal;
   }
 
   protected createNewWidget(context: DocumentRegistry.Context): DocumentWidget {
     // Creates a blank widget with a DocumentWidget wrapper
-    const props = {
+    const props: IPipelineEditorWidgetProps = {
       shell: this.shell,
       commands: this.commands,
       browserFactory: this.browserFactory,
       context: context,
-      addFileToPipelineSignal: this.addFileToPipelineSignal,
-      refreshPaletteSignal: this.refreshPaletteSignal,
       settings: this.settings,
-      defaultRuntimeType: this.defaultRuntimeType
+      defaultRuntimeType: this.defaultRuntimeType,
+      serviceManager: this.serviceManager
     };
-    const content = new PipelineEditorWidget(props);
+    this.content = new PipelineEditorWidget(props);
 
-    const widget = new DocumentWidget({ content, context });
+    const widget = new DocumentWidget({ content: this.content, context });
     widget.addClass(PIPELINE_CLASS);
     widget.title.icon = pipelineIcon;
     return widget;

--- a/packages/pipeline-editor/src/RuntimeImagesWidget.tsx
+++ b/packages/pipeline-editor/src/RuntimeImagesWidget.tsx
@@ -17,12 +17,10 @@
 import {
   MetadataWidget,
   IMetadataWidgetProps,
-  IMetadata,
   MetadataDisplay,
   IMetadataDisplayProps
-  //IMetadataDisplayState,
 } from '@elyra/metadata-common';
-import { IDictionary } from '@elyra/services';
+import { IMetadataResource } from '@elyra/services';
 
 import React from 'react';
 
@@ -56,16 +54,17 @@ const getLinkFromImageName = (imageName: string): string => {
  * A React Component for displaying the runtime images list.
  */
 class RuntimeImagesDisplay extends MetadataDisplay<IMetadataDisplayProps> {
-  renderExpandableContent(metadata: IDictionary<any>): JSX.Element {
+  renderExpandableContent(metadata: IMetadataResource): JSX.Element {
+    const imageName = metadata.metadata.image_name as string;
     return (
       <div>
         <h6>Container Image</h6>
         <a
-          href={getLinkFromImageName(metadata.metadata.image_name)}
+          href={getLinkFromImageName(imageName)}
           target="_blank"
           rel="noreferrer noopener"
         >
-          {metadata.metadata.image_name}
+          {imageName}
         </a>
       </div>
     );
@@ -80,7 +79,7 @@ export class RuntimeImagesWidget extends MetadataWidget {
     super(props);
   }
 
-  renderDisplay(metadata: IMetadata[]): React.ReactElement {
+  renderDisplay(metadata: IMetadataResource[]): React.ReactElement {
     if (Array.isArray(metadata) && !metadata.length) {
       // Empty metadata
       return (

--- a/packages/pipeline-editor/src/SubmitFileButtonExtension.tsx
+++ b/packages/pipeline-editor/src/SubmitFileButtonExtension.tsx
@@ -15,7 +15,12 @@
  */
 
 import { ContentParser } from '@elyra/services';
-import { RequestErrors, showFormDialog } from '@elyra/ui-components';
+import {
+  GenericObjectType,
+  IErrorResponse,
+  RequestErrors,
+  showFormDialog
+} from '@elyra/ui-components';
 import { Dialog, showDialog, ToolbarButton } from '@jupyterlab/apputils';
 import { PathExt } from '@jupyterlab/coreutils';
 import { DocumentRegistry, DocumentWidget } from '@jupyterlab/docregistry';
@@ -58,113 +63,124 @@ export class SubmitFileButtonExtension<
       await context.save();
     }
 
-    const env = await ContentParser.getEnvVars(context.path).catch((error) =>
-      RequestErrors.serverError(error)
-    );
-    const runtimeTypes: any = await PipelineService.getRuntimeTypes().catch(
-      (error) => RequestErrors.serverError(error)
-    );
-    const runtimes = await PipelineService.getRuntimes()
-      .then((runtimeList) => {
-        return runtimeList.filter((runtime: any) => {
-          return (
-            !runtime.metadata.runtime_enabled &&
-            !!runtimeTypes.find(
-              (r: any) => runtime.metadata.runtime_type === r.id
-            )
-          );
-        });
-      })
-      .catch((error) => RequestErrors.serverError(error));
-    const images = await PipelineService.getRuntimeImages().catch((error) =>
-      RequestErrors.serverError(error)
-    );
-    const schema = await PipelineService.getRuntimesSchema().catch((error) =>
-      RequestErrors.serverError(error)
-    );
+    try {
+      const env = await ContentParser.getEnvVars(context.path);
 
-    const runtimeData = createRuntimeData({ schema, runtimes });
-
-    if (!runtimeData.platforms.find((p) => p.configs.length > 0)) {
-      const res = await RequestErrors.noMetadataError(
-        'runtime',
-        `run file as pipeline.`
+      const runtimeTypes = await PipelineService.getRuntimeTypes();
+      const runtimes = await PipelineService.getRuntimes().then(
+        (runtimeList) => {
+          return runtimeList?.filter((runtime) => {
+            return (
+              !runtime.metadata.runtime_enabled &&
+              !!runtimeTypes.find((r) => runtime.metadata.runtime_type === r.id)
+            );
+          });
+        }
       );
 
-      if (res.button.label.includes(RUNTIMES_SCHEMASPACE)) {
-        // Open the runtimes widget
-        Utils.getLabShell(document).activateById(
-          `elyra-metadata:${RUNTIMES_SCHEMASPACE}`
-        );
+      if (!runtimes) {
+        await RequestErrors.noMetadataError('runtime');
+        return;
       }
-      return;
+
+      const images = await PipelineService.getRuntimeImages();
+      const schema = await PipelineService.getRuntimesSchema();
+
+      if (!schema) {
+        await RequestErrors.noMetadataError('schema');
+        return;
+      }
+
+      if (!images) {
+        await RequestErrors.noMetadataError('runtime images');
+        return;
+      }
+
+      const runtimeData = createRuntimeData({ schema, runtimes });
+
+      if (!runtimeData.platforms.find((p) => p.configs.length > 0)) {
+        const res = await RequestErrors.noMetadataError(
+          'runtime',
+          `run file as pipeline.`
+        );
+
+        if (res.button.label.includes(RUNTIMES_SCHEMASPACE)) {
+          // Open the runtimes widget
+          Utils.getLabShell(document)?.activateById(
+            `elyra-metadata:${RUNTIMES_SCHEMASPACE}`
+          );
+        }
+        return;
+      }
+
+      let dependencyFileExtension = PathExt.extname(context.path);
+      if (dependencyFileExtension === '.ipynb') {
+        dependencyFileExtension = '.py';
+      }
+
+      const dialogOptions: Partial<Dialog.IOptions<GenericObjectType>> = {
+        title: 'Run file as pipeline',
+        body: formDialogWidget(
+          <FileSubmissionDialog
+            env={env}
+            dependencyFileExtension={dependencyFileExtension}
+            images={images}
+            runtimeData={runtimeData}
+          />
+        ),
+        buttons: [Dialog.cancelButton(), Dialog.okButton()]
+      };
+
+      const dialogResult = await showFormDialog(dialogOptions);
+
+      if (dialogResult.value === null) {
+        // When Cancel is clicked on the dialog, just return
+        return;
+      }
+
+      const {
+        runtime_config,
+        framework,
+        cpu,
+        cpu_limit,
+        gpu,
+        memory,
+        memory_limit,
+        dependency_include,
+        dependencies,
+        ...envObject
+      } = dialogResult.value;
+
+      const configDetails = getConfigDetails(runtimeData, runtime_config);
+
+      // prepare file submission details
+      const pipeline = Utils.generateSingleFilePipeline(
+        context.path,
+        configDetails,
+        framework,
+        dependency_include ? dependencies.split(',') : undefined,
+        envObject,
+        cpu,
+        cpu_limit,
+        gpu,
+        memory,
+        memory_limit
+      );
+
+      PipelineService.submitPipeline(
+        pipeline,
+        configDetails?.platform.displayName ?? ''
+      );
+    } catch (error) {
+      await RequestErrors.serverError(error as IErrorResponse);
     }
-
-    let dependencyFileExtension = PathExt.extname(context.path);
-    if (dependencyFileExtension === '.ipynb') {
-      dependencyFileExtension = '.py';
-    }
-
-    const dialogOptions = {
-      title: 'Run file as pipeline',
-      body: formDialogWidget(
-        <FileSubmissionDialog
-          env={env}
-          dependencyFileExtension={dependencyFileExtension}
-          images={images}
-          runtimeData={runtimeData}
-        />
-      ),
-      buttons: [Dialog.cancelButton(), Dialog.okButton()]
-    };
-
-    const dialogResult = await showFormDialog(dialogOptions);
-
-    if (dialogResult.value === null) {
-      // When Cancel is clicked on the dialog, just return
-      return;
-    }
-
-    const {
-      runtime_config,
-      framework,
-      cpu,
-      cpu_limit,
-      gpu,
-      memory,
-      memory_limit,
-      dependency_include,
-      dependencies,
-      ...envObject
-    } = dialogResult.value;
-
-    const configDetails = getConfigDetails(runtimeData, runtime_config);
-
-    // prepare file submission details
-    const pipeline = Utils.generateSingleFilePipeline(
-      context.path,
-      configDetails,
-      framework,
-      dependency_include ? dependencies.split(',') : undefined,
-      envObject,
-      cpu,
-      cpu_limit,
-      gpu,
-      memory,
-      memory_limit
-    );
-
-    PipelineService.submitPipeline(
-      pipeline,
-      configDetails?.platform.displayName ?? ''
-    ).catch((error) => RequestErrors.serverError(error));
   };
 
   createNew(editor: T): IDisposable {
     // Create the toolbar button
     const submitFileButton = new ToolbarButton({
       label: 'Run as Pipeline',
-      onClick: (): any => this.showWidget(editor),
+      onClick: () => this.showWidget(editor),
       tooltip: 'Run file as batch'
     });
 

--- a/packages/pipeline-editor/src/dialogs.tsx
+++ b/packages/pipeline-editor/src/dialogs.tsx
@@ -17,7 +17,7 @@
 import { Dialog } from '@jupyterlab/apputils';
 import React from 'react';
 
-export const unknownError = (message: string): any => ({
+export const unknownError = (message: string) => ({
   title: 'Load pipeline failed!',
   body: message,
   buttons: [Dialog.okButton()]

--- a/packages/pipeline-editor/src/formDialogWidget.ts
+++ b/packages/pipeline-editor/src/formDialogWidget.ts
@@ -14,22 +14,25 @@
  * limitations under the License.
  */
 
+import { GenericObjectType } from '@elyra/ui-components';
 import { ReactWidget, Dialog } from '@jupyterlab/apputils';
 import { MessageLoop } from '@lumino/messaging';
 import { Widget } from '@lumino/widgets';
 
 export const formDialogWidget = (
   dialogComponent: JSX.Element
-): Dialog.IBodyWidget<any> => {
-  const widget = ReactWidget.create(dialogComponent) as Dialog.IBodyWidget<any>;
+): Dialog.IBodyWidget<GenericObjectType> => {
+  const widget = ReactWidget.create(
+    dialogComponent
+  ) as Dialog.IBodyWidget<GenericObjectType>;
 
   // Immediately update the body even though it has not yet attached in
   // order to trigger a render of the DOM nodes from the React element.
   MessageLoop.sendMessage(widget, Widget.Msg.UpdateRequest);
 
-  widget.getValue = (): any => {
+  widget.getValue = (): GenericObjectType => {
     const form = widget.node.querySelector('form');
-    const formValues: { [key: string]: any } = {};
+    const formValues: GenericObjectType = {};
     for (const element of Object.values(
       form?.elements ?? []
     ) as HTMLInputElement[]) {

--- a/packages/pipeline-editor/src/runtime-utils.ts
+++ b/packages/pipeline-editor/src/runtime-utils.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-import { IRuntime, ISchema } from './PipelineService';
+import { IMetadataResource } from '@elyra/services';
+
+import { IRuntimeSchema } from './PipelineService';
 
 export interface IRuntimeData {
   platforms: {
@@ -36,8 +38,8 @@ export const createRuntimeData = ({
   schema,
   allowLocal
 }: {
-  runtimes: IRuntime[];
-  schema: ISchema[];
+  runtimes: IMetadataResource[];
+  schema: IRuntimeSchema[];
   allowLocal?: boolean;
 }): IRuntimeData => {
   const platforms: IRuntimeData['platforms'] = [];
@@ -48,7 +50,7 @@ export const createRuntimeData = ({
     }
     platforms.push({
       id: s.runtime_type,
-      displayName: s.title,
+      displayName: s.title ?? '',
       configs: runtimes
         .filter((r) => r.metadata.runtime_type === s.runtime_type)
         .map((r) => ({

--- a/packages/pipeline-editor/src/test/pipeline-hooks.spec.ts
+++ b/packages/pipeline-editor/src/test/pipeline-hooks.spec.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import {
   IRuntimeComponent,
   GENERIC_CATEGORY_ID,
@@ -52,7 +53,12 @@ const createMockComponent = (name: string): Component => {
     type: 'execution_node',
     inputs: [],
     outputs: [],
-    app_data: {}
+    app_data: {
+      image: 'image',
+      ui_data: {
+        image: 'ui_data_image'
+      }
+    }
   };
 };
 

--- a/packages/pipeline-editor/src/theme.tsx
+++ b/packages/pipeline-editor/src/theme.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Theme } from '@elyra/pipeline-editor/dist/types';
 import { trashIcon } from '@elyra/ui-components';
 import {
   closeIcon,
@@ -24,6 +25,7 @@ import {
   paletteIcon
 } from '@jupyterlab/ui-components';
 import * as React from 'react';
+import { DeepPartial } from 'redux';
 
 interface ISvgIconProps {
   children: React.ReactNode;
@@ -43,7 +45,7 @@ const SvgIcon: React.FC<ISvgIconProps> = ({ children }) => {
   );
 };
 
-const theme: any = {
+const theme: DeepPartial<Theme> = {
   palette: {
     focus: 'var(--jp-brand-color0)',
     border: 'var(--jp-border-color0)',
@@ -68,10 +70,6 @@ const theme: any = {
       main: 'var(--jp-error-color1)',
       contrastText: 'rgba(255, 255, 255, 0.9)',
       errorBorder: 'var(--jp-error-color0)'
-    },
-    icon: {
-      primary: 'var(--jp-ui-font-color0)',
-      secondary: 'var(--jp-ui-font-color0)'
     },
     text: {
       primary: 'var(--jp-content-font-color0)',

--- a/packages/pipeline-editor/src/utils.ts
+++ b/packages/pipeline-editor/src/utils.ts
@@ -16,8 +16,11 @@
 
 import { PIPELINE_CURRENT_VERSION } from '@elyra/pipeline-editor';
 
+import { GenericObjectType } from '@elyra/ui-components';
+
 import { LabShell } from '@jupyterlab/application';
 import { PathExt } from '@jupyterlab/coreutils';
+import { Widget } from '@lumino/widgets';
 
 import uuid4 from 'uuid/v4';
 
@@ -41,7 +44,7 @@ export default class Utils {
     gpu?: number,
     memory?: number,
     memory_limit?: number
-  ): any {
+  ): GenericObjectType {
     const generated_uuid = uuid4();
 
     const artifactName = PathExt.basename(filename, PathExt.extname(filename));
@@ -119,7 +122,7 @@ export default class Utils {
   /**
    * From a given widget, find the application shell and return it
    */
-  static getLabShell = (widget: any): LabShell => {
+  static getLabShell = (widget: Widget | null): LabShell | null => {
     while (widget !== null && !(widget instanceof LabShell)) {
       widget = widget.parent;
     }

--- a/packages/python-editor/install.json
+++ b/packages/python-editor/install.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "python",
   "packageName": "elyra_python_editor_extension",
   "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package elyra_python_editor_extension"
 }

--- a/packages/python-editor/src/index.ts
+++ b/packages/python-editor/src/index.ts
@@ -219,7 +219,7 @@ const extension: JupyterFrontEndPlugin<void> = {
 
     app.docRegistry.addWidgetFactory(factory);
 
-    factory.widgetCreated.connect((sender: any, widget: any) => {
+    factory.widgetCreated.connect((_sender, widget) => {
       void tracker.add(widget);
 
       // Notify the widget tracker if restore data needs to update
@@ -230,7 +230,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     });
 
     // Handle the settings of new widgets. Adapted from fileeditor-extension.
-    tracker.widgetAdded.connect((sender, widget) => {
+    tracker.widgetAdded.connect((_sender, widget) => {
       updateWidget(widget);
     });
 
@@ -256,6 +256,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     }
 
     // Function to create a new untitled python file, given the current working directory
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `app.commands.execute` returns a Promise<any>
     const createNew = (cwd: string): Promise<any> => {
       return app.commands
         .execute(commandIDs.newDocManager, {

--- a/packages/r-editor/src/index.ts
+++ b/packages/r-editor/src/index.ts
@@ -220,6 +220,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     }
 
     // Function to create a new untitled r file, given the current working directory
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `app.commands.execute` returns a Promise<any>
     const createNew = (cwd: string): Promise<any> => {
       return app.commands
         .execute(commandIDs.newDocManager, {

--- a/packages/scala-editor/src/index.ts
+++ b/packages/scala-editor/src/index.ts
@@ -223,6 +223,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     }
 
     // Function to create a new untitled scala file, given the current working directory
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- `app.commands.execute` returns a Promise<any>
     const createNew = (cwd: string): Promise<any> => {
       return app.commands
         .execute(commandIDs.newDocManager, {

--- a/packages/script-debugger/install.json
+++ b/packages/script-debugger/install.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "python",
   "packageName": "elyra_script_debugger_extension",
   "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package elyra_script_debugger_extension"
 }

--- a/packages/script-debugger/src/index.ts
+++ b/packages/script-debugger/src/index.ts
@@ -149,7 +149,7 @@ const scriptEditorDebuggerExtension: JupyterFrontEndPlugin<void> = {
         type: 'file',
         name: path
       };
-      let sessionConnection = null;
+      let sessionConnection: Session.ISessionConnection | null = null;
       try {
         if (kernelSelection) {
           sessionConnection = await sessionManager.startNew(options);

--- a/packages/script-editor/install.json
+++ b/packages/script-editor/install.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "python",
   "packageName": "elyra_script_editor",
   "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package elyra_script_editor"
 }

--- a/packages/script-editor/src/KernelDropdown.tsx
+++ b/packages/script-editor/src/KernelDropdown.tsx
@@ -65,7 +65,7 @@ const DropDown = forwardRef<ISelect, IProps>(
       ))
     );
 
-    const handleSelection = (e: any): void => {
+    const handleSelection = (e: { target: HTMLSelectElement }): void => {
       const selection = e.target.value;
       setSelection(selection);
       callback(selection);

--- a/packages/script-editor/src/ScriptEditor.tsx
+++ b/packages/script-editor/src/ScriptEditor.tsx
@@ -45,7 +45,7 @@ import React, { RefObject } from 'react';
 
 import { ISelect, KernelDropdown } from './KernelDropdown';
 import { ScriptEditorController } from './ScriptEditorController';
-import { ScriptRunner } from './ScriptRunner';
+import { IMessageOutput, ScriptRunner } from './ScriptRunner';
 
 /**
  * ScriptEditor widget CSS classes.
@@ -255,7 +255,7 @@ export abstract class ScriptEditor extends DocumentWidget<
   /**
    * Function: Call back function passed to runner, that handles messages coming from the kernel.
    */
-  private handleKernelMsg = async (msg: any): Promise<void> => {
+  private handleKernelMsg = (msg: IMessageOutput): void => {
     let output = '';
 
     if (msg.status) {
@@ -432,19 +432,19 @@ export abstract class ScriptEditor extends DocumentWidget<
   /**
    * Function: Saves file editor content.
    */
-  private saveFile = async (): Promise<any> => {
+  private saveFile = async (): Promise<void> => {
     if (this.context.model.readOnly) {
-      return showDialog({
+      await showDialog({
         title: 'Cannot Save',
         body: 'Document is read-only',
         buttons: [Dialog.okButton()]
       });
-    }
-    void this.context.save().then(() => {
-      if (!this.isDisposed) {
-        return this.context.createCheckpoint();
-      }
       return;
+    }
+    this.context.save().then(async () => {
+      if (!this.isDisposed) {
+        await this.context.createCheckpoint();
+      }
     });
   };
 }

--- a/packages/script-editor/src/ScriptEditorController.ts
+++ b/packages/script-editor/src/ScriptEditorController.ts
@@ -84,8 +84,8 @@ export class ScriptEditorController {
 
     const empty = '';
     if (specsByLang && Object.keys(specsByLang.kernelspecs).length !== 0) {
-      const [key, value]: any = Object.entries(specsByLang.kernelspecs)[0];
-      return value.name ?? key;
+      const [key, value] = Object.entries(specsByLang.kernelspecs)[0];
+      return value?.name ?? key;
     }
     return empty;
   };

--- a/packages/script-editor/src/test/script-editor.spec.ts
+++ b/packages/script-editor/src/test/script-editor.spec.ts
@@ -17,7 +17,7 @@
 import { JupyterServer } from '@jupyterlab/testutils';
 
 import { ScriptEditorController } from '../ScriptEditorController';
-import { ScriptRunner } from '../ScriptRunner';
+import { IMessageOutput, ScriptRunner } from '../ScriptRunner';
 
 jest.setTimeout(3 * 60 * 1000);
 
@@ -93,8 +93,9 @@ describe('@elyra/script-editor', () => {
 
       it('should run script', async () => {
         const code = 'print("Test")';
-        const testCallback = async (kernelMsg: any): Promise<void> =>
+        const testCallback = (kernelMsg: IMessageOutput): void => {
           kernelMsg.output && expect(kernelMsg.output).toMatch(/test/i);
+        };
         expect(kernelName).not.toBe('');
         await runner.runScript(kernelName, testPath, code, testCallback);
         await runner.shutdownSession();
@@ -102,8 +103,9 @@ describe('@elyra/script-editor', () => {
 
       it('should receive error message when running a broken script', async () => {
         const code = 'print(Broken Test)';
-        const testCallback = async (kernelMsg: any): Promise<void> =>
+        const testCallback = (kernelMsg: IMessageOutput): void => {
           kernelMsg.error && expect(kernelMsg.error.type).toMatch(/error/i);
+        };
         expect(kernelName).not.toBe('');
         await runner.runScript(kernelName, testPath, code, testCallback);
         await runner.shutdownSession();

--- a/packages/services/install.json
+++ b/packages/services/install.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "python",
   "packageName": "elyra_services",
   "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package elyra_services"
 }

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -19,3 +19,4 @@ import '../style/index.css';
 export * from './parsing';
 export * from './metadata';
 export * from './requests';
+export * from './types';

--- a/packages/services/src/parsing.ts
+++ b/packages/services/src/parsing.ts
@@ -15,6 +15,7 @@
  */
 
 import { RequestHandler } from './requests';
+import { IContentsPropertiesResource } from './types';
 
 const ELYRA_FILE_PARSER_API_ENDPOINT = 'elyra/contents/properties/';
 
@@ -34,13 +35,14 @@ export class ContentParser {
    * @param file_path - relative path to file
    * @returns A string array of the env vars accessed in the given file
    */
-  static async getEnvVars(file_path: string): Promise<any> {
+  static async getEnvVars(file_path: string): Promise<string[]> {
     try {
-      const response = await RequestHandler.makeGetRequest(
-        ELYRA_FILE_PARSER_API_ENDPOINT + file_path
-      );
+      const response =
+        await RequestHandler.makeGetRequest<IContentsPropertiesResource>(
+          ELYRA_FILE_PARSER_API_ENDPOINT + file_path
+        );
       // Only return environment var names (not values)
-      return Object.keys(response.env_vars);
+      return Object.keys(response?.env_vars ?? {});
     } catch (error) {
       return Promise.reject(error);
     }

--- a/packages/services/src/types.ts
+++ b/packages/services/src/types.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018-2025 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IDictionary } from './parsing';
+
+// Types extracted from `elyra/api/elyra.yaml`
+
+export interface IElyraResource {}
+
+export interface IMetadataResourceBody {
+  display_name: string;
+  schema_name: string;
+  metadata: IDictionary<unknown>;
+}
+
+export interface IMetadataResource
+  extends IElyraResource,
+    IMetadataResourceBody {
+  name: string;
+}
+
+export interface ISchemaspaceResource extends IElyraResource {
+  name: string;
+  id: string;
+  display_name: string;
+  description: string;
+}
+
+export interface ISchemaResource extends IElyraResource {
+  schemaspace: string;
+  name: string;
+  title?: string;
+  properties?: IDictionary<unknown>;
+  uihints?: {
+    title: string;
+    icon: string;
+    reference_url: string;
+  };
+}
+
+export interface IMetadataSchemaspaceResource extends IElyraResource {
+  [schemaspace: string]: IMetadataResource[];
+}
+
+export interface ISchemaSchemaspaceResource extends IElyraResource {
+  [schemaspace: string]: ISchemaResource[];
+}
+
+export interface ISchemaspacesResource extends IElyraResource {
+  schemaspaces: string[];
+}
+
+export interface IComponentCacheResource extends IElyraResource {
+  action: 'refresh';
+}
+
+export interface IContentsPropertiesResource extends IElyraResource {
+  env_vars: Record<string, string | null>;
+  inputs: Array<string>;
+  outputs: Array<string>;
+}

--- a/packages/theme/install.json
+++ b/packages/theme/install.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "python",
   "packageName": "elyra_theme_extension",
   "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package elyra_theme_extension"
 }

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -102,7 +102,7 @@ const extension: JupyterFrontEndPlugin<ILauncher> = {
 
     commands.addCommand(CommandIDs.create, {
       label: trans.__('New Launcher'),
-      execute: (args: any) => {
+      execute: (args) => {
         const cwd = args['cwd'] ? String(args['cwd']) : '';
         const id = `launcher-${Private.id++}`;
         const callback = (item: Widget): void => {
@@ -170,7 +170,7 @@ const extension: JupyterFrontEndPlugin<ILauncher> = {
     commands.addCommand(CommandIDs.openHelp, {
       label: 'Documentation',
       icon: helpIcon,
-      execute: (args: any) => {
+      execute: () => {
         window.open('https://elyra.readthedocs.io/en/latest/', '_blank');
       }
     });
@@ -179,7 +179,7 @@ const extension: JupyterFrontEndPlugin<ILauncher> = {
       label: "What's new in latest",
       caption: "What's new in this release",
       icon: whatsNewIcon,
-      execute: (args: any) => {
+      execute: () => {
         window.open(
           'https://github.com/elyra-ai/elyra/releases/latest/',
           '_blank'

--- a/packages/theme/src/launcher.tsx
+++ b/packages/theme/src/launcher.tsx
@@ -116,7 +116,7 @@ export class Launcher extends JupyterlabLauncher {
   /**
    * Render the launcher to virtual DOM nodes.
    */
-  protected render(): React.ReactElement<any> | null {
+  protected render(): React.ReactElement<React.JSX.Element> | null {
     // Bail if there is no model.
     if (!this.model) {
       return null;
@@ -128,7 +128,7 @@ export class Launcher extends JupyterlabLauncher {
     const launcherContent = launcherBody?.props.children;
     const launcherCategories = launcherContent.props.children;
 
-    const categories: React.ReactElement<any>[] = [];
+    const categories: React.ReactElement<string>[] = [];
 
     const knownCategories = [
       this._translator.__('Notebook'),
@@ -139,7 +139,7 @@ export class Launcher extends JupyterlabLauncher {
 
     // Assemble the final ordered list of categories
     // based on knownCategories.
-    each(knownCategories, (category, index) => {
+    each(knownCategories, (category) => {
       React.Children.forEach(launcherCategories, (cat) => {
         if (cat.key === category) {
           if (cat.key === ELYRA_CATEGORY) {

--- a/packages/ui-components/install.json
+++ b/packages/ui-components/install.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "python",
   "packageName": "elyra_ui_components",
   "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package elyra_ui_components"
 }

--- a/packages/ui-components/src/Dropzone.tsx
+++ b/packages/ui-components/src/Dropzone.tsx
@@ -31,10 +31,10 @@ interface IRootProps {
 }
 
 interface IProps {
-  onDragEnter?: (e: Drag.Event) => any;
-  onDragLeave?: (e: Drag.Event) => any;
-  onDragOver?: (e: Drag.Event) => any;
-  onDrop?: (e: Drag.Event) => any;
+  onDragEnter?: (e: Drag.Event) => void;
+  onDragLeave?: (e: Drag.Event) => void;
+  onDragOver?: (e: Drag.Event) => void;
+  onDrop?: (e: Drag.Event) => void;
   children?: React.ReactNode;
 }
 

--- a/packages/ui-components/src/ExpandableComponent.tsx
+++ b/packages/ui-components/src/ExpandableComponent.tsx
@@ -44,7 +44,7 @@ const DRAGGABLE_CLASS = 'elyra-expandableContainer-draggable';
 export interface IExpandableActionButton {
   title: string;
   icon: LabIcon;
-  onClick: () => any;
+  onClick: () => void;
   feedback?: string;
 }
 
@@ -52,9 +52,9 @@ export interface IExpandableComponentProps {
   displayName: string;
   tooltip: string;
   actionButtons?: IExpandableActionButton[];
-  onExpand?: (isExpanded: boolean) => any;
-  onBeforeExpand?: (isExpanded: boolean) => any;
-  onMouseDown?: (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => any;
+  onExpand?: (isExpanded: boolean) => void;
+  onBeforeExpand?: (isExpanded: boolean) => void;
+  onMouseDown?: (e: React.MouseEvent<HTMLSpanElement, MouseEvent>) => void;
   children?: React.ReactNode;
 }
 

--- a/packages/ui-components/src/FormComponents/DropDown.tsx
+++ b/packages/ui-components/src/FormComponents/DropDown.tsx
@@ -48,7 +48,7 @@ export const DropDown: React.FC<FieldProps> = (props: FieldProps) => {
     <div>
       <input
         required={required}
-        onChange={(event: any): void => {
+        onChange={(event): void => {
           handleChange(event.target.value);
         }}
         value={current ?? ''}

--- a/packages/ui-components/src/FormComponents/Tags.tsx
+++ b/packages/ui-components/src/FormComponents/Tags.tsx
@@ -206,11 +206,11 @@ export const Tags: React.FC<ITagProps> = ({
 };
 
 export const TagsField: React.FC<FieldProps> = (props: FieldProps) => {
-  const errors = [];
+  const errors: JSX.Element[] = [];
   const errorSchema = props.errorSchema ?? {};
   if (Object.keys(errorSchema).length > 0) {
     for (const i in props.errorSchema) {
-      for (const err of (props.errorSchema[i] as any)['__errors']) {
+      for (const err of props.errorSchema[i]?.['__errors'] ?? []) {
         errors.push(<li className="text-danger">{err}</li>);
       }
     }

--- a/packages/ui-components/src/FormEditor.tsx
+++ b/packages/ui-components/src/FormEditor.tsx
@@ -23,10 +23,18 @@ import {
   FieldTemplateProps,
   RegistryFieldsType,
   RegistryWidgetsType,
-  RJSFValidationError
+  RJSFValidationError,
+  UiSchema
 } from '@rjsf/utils';
 import validator from '@rjsf/validator-ajv8';
 import * as React from 'react';
+
+type ElyraSchema = GenericObjectType & {
+  uihints?: { title: string; icon: string; reference_url: string };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- a record that holds any value
+export type GenericObjectType = Record<string, any>;
 
 /**
  * Props passed to the FormEditor.
@@ -35,12 +43,12 @@ interface IFormEditorProps {
   /**
    * Schema for form fields to be displayed.
    */
-  schema: any;
+  schema: GenericObjectType;
 
   /**
    * Handler to update form data in parent component.
    */
-  onChange: (formData: any) => void;
+  onChange: (formData: GenericObjectType) => void;
 
   /**
    * Editor services to create new editors in code fields.
@@ -60,7 +68,7 @@ interface IFormEditorProps {
   /**
    * Metadata that already exists (if there is any)
    */
-  originalData?: any;
+  originalData?: GenericObjectType;
 
   /**
    * All existing tags to give as options.
@@ -83,7 +91,7 @@ export type FormValidationState =
     };
 
 export interface IFormEditorRef {
-  validateForm: (data: any) => FormValidationState;
+  validateForm: (data: GenericObjectType) => FormValidationState;
 }
 
 /**
@@ -174,14 +182,15 @@ const RefForwardingFormEditor: React.ForwardRefRenderFunction<
   /**
    * Generate the rjsf uiSchema from uihints in the elyra metadata schema.
    */
-  const uiSchema: any = {
+  const uiSchema: UiSchema = {
     classNames: 'elyra-formEditor'
   };
   for (const category in schema?.properties) {
-    const properties = schema.properties[category];
+    const properties = schema.properties[category] as GenericObjectType;
     uiSchema[category] = {};
     for (const field in properties.properties) {
-      uiSchema[category][field] = properties.properties[field].uihints ?? {};
+      const fieldProperties = properties.properties[field] as ElyraSchema;
+      uiSchema[category][field] = fieldProperties.uihints ?? {};
       uiSchema[category][field].classNames = `elyra-formEditor-form-${field}`;
     }
   }

--- a/packages/ui-components/src/JSONComponent.tsx
+++ b/packages/ui-components/src/JSONComponent.tsx
@@ -40,7 +40,7 @@ const theme = {
 };
 
 interface IProps {
-  json: any;
+  json: Record<string, unknown> | Array<unknown>;
 }
 
 /**
@@ -64,7 +64,7 @@ export const JSONComponent: React.FC<IProps> = ({ json }) => (
       data: string,
       itemType: string,
       itemString: string
-    ): any =>
+    ): React.ReactNode =>
       Array.isArray(data) ? (
         // Always display array type and the number of items i.e. "[] 2 items".
         <span>
@@ -77,10 +77,13 @@ export const JSONComponent: React.FC<IProps> = ({ json }) => (
         null! // Upstream typings don't accept null, but it should be ok
       )
     }
-    labelRenderer={([label, type]: [string, any]): any => {
+    labelRenderer={([label, _type]: [
+      string,
+      string | number | boolean | null | undefined
+    ]): JSX.Element => {
       return <span className="cm-keyword">{`${label}: `}</span>;
     }}
-    valueRenderer={(raw: any): any => {
+    valueRenderer={(raw: string | number): JSX.Element => {
       let className = 'cm-string';
       if (typeof raw === 'number') {
         className = 'cm-number';

--- a/packages/ui-components/src/RequestErrors.tsx
+++ b/packages/ui-components/src/RequestErrors.tsx
@@ -20,6 +20,16 @@ import * as React from 'react';
 
 import { ExpandableErrorDialog } from './ExpandableErrorDialog';
 
+export interface IErrorResponse {
+  status?: number;
+  message?: string;
+  requestPath?: string;
+  reason?: string;
+  timestamp?: string;
+  traceback?: string;
+  issues: object[];
+}
+
 /**
  * A class for handling errors when making requests to the jupyter lab server.
  */
@@ -32,7 +42,7 @@ export class RequestErrors {
    *
    * @returns A human readable multiline string for displaying the issues
    */
-  private static formatIssues(issues: any): string {
+  private static formatIssues(issues: object[]): string {
     let formatted = '';
     for (const issue of issues) {
       formatted += JSON.stringify(issue, null, 2) + '\n';
@@ -47,7 +57,7 @@ export class RequestErrors {
    *
    * @returns A promise that resolves with whether the dialog was accepted.
    */
-  static serverError(response: any): Promise<Dialog.IResult<any>> {
+  static serverError(response: IErrorResponse): Promise<Dialog.IResult<void>> {
     if (response.status === 404) {
       return this.server404(response.requestPath);
     }
@@ -87,7 +97,9 @@ export class RequestErrors {
    *
    * @returns A promise that resolves with whether the dialog was accepted.
    */
-  private static server404(endpoint: string): Promise<Dialog.IResult<any>> {
+  private static server404(
+    endpoint: string = 'unknown'
+  ): Promise<Dialog.IResult<void>> {
     return showDialog({
       title: 'Error contacting server',
       body: (
@@ -115,7 +127,7 @@ export class RequestErrors {
     schemaspace: string,
     action?: string,
     schemaName?: string
-  ): Promise<Dialog.IResult<any>> {
+  ): Promise<Dialog.IResult<void>> {
     return showDialog({
       title: action ? `Cannot ${action}` : 'Error retrieving metadata',
       body: (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3280,6 +3280,7 @@ __metadata:
     react-redux: ^7.2.0
     react-scripts: 4.0.3
     react-toastify: ^9.0.8
+    redux: ^4.2.0
     rimraf: ~5.0.5
     source-map-loader: ^0.2.4
     swr: ^0.5.6
@@ -23730,6 +23731,15 @@ __metadata:
   dependencies:
     "@babel/runtime": "npm:^7.9.2"
   checksum: 75f3955c89b3f18edf5411e5fb482aa2e4f41a416183e8802a6bf6472c4fc3d47675b8b321d147f8af8e0f616436ac507bf5a25f1c4d6180e797b549c7db2c1d
+  languageName: node
+  linkType: hard
+
+"redux@npm:^4.2.0":
+  version: 4.2.1
+  resolution: "redux@npm:4.2.1"
+  dependencies:
+    "@babel/runtime": ^7.9.2
+  checksum: f63b9060c3a1d930ae775252bb6e579b42415aee7a23c4114e21a0b4ba7ec12f0ec76936c00f546893f06e139819f0e2855e0d55ebfce34ca9c026241a6950dd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

Cherry-picked from [ODH Elyra](https://github.com/opendatahub-io/elyra/)

While migrating the extensions to JupyterLab v4, we faced issues related to type incompatibility after library upgrades. Many of these issues were identified only at runtime due to the extensive usage of `any` throughout the code instead of the correct types. So, this PR reviews the usage of `any` and makes appropriate changes to avoid it as much as possible. Also, the build now throws an error if `any` is used without a reason. Given the structure of the code that has been built on top of `any`, the changes on this PR are not perfect, but, hopefully, they will provide more protection to the code on future fixes, upgrades, and new features.

### How was this pull request tested?
<!--
Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases, if possible.

If changes were tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added e.g. documentation only, GH workflow updates, etc.
-->

Through CI runs and manual tests.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
