### PR TITLE
Fix cypress submit notebook race condition

### DIFF
--- a/cypress/tests/submitnotebookbutton.cy.ts
+++ b/cypress/tests/submitnotebookbutton.cy.ts
@@ -42,6 +42,9 @@ describe('Submit Notebook Button tests', () => {
 
     openNewNotebookFile();
 
+    // Ensure notebook is dirty right before clicking Run as Pipeline
+    cy.get('.cm-content').first().type('# test');
+
     // Click submit notebook button
     cy.findByText(/run as pipeline/i).click();
 


### PR DESCRIPTION
Ensure the notebook is dirty right before clicking "Run as
Pipeline" by typing into the cell. JupyterLab's auto-save
could fire during the wait after opening a new notebook,
causing the save confirmation dialog to be skipped and the
test to fail looking for the "Save and Submit" button.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
