### PR TITLE
Fix main icon replacement by Elyra icon

### DIFF
--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -65,35 +65,31 @@ const extension: JupyterFrontEndPlugin<ILauncher> = {
   ): ILauncher => {
     console.log('Elyra - theme extension is activated!');
 
-    // Find the MainLogo widget in the shell and replace it with the Elyra Logo
-    const widgets = app.shell.widgets('top');
-    let next = widgets.next();
-
-    while (!next.done) {
-      const widget = next.value;
-      if (widget.id === 'jp-MainLogo') {
-        // Object literal may only specify known properties, and 'justify' does not exist in type 'IProps'.ts(2353)
-
-        const propsWithJustify: {
-          container: HTMLElement;
-          justify?: string;
-          margin: string;
-          height: string;
-          width: string;
-        } = {
-          container: widget.node,
-          justify: 'center',
-          margin: '2px 5px 2px 5px',
-          height: 'auto',
-          width: '20px'
-        };
-
-        elyraIcon.element(propsWithJustify);
-
-        break;
+    // Find the MainLogo element and replace it with the Elyra Logo
+    app.restored.then(() => {
+      const logoElement = document.getElementById('jp-MainLogo');
+      if (!logoElement) {
+        return;
       }
-      next = widgets.next();
-    }
+
+      logoElement.innerHTML = '';
+
+      const propsWithJustify: {
+        container: HTMLElement;
+        justify?: string;
+        margin: string;
+        height: string;
+        width: string;
+      } = {
+        container: logoElement,
+        justify: 'center',
+        margin: '2px 5px 2px 5px',
+        height: 'auto',
+        width: '20px'
+      };
+
+      elyraIcon.element(propsWithJustify);
+    });
 
     // Use custom Elyra launcher
     const { commands, shell } = app;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

I've noticed this part of the code stopped working after the upgrade to JupyterLab 4. So, this PR fixes it in a simpler approach (get the element directly by ID instead of iterating through widgets). In the future, we may consider having a mechanism to enable/disable this replacement since there could be use cases where it would not be interesting for the JupyterLab icon to be replaced.

Before:
<img width="370" alt="image" src="https://github.com/user-attachments/assets/5f925d3b-5f69-4444-a525-87d2e599ce08" />

After:
<img width="404" alt="image" src="https://github.com/user-attachments/assets/9905d84b-35bd-4e7a-baed-02ca0edfd733" />


### How was this pull request tested?
<!--
Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases, if possible.

If changes were tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added e.g. documentation only, GH workflow updates, etc.
-->
Manual tests.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
