### PR TITLE
Update release script for Elyra 4.0 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,6 @@ help:
 purge:
 	rm -rf build *.egg-info yarn-error.log
 	rm -rf node_modules lib dist
-	rm -rf $$(find labextensions -name labextension -type d)
 	rm -rf $$(find packages -name node_modules -type d -maxdepth 2)
 	rm -rf $$(find packages -name dist -type d)
 	rm -rf $$(find packages -name lib -type d)

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ help:
 purge:
 	rm -rf build *.egg-info yarn-error.log
 	rm -rf node_modules lib dist
+	rm -rf $$(find labextension -name labextensions -type d)
 	rm -rf $$(find packages -name node_modules -type d -maxdepth 2)
 	rm -rf $$(find packages -name dist -type d)
 	rm -rf $$(find packages -name lib -type d)

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ help:
 purge:
 	rm -rf build *.egg-info yarn-error.log
 	rm -rf node_modules lib dist
+	rm -rf $$(find labextensions -name labextension -type d)
 	rm -rf $$(find packages -name node_modules -type d -maxdepth 2)
 	rm -rf $$(find packages -name dist -type d)
 	rm -rf $$(find packages -name lib -type d)

--- a/create-release.py
+++ b/create-release.py
@@ -722,7 +722,7 @@ def prepare_extensions_release() -> None:
         setup_file = os.path.join(extension_source_dir, "setup.py")
         sed(setup_file, "{{package-name}}", extension)
         sed(setup_file, "{{version}}", config.new_version)
-        sed(setup_file, "{{data - files}}", re.escape("('share/jupyter/labextensions', 'build/labextensions', '**')"))
+        sed(setup_file, "{{data - files}}", "('share/jupyter/labextensions', 'build/labextensions', '**')")
         sed(setup_file, "{{install - requires}}", f"'elyra-server=={config.new_version}',")
         sed(setup_file, "{{description}}", f"'{extensions[extension].description}'")
 

--- a/create-release.py
+++ b/create-release.py
@@ -650,7 +650,7 @@ def copy_extension_dir(extension: str, work_dir: str) -> None:
     extension = extension.replace("-", "_")
     extension_package_source_dir = os.path.join(config.source_dir, f"labextensions/elyra_{extension}")
     extension_package_dest_dir = os.path.join(work_dir, f"labextensions/elyra_{extension}")
-    print(f">>>Copying extension package from {extension_package_source_dir} to {extension_package_dest_dir}")
+    print(f">>> Copying extension package from {extension_package_source_dir} to {extension_package_dest_dir}")
     os.makedirs(os.path.dirname(extension_package_dest_dir), exist_ok=True)
     shutil.copytree(extension_package_source_dir, extension_package_dest_dir)
 

--- a/create-release.py
+++ b/create-release.py
@@ -64,8 +64,8 @@ def check_run(args, cwd=os.getcwd(), capture_output=True, env=None, shell=False)
             error_msg = ex.stderr.decode("utf-8", errors="replace")
         else:
             error_msg = str(ex.stderr)
-        
-        raise RuntimeError(f'Error executing process: {error_msg}') from ex
+
+        raise RuntimeError(f"Error executing process: {error_msg}") from ex
 
 
 def check_output(args, cwd=os.getcwd(), env=None, shell=False) -> str:
@@ -90,22 +90,22 @@ def sed(file: str, pattern: str, replace: str) -> None:
         # Validate file path
         if not os.path.exists(file):
             raise RuntimeError(f"File does not exist: {file}")
-        
+
         # Read file content
-        with open(file, 'r', encoding='utf-8') as f:
+        with open(file, "r", encoding="utf-8") as f:
             content = f.read()
-        
+
         # Perform regex substitution with MULTILINE flag for ^ and $ anchors
         modified_content = re.sub(pattern, replace, content, flags=re.MULTILINE)
-        
+
         # Write back only if content changed
         if modified_content != content:
-            with open(file, 'w', encoding='utf-8') as f:
+            with open(file, "w", encoding="utf-8") as f:
                 f.write(modified_content)
             print(f"Updated {file}: {pattern} -> {replace}")
         else:
             print(f"No changes needed in {file} for pattern: {pattern}")
-                
+
     except Exception as ex:
         raise RuntimeError(f"Error processing file {file}: {str(ex)}") from ex
 
@@ -117,19 +117,19 @@ def sed_remove(file: str, pattern: str) -> None:
         if not os.path.exists(file):
             # Silently return if file doesn't exist (common case for install.json)
             return
-        
+
         # Read file content
-        with open(file, 'r', encoding='utf-8') as f:
+        with open(file, "r", encoding="utf-8") as f:
             lines = f.readlines()
-        
+
         # Filter out lines matching pattern
         filtered_lines = [line for line in lines if not re.search(pattern, line)]
-        
+
         # Write back only if content changed
         if len(filtered_lines) != len(lines):
-            with open(file, 'w', encoding='utf-8') as f:
+            with open(file, "w", encoding="utf-8") as f:
                 f.writelines(filtered_lines)
-                
+
     except Exception as ex:
         raise RuntimeError(f"Error processing file {file}: {str(ex)}") from ex
 
@@ -161,10 +161,22 @@ def update_version_to_release() -> None:
 
     try:
         # Update backend version
-        sed(_source(".bumpversion.cfg"), rf"^current_version\s*=\s*{re.escape(old_version)}", f"current_version = {new_version}")
-        sed(_source("elyra/_version.py"), rf'^__version__\s*=\s*"{re.escape(old_version)}"', f'__version__ = "{new_version}"')
+        sed(
+            _source(".bumpversion.cfg"),
+            rf"^current_version\s*=\s*{re.escape(old_version)}",
+            f"current_version = {new_version}",
+        )
+        sed(
+            _source("elyra/_version.py"),
+            rf'^__version__\s*=\s*"{re.escape(old_version)}"',
+            f'__version__ = "{new_version}"',
+        )
         sed(_source("README.md"), rf"elyra {re.escape(old_version)}", f"elyra {new_version}")
-        sed(_source("docs/source/getting_started/installation.md"), rf"elyra {re.escape(old_version)}", f"elyra {new_version}")
+        sed(
+            _source("docs/source/getting_started/installation.md"),
+            rf"elyra {re.escape(old_version)}",
+            f"elyra {new_version}",
+        )
 
         # Update docker related tags
         sed(_source("Makefile"), r"^TAG:=dev", f"TAG:={new_version}")
@@ -177,7 +189,9 @@ def update_version_to_release() -> None:
 
         # Update UI component versions
         sed(_source("README.md"), rf"v{re.escape(old_npm_version)}", f"v{new_version}")
-        sed(_source("docs/source/getting_started/installation.md"), rf"v{re.escape(old_npm_version)}", f"v{new_version}")
+        sed(
+            _source("docs/source/getting_started/installation.md"), rf"v{re.escape(old_npm_version)}", f"v{new_version}"
+        )
 
         sed(
             _source("packages/theme/src/index.ts"),
@@ -336,10 +350,22 @@ def update_version_to_dev() -> None:
 
     try:
         # Update backend version
-        sed(_source(".bumpversion.cfg"), rf"^current_version\s*=\s*{re.escape(new_version)}", f"current_version = {dev_version}")
-        sed(_source("elyra/_version.py"), rf'^__version__\s*=\s*"{re.escape(new_version)}"', f'__version__ = "{dev_version}"')
+        sed(
+            _source(".bumpversion.cfg"),
+            rf"^current_version\s*=\s*{re.escape(new_version)}",
+            f"current_version = {dev_version}",
+        )
+        sed(
+            _source("elyra/_version.py"),
+            rf'^__version__\s*=\s*"{re.escape(new_version)}"',
+            f'__version__ = "{dev_version}"',
+        )
         sed(_source("README.md"), rf"elyra {re.escape(new_version)}", f"elyra {dev_version}")
-        sed(_source("docs/source/getting_started/installation.md"), rf"elyra {re.escape(new_version)}", f"elyra {dev_version}")
+        sed(
+            _source("docs/source/getting_started/installation.md"),
+            rf"elyra {re.escape(new_version)}",
+            f"elyra {dev_version}",
+        )
 
         # Update docker related tags
         sed(_source("Makefile"), rf"^TAG:={new_version}", "TAG:=dev")
@@ -502,19 +528,19 @@ def update_version_to_dev() -> None:
 def _source(file: str) -> str:
     """Get absolute path for a file within the source directory with path validation"""
     global config
-    
+
     # Validate input
-    if not file or '..' in file or file.startswith('/'):
+    if not file or ".." in file or file.startswith("/"):
         raise ValueError(f"Invalid file path: {file}")
-    
+
     # Create absolute path
     source_path = os.path.abspath(config.source_dir)
     file_path = os.path.abspath(os.path.join(source_path, file))
-    
+
     # Ensure the resolved path is within source directory (prevent path traversal)
     if not file_path.startswith(source_path + os.sep) and file_path != source_path:
         raise ValueError(f"Path traversal attempt detected: {file}")
-    
+
     return file_path
 
 

--- a/create-release.py
+++ b/create-release.py
@@ -885,6 +885,8 @@ def prepare_release() -> None:
     checkout_code()
     # Update to new release version
     update_version_to_release()
+    # build packages to update yarn.lock
+    update_yarn_lock()
     # commit and tag
     check_run(["git", "commit", "-s", "-a", "-m", f"Release v{config.new_version}"], cwd=config.source_dir)
     check_run(["git", "tag", config.tag], cwd=config.source_dir)

--- a/create-release.py
+++ b/create-release.py
@@ -543,20 +543,6 @@ def checkout_code() -> None:
     print("")
 
 
-def update_yarn_lock():
-    global config
-
-    print("-----------------------------------------------------------------")
-    print("----------------------- Update Yarn lock ------------------------")
-    print("-----------------------------------------------------------------")
-
-    # Build wheels and source packages
-    print(f">>> Updating yarn lock file in {config.source_dir}")
-    check_run(["yarn", "install"], cwd=config.source_dir, capture_output=False)
-
-    print("")
-
-
 def build_release():
     global config
 
@@ -615,6 +601,20 @@ def show_release_artifacts():
     print(f"Location \t {dist_dir}")
     print("")
     check_run(["ls", "-la", dist_dir], capture_output=False)
+    print("")
+
+
+def update_yarn_lock():
+    global config
+
+    print("-----------------------------------------------------------------")
+    print("----------------------- Update Yarn lock ------------------------")
+    print("-----------------------------------------------------------------")
+
+    # Build wheels and source packages
+    print(f">>> Updating yarn lock file in {config.source_dir}")
+    check_run(["yarn", "install"], cwd=config.source_dir, capture_output=False)
+
     print("")
 
 

--- a/create-release.py
+++ b/create-release.py
@@ -484,15 +484,15 @@ def checkout_code() -> None:
 
     print("")
 
-def build_all():
+def update_yarn_lock():
     global config
 
     print("-----------------------------------------------------------------")
-    print("----------------------- Building (Prod)  ------------------------")
+    print("----------------------- Update Yarn lock ------------------------")
     print("-----------------------------------------------------------------")
 
     # Build wheels and source packages
-    check_run(["make", "install-prod"], cwd=config.source_dir, capture_output=False)
+    check_run(["make", "release"], cwd=config.source_dir, capture_output=False)
 
     print("")
 
@@ -798,7 +798,7 @@ def prepare_release() -> None:
     # back to development
     update_version_to_dev()
     # build packages to update yarn.lock
-    build_all()
+    update_yarn_lock()
     # commit
     check_run(["git", "commit", "-s", "-a", "-m", f"Prepare for next development iteration"], cwd=config.source_dir)
     # prepare extensions

--- a/create-release.py
+++ b/create-release.py
@@ -53,6 +53,7 @@ class UpdateVersionException(Exception):
 
 
 def check_run(args, cwd=os.getcwd(), capture_output=True, env=None, shell=False) -> subprocess.CompletedProcess:
+    """Run a command and return the response"""
     try:
         return subprocess.run(args, cwd=cwd, capture_output=capture_output, check=True, env=env, shell=shell)
     except subprocess.CalledProcessError as ex:
@@ -60,6 +61,7 @@ def check_run(args, cwd=os.getcwd(), capture_output=True, env=None, shell=False)
 
 
 def check_output(args, cwd=os.getcwd(), env=None, shell=False) -> str:
+    """Run a command and return its output"""
     response = check_run(args, cwd, capture_output=True, env=env, shell=shell)
     return response.stdout.decode("utf-8").replace("\n", "")
 
@@ -267,21 +269,21 @@ def update_version_to_release() -> None:
         # UI packages
         sed(
             _source("lerna.json"),
-            fr"{old_npm_version}",
+            rf"{old_npm_version}",
             rf"{new_npm_version}",
         )
         sed(
             _source("package.json"),
-            fr"{old_npm_version}",
+            rf"{old_npm_version}",
             rf"{new_npm_version}",
         )
 
         packages_dir = os.path.join(config.source_dir, "packages")
         for dir in os.listdir(packages_dir):
             file_path = os.path.join(packages_dir, dir, "package.json")
-            sed(file_path,fr"{old_npm_version}",rf"{new_npm_version}")
+            sed(file_path, rf"{old_npm_version}", rf"{new_npm_version}")
             file_path = os.path.join(packages_dir, dir, "install.json")
-            sed_remove(file_path, fr"packageManager")
+            sed_remove(file_path, rf"packageManager")
 
     except Exception as ex:
         raise UpdateVersionException from ex
@@ -437,22 +439,20 @@ def update_version_to_dev() -> None:
 
         sed(
             _source("lerna.json"),
-            fr"{new_npm_version}",
+            rf"{new_npm_version}",
             rf"{dev_npm_version}",
         )
 
         sed(
             _source("package.json"),
-            fr"{new_npm_version}",
+            rf"{new_npm_version}",
             rf"{dev_npm_version}",
         )
 
         packages_dir = os.path.join(config.source_dir, "packages")
         for dir in os.listdir(packages_dir):
             file_path = os.path.join(packages_dir, dir, "package.json")
-            sed(file_path,fr"{new_npm_version}",rf"{dev_npm_version}")
-
-
+            sed(file_path, rf"{new_npm_version}", rf"{dev_npm_version}")
 
     except Exception as ex:
         raise UpdateVersionException from ex
@@ -484,6 +484,7 @@ def checkout_code() -> None:
 
     print("")
 
+
 def update_yarn_lock():
     global config
 
@@ -495,6 +496,7 @@ def update_yarn_lock():
     check_run(["make", "release"], cwd=config.source_dir, capture_output=False)
 
     print("")
+
 
 def build_release():
     global config
@@ -560,7 +562,7 @@ def copy_extension_dir(extension: str, work_dir: str) -> None:
     global config
 
     extension = extension.replace("-", "_")
-    extension_package_source_dir = os.path.join(config.source_dir, f"labextensions/elyra_{extension}" )
+    extension_package_source_dir = os.path.join(config.source_dir, f"labextensions/elyra_{extension}")
     extension_package_dest_dir = os.path.join(work_dir, f"labextensions/elyra_{extension}")
     os.makedirs(os.path.dirname(extension_package_dest_dir), exist_ok=True)
     shutil.copytree(extension_package_source_dir, extension_package_dest_dir)

--- a/create-release.py
+++ b/create-release.py
@@ -493,7 +493,8 @@ def update_yarn_lock():
     print("-----------------------------------------------------------------")
 
     # Build wheels and source packages
-    check_run(["make", "release"], cwd=config.source_dir, capture_output=False)
+    print(f">>> Updating yarn lock file in {config.source_dir}")
+    check_run(["yarn", "install"], cwd=config.source_dir, capture_output=False)
 
     print("")
 
@@ -506,6 +507,7 @@ def build_release():
     print("-----------------------------------------------------------------")
 
     # Build wheels and source packages
+    print(f">>> Building release in {config.source_dir}")
     check_run(["make", "release"], cwd=config.source_dir, capture_output=False)
 
     if not config.pre_release:
@@ -564,6 +566,7 @@ def copy_extension_dir(extension: str, work_dir: str) -> None:
     extension = extension.replace("-", "_")
     extension_package_source_dir = os.path.join(config.source_dir, f"labextensions/elyra_{extension}")
     extension_package_dest_dir = os.path.join(work_dir, f"labextensions/elyra_{extension}")
+    print(f">>>Copying extension package from {extension_package_source_dir} to {extension_package_dest_dir}")
     os.makedirs(os.path.dirname(extension_package_dest_dir), exist_ok=True)
     shutil.copytree(extension_package_source_dir, extension_package_dest_dir)
 

--- a/create-release.py
+++ b/create-release.py
@@ -57,7 +57,15 @@ def check_run(args, cwd=os.getcwd(), capture_output=True, env=None, shell=False)
     try:
         return subprocess.run(args, cwd=cwd, capture_output=capture_output, check=True, env=env, shell=shell)
     except subprocess.CalledProcessError as ex:
-        raise RuntimeError(f'Error executing process: {ex.stderr.decode("unicode_escape")}') from ex
+        # Safely extract error message
+        if ex.stderr is None:
+            error_msg = "No error output available"
+        elif isinstance(ex.stderr, bytes):
+            error_msg = ex.stderr.decode("utf-8", errors="replace")
+        else:
+            error_msg = str(ex.stderr)
+        
+        raise RuntimeError(f'Error executing process: {error_msg}') from ex
 
 
 def check_output(args, cwd=os.getcwd(), env=None, shell=False) -> str:

--- a/create-release.py
+++ b/create-release.py
@@ -130,7 +130,7 @@ def update_version_to_release() -> None:
     try:
         # Update backend version
         sed(_source(".bumpversion.cfg"), rf"^current_version* =* {old_version}", f"current_version = {new_version}")
-        sed(_source("elyra/_version.py"), rf'^__version__* =* "{old_version}"', f'__version__ = "{new_version}"'),
+        sed(_source("elyra/_version.py"), rf'^__version__* =* "{old_version}"', f'__version__ = "{new_version}"')
         sed(_source("README.md"), rf"elyra {old_version}", f"elyra {new_version}")
         sed(_source("docs/source/getting_started/installation.md"), rf"elyra {old_version}", f"elyra {new_version}")
 

--- a/create-release.py
+++ b/create-release.py
@@ -704,9 +704,9 @@ def generate_changelog() -> None:
                 # print(f'>>> {commit_hash} - {commit_title}')
                 if commit_title != "Prepare for next development iteration":
                     pr_string = ""
-                    pr = re.findall("\(#(.*?)\)", commit_title)
+                    pr = re.findall(r"\(#(.*?)\)", commit_title)
                     if pr:
-                        commit_title = re.sub("\(#(.*?)\)", "", commit_title).strip()
+                        commit_title = re.sub(r"\(#(.*?)\)", "", commit_title).strip()
                         pr_string = f" - [#{pr[0]}](https://github.com/elyra-ai/elyra/pull/{pr[0]})"
                     changelog_entry = f"- {commit_title}{pr_string}\n"
                     changelog.write(changelog_entry)

--- a/create-release.py
+++ b/create-release.py
@@ -195,13 +195,13 @@ def update_version_to_release() -> None:
 
         sed(
             _source("packages/theme/src/index.ts"),
-            r"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
         )
 
         sed(
             _source("packages/theme/src/index.ts"),
-            r"https://github.com/elyra-ai/elyra/releases/latest/",
+            re.escape("https://github.com/elyra-ai/elyra/releases/latest/"),
             rf"https://github.com/elyra-ai/elyra/releases/v{new_version}/",
         )
 
@@ -213,26 +213,26 @@ def update_version_to_release() -> None:
 
         sed(
             _source("elyra/cli/pipeline_app.py"),
-            r"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
         )
 
         # Update documentation version for elyra-metadata cli help
         sed(
             _source("elyra/metadata/metadata_app_utils.py"),
-            r"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
         )
 
         sed(
             _source("packages/pipeline-editor/src/EmptyPipelineContent.tsx"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         sed(
             _source("packages/pipeline-editor/src/PipelineEditorWidget.tsx"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
@@ -240,50 +240,50 @@ def update_version_to_release() -> None:
         # located in elyra/metadata/schemas/
         sed(
             _source("elyra/metadata/schemas/url-catalog.json"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         sed(
             _source("elyra/metadata/schemas/local-directory-catalog.json"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         sed(
             _source("elyra/metadata/schemas/local-file-catalog.json"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         sed(
             _source("elyra/metadata/schemas/airflow.json"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         sed(
             _source("elyra/metadata/schemas/kfp.json"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         sed(
             _source("elyra/metadata/schemas/code-snippet.json"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         sed(
             _source("elyra/metadata/schemas/runtime-image.json"),
-            r"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
         )
 
         # Update documentation references in documentation
         sed(
             _source("docs/source/user_guide/jupyterlab-interface.md"),
-            r"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
         )
 
@@ -387,13 +387,13 @@ def update_version_to_dev() -> None:
         sed(
             _source("packages/theme/src/index.ts"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
-            rf"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
         )
 
         sed(
             _source("packages/theme/src/index.ts"),
             rf"https://github.com/elyra-ai/elyra/releases/v{new_version}/",
-            rf"https://github.com/elyra-ai/elyra/releases/latest/",
+            re.escape("https://github.com/elyra-ai/elyra/releases/latest/"),
         )
 
         sed(
@@ -406,32 +406,32 @@ def update_version_to_dev() -> None:
         sed(
             _source("docs/source/user_guide/jupyterlab-interface.md"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
-            r"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
         )
 
         sed(
             _source("elyra/cli/pipeline_app.py"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
-            rf"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
         )
 
         # Update documentation version for elyra-metadata cli help
         sed(
             _source("elyra/metadata/metadata_app_utils.py"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/",
-            rf"https://elyra.readthedocs.io/en/latest/",
+            re.escape("https://elyra.readthedocs.io/en/latest/"),
         )
 
         sed(
             _source("packages/pipeline-editor/src/EmptyPipelineContent.tsx"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         sed(
             _source("packages/pipeline-editor/src/PipelineEditorWidget.tsx"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         # Update GitHub references in documentation
@@ -461,43 +461,43 @@ def update_version_to_dev() -> None:
         sed(
             _source("elyra/metadata/schemas/url-catalog.json"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         sed(
             _source("elyra/metadata/schemas/local-directory-catalog.json"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         sed(
             _source("elyra/metadata/schemas/local-file-catalog.json"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         sed(
             _source("elyra/metadata/schemas/airflow.json"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         sed(
             _source("elyra/metadata/schemas/kfp.json"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         sed(
             _source("elyra/metadata/schemas/code-snippet.json"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         sed(
             _source("elyra/metadata/schemas/runtime-image.json"),
             rf"https://elyra.readthedocs.io/en/v{new_version}/user_guide/",
-            rf"https://elyra.readthedocs.io/en/latest/user_guide/",
+            re.escape("https://elyra.readthedocs.io/en/latest/user_guide/"),
         )
 
         sed(

--- a/create-release.py
+++ b/create-release.py
@@ -70,7 +70,7 @@ def dependency_exists(command) -> bool:
     """Returns true if a command exists on the system"""
     try:
         check_run(["which", command])
-    except subprocess.CalledProcessError:
+    except RuntimeError:
         return False
 
     return True

--- a/create-release.py
+++ b/create-release.py
@@ -279,11 +279,16 @@ def update_version_to_release() -> None:
         )
 
         packages_dir = os.path.join(config.source_dir, "packages")
-        for dir in os.listdir(packages_dir):
-            file_path = os.path.join(packages_dir, dir, "package.json")
-            sed(file_path, rf"{old_npm_version}", rf"{new_npm_version}")
-            file_path = os.path.join(packages_dir, dir, "install.json")
-            sed_remove(file_path, rf"packageManager")
+        if os.path.exists(packages_dir) and os.path.isdir(packages_dir):
+            for dir in os.listdir(packages_dir):
+                dir_path = os.path.join(packages_dir, dir)
+                if os.path.isdir(dir_path):
+                    file_path = os.path.join(dir_path, "package.json")
+                    if os.path.exists(file_path):
+                        sed(file_path, rf"{old_npm_version}", rf"{new_npm_version}")
+                    file_path = os.path.join(dir_path, "install.json")
+                    if os.path.exists(file_path):
+                        sed_remove(file_path, rf"packageManager")
 
     except Exception as ex:
         raise UpdateVersionException from ex
@@ -450,9 +455,13 @@ def update_version_to_dev() -> None:
         )
 
         packages_dir = os.path.join(config.source_dir, "packages")
-        for dir in os.listdir(packages_dir):
-            file_path = os.path.join(packages_dir, dir, "package.json")
-            sed(file_path, rf"{new_npm_version}", rf"{dev_npm_version}")
+        if os.path.exists(packages_dir) and os.path.isdir(packages_dir):
+            for dir in os.listdir(packages_dir):
+                dir_path = os.path.join(packages_dir, dir)
+                if os.path.isdir(dir_path):
+                    file_path = os.path.join(dir_path, "package.json")
+                    if os.path.exists(file_path):
+                        sed(file_path, rf"{new_npm_version}", rf"{dev_npm_version}")
 
     except Exception as ex:
         raise UpdateVersionException from ex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,6 @@ core-metadata-version = "2.3"
 core-metadata-version = "2.3"
 artifacts = [
     "labextensions/elyra_code_snippet_extension/labextension",
-    "labextensions/elyra_code_viewer_extension/labextension",
     "labextensions/elyra_metadata_common/labextension",
     "labextensions/elyra_metadata_extension/labextension",
     "labextensions/elyra_pipeline_editor_extension/labextension",


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update release script for Elyra 4.0 release
- Remove unnecessary steps (e.g., publish npm)
- Fix CodeQL security alert
- URL Regex Escaping: All URL patterns now use re.escape() - this completely resolves the CodeQL security alert about unescaped dots in hostnames.
- Path Traversal Protection: The _source() function now includes robust path validation to prevent directory traversal attacks.
 - Safe Directory Deletion: Added validation before shutil.rmtree() operations to prevent accidental deletion of important directories.
 - Robust stderr Processing: The check_run() function now safely handles different stderr types (None, bytes, string) with proper encoding.
 - Comprehensive Exception Handling: Better error messages and proper exception chaining throughout.
 - Pure Python Implementation: Replaced platform-specific sed shell commands with pure Python regex operations - much more reliable and maintainable.
 - File Existence Checks: Added proper validation before file operations.
 - Consistent Escaping: Version strings now use re.escape() consistently throughout both functions.
 - Directory Structure Validation: Added checks for directory existence before iterating through packages.
 - Minor Bug Fixes: Fixed incorrect variable references in logging statements.
  
### How was this pull request tested?
These updates were used to create the release candidates and final release.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
