### PR TITLE
Pin `click` package to version `8.1.8`

### DIFF
--- a/lint_requirements.txt
+++ b/lint_requirements.txt
@@ -1,5 +1,5 @@
 black[jupyter]>=22.8.0
-click>=8.0.0
+click==8.1.8  # 8.2.0 dropped support for Python 3.9
 flake8>=3.5.0
 flake8-import-order>=0.18.1
 flake8-pyproject>=1.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "autopep8>=1.5.0",
-    "click>=8",  # elyra-ai/elyra#2579
+    "click==8.1.8",  # elyra-ai/elyra#2579 -- 8.2.0 dropped support for Python 3.9
     "colorama",
     "deprecation",
     "entrypoints>=0.3",


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our [contributor guidelines](https://github.com/elyra-ai/community/blob/main/contributing.md)
    1.1 Please follow the [7 rules for a great commit message](https://github.com/elyra-ai/community/blob/main/contributing.md#creating-a-pull-request)
  2. If the PR is unfinished, leave it as 'DRAFT', add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...' or use the 'status:Work in Progress' label.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If this PR involves UI changes, please provide a screen capture (before/after) for a faster review.
  6. Remember to add 'Fixes #ISSUE_NUMBER' (or any [valid keyword](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)) to the end of your message body to get the issue properly closed when the PR is merged.
  7. Set the proper milestone based on the target release for the issue.
  8. Consider whether any documentation need to be added or updated based on your changes.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor code that leads to class changes, showing the updated class hierarchy will help reviewers.
  2. If there is design documentation, please add the link.
-->

One of the tests in `Test Server` started to fail (see [here](https://github.com/elyra-ai/elyra/actions/runs/14969394427/job/42046673290)) after the new version of the `click` package rolled out (`v8.2.0`) because the return code for a no-args call in the CLI changed from 0 to 2 (see more information [here](https://github.com/pallets/click/issues/2909)). Also, this [new version](https://github.com/pallets/click/releases/tag/8.2.0) dropped support for Python 3.9, so I'm pinning the version to the most compatible one with Elyra, which is `v8.1.8`, to get the CI back to green. We can revert this as soon as we drop support for Python 3.9 (EOL scheduled for October 2025).

### How was this pull request tested?
<!--
Please make sure to add some test cases that check the changes thoroughly
including negative and positive cases, if possible.

If changes were tested in a way different from regular unit tests, please clarify how you tested step by step,
ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.

If tests were not added, please describe why they were not added e.g. documentation only, GH workflow updates, etc.
-->
Through CI runs.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
