### PR TITLE
Cap jupyter-ai <3.0 and fix session shutdown race

### DIFF
--- a/JUPYTER_AI_3X_ISSUE.md
+++ b/JUPYTER_AI_3X_ISSUE.md
@@ -1,0 +1,130 @@
+# Jupyter AI 3.x Compatibility Issue
+
+## Summary
+
+The release of `jupyter-ai 3.0.0` introduces a transitive dependency on
+`jupyter-collaboration`, which installs `jupyter-server-ydoc` and its
+real-time collaboration infrastructure. This breaks Elyra's UI unit tests
+by causing `LookupError: No room found for session` errors during kernel
+session shutdown.
+
+## Root Cause
+
+`jupyter-ai 3.0` added a new dependency chain that did not exist in 2.x:
+
+```
+jupyter-ai >=3.0.0
+  -> jupyter-ai-router >=0.0.3
+    -> jupyter-collaboration >=4.0.0
+      -> jupyter-server-ydoc >=2.3.0
+        -> pycrdt-websocket
+```
+
+`jupyter-server-ydoc` registers a server extension that wraps Jupyter
+sessions in collaborative "rooms". When a session is deleted via
+`DELETE /api/sessions/<id>`, the ydoc layer attempts to find the
+corresponding room. If the session was not created through the
+collaboration flow (as is the case with programmatic `SessionManager`
+usage in tests), the room lookup fails with:
+
+```
+LookupError: No room found for session '<session-id>'
+```
+
+This causes `session.shutdown()` to throw a `500` error, which in turn
+causes test assertions like `expect(runner.sessionConnection).toBeNull()`
+to fail.
+
+## Why This Was Not an Issue Before
+
+`jupyter-ai 2.x` does **not** depend on `jupyter-collaboration`:
+
+```
+# jupyter-ai 2.x dependency tree (no collaboration stack)
+jupyter-ai 2.31.7
+  -> jupyter-ai-magics
+  -> (no jupyter-ai-router, no jupyter-collaboration)
+```
+
+Elyra's `pyproject.toml` specified `"jupyter-ai>=2.0.0"` without an
+upper bound, so pip resolved to `3.0.0` as soon as it was released on
+PyPI.
+
+## Why It Appeared to Be Python-Version Specific
+
+The failure initially appeared tied to Python 3.12+ because:
+
+- **Local development (Python 3.11):** `jupyter-ai` was either not
+  installed or was installed at a 2.x version before 3.0 existed.
+  Without `jupyter-collaboration`, the "room" infrastructure is absent
+  and session shutdown works normally.
+
+- **CI (Python 3.13):** A fresh `pip install` resolves `jupyter-ai` to
+  `3.0.0`, pulling in the full collaboration stack. The ydoc server
+  extension loads automatically when `jupyter-lab` starts, and session
+  deletion fails.
+
+The issue is **not Python-version specific** — it affects any
+environment where `jupyter-ai 3.0+` is installed.
+
+## Impact
+
+| Component | Effect |
+|-----------|--------|
+| `ScriptRunner.shutdownSession()` | `session.shutdown()` throws due to 500 from server |
+| UI unit test: "should shut down a kernel session" | `expect(runner.sessionConnection).toBeNull()` fails |
+| UI unit test: "should start a kernel session" | Unawaited `shutdownSession()` leaks into next test |
+| CI `test-ui` job | Fails consistently on any Python version |
+
+## Applied Fixes
+
+### 1. Cap `jupyter-ai` to `<3.0.0`
+
+**File:** `pyproject.toml`
+
+```python
+"jupyter-ai>=2.0.0,<3.0.0",  # 3.0 pulls in jupyter-collaboration which breaks session shutdown
+```
+
+This prevents the collaboration stack from being installed as a
+transitive dependency.
+
+### 2. Defensive `finally` block in `shutdownSession()`
+
+**File:** `packages/script-editor/src/ScriptRunner.ts`
+
+Moved `this.sessionConnection = null` from the `try` block into a
+`finally` block so that local state is always cleared, even if the
+server returns an error during shutdown.
+
+### 3. Missing `await` in test cleanup
+
+**File:** `packages/script-editor/src/test/script-editor.spec.ts`
+
+Added `await` to `runner.shutdownSession()` in the "should start a
+kernel session" test to prevent the unawaited shutdown from racing with
+the next test's session start.
+
+## Future Considerations
+
+When Elyra is ready to adopt `jupyter-ai 3.x`, the following options
+should be evaluated:
+
+1. **Disable `jupyter-server-ydoc` in test server configuration** by
+   passing `configData` to `JupyterServer.start()` with:
+   ```json
+   {
+     "ServerApp": {
+       "jpserver_extensions": {
+         "jupyter_server_ydoc": false
+       }
+     }
+   }
+   ```
+
+2. **Ensure the collaboration extension is compatible** with
+   programmatic session management (i.e., sessions created outside the
+   collaborative editing flow).
+
+3. **Pin or test against specific `jupyter-collaboration` versions** to
+   avoid surprise breakage from upstream releases.

--- a/packages/script-editor/src/ScriptRunner.ts
+++ b/packages/script-editor/src/ScriptRunner.ts
@@ -185,10 +185,11 @@ export class ScriptRunner {
 
       try {
         await this.sessionConnection.shutdown();
-        this.sessionConnection = null;
-        console.log(name + ' kernel shut down');
       } catch (e) {
         console.log('Exception: session shutdown = ' + JSON.stringify(e));
+      } finally {
+        this.sessionConnection = null;
+        console.log(name + ' kernel shut down');
       }
     }
   };

--- a/packages/script-editor/src/test/script-editor.spec.ts
+++ b/packages/script-editor/src/test/script-editor.spec.ts
@@ -82,7 +82,7 @@ describe('@elyra/script-editor', () => {
             'connecting'
           );
         }
-        runner.shutdownSession();
+        await runner.shutdownSession();
       });
 
       it('should shut down a kernel session', async () => {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
     "pygithub",
     "black>=22.8.0",
     # AI assistant dependencies
-    "jupyter-ai>=2.0.0",
+    "jupyter-ai>=2.0.0,<3.0.0",  # 3.0 pulls in jupyter-collaboration which breaks session shutdown in tests
     "jupyterlab-magic-wand>=0.1.0",
 ]
 classifiers = [


### PR DESCRIPTION
jupyter-ai 3.0 introduced a transitive dependency on jupyter-collaboration via jupyter-ai-router, which installs jupyter-server-ydoc. The ydoc extension wraps sessions in collaborative "rooms" and throws LookupError on session deletion when the session was created outside the
collaboration flow, causing UI unit test failures.

Cap jupyter-ai to <3.0.0 to avoid pulling in the
collaboration stack. Additionally, move sessionConnection null assignment to a finally block in shutdownSession() so local state is always cleared even on server errors, and add missing await in the test to prevent race conditions between sequential test runs.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
