### PR TITLE
Update docs to align with current Elyra implementation

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -140,6 +140,75 @@ make lint
 - `pyproject.toml` - Python project configuration
 - `package.json` - JS/TS workspace configuration
 
+## Documentation Tone & Style
+
+When writing or updating documentation in `docs/source/`, follow the
+established tone and style conventions described below.
+
+### Voice
+
+- Use **third-person, impersonal, product-focused** language. The subject
+  should be "Elyra" or the feature itself, not the reader.
+  - *Yes:* "Elyra provides a Pipeline Visual Editor..."
+  - *No:* "We give you a Pipeline Visual Editor..."
+- Address the reader directly with "you" only in **instructional/procedural**
+  sections (installation steps, recipes, troubleshooting), not in conceptual
+  descriptions.
+
+### Tone
+
+- **Formal-neutral and technical.** No humor, colloquialisms, or
+  personality flourishes.
+- **No enthusiasm markers.** Avoid exclamation points, "exciting",
+  "powerful", or other marketing language. Adjectives should be strictly
+  functional (e.g., "enhanced", "reusable", "generic").
+- **Understated warnings.** Use inline `Note:` or `**NOTE:**` blocks
+  rather than dramatic callouts.
+- **Cautious hedging** where appropriate (e.g., "might work but have not
+  been tested").
+
+### Structure
+
+- Use **bulleted and numbered lists** liberally.
+- Follow a **hierarchical heading structure** (H2 > H3 > H4 > H5) for
+  reference-style content.
+- Write procedural sections as **numbered step-by-step** instructions.
+- Include **screenshots and GIFs** as primary illustration where
+  applicable.
+- Add frequent **cross-references** to other doc pages and external
+  resources using relative links.
+- For property/configuration reference sections, use a
+  **definition-style** format: property name followed by a dash and its
+  description.
+
+### Sentence Style
+
+- Prefer **long, information-dense sentences** that pack multiple related
+  concepts together over short, choppy ones.
+- Favor **noun phrases** over verb phrases where natural (e.g., "the
+  conversion of multiple notebooks" rather than "converting multiple
+  notebooks").
+
+### Terminology
+
+- *Italicize* key terms on first use (e.g., _pipeline_, _nodes_,
+  _component_).
+- **Bold** product names and feature names on first mention.
+- Use technical terms (PVC, DAG, KubernetesPodOperator) without
+  simplification — assume a **technically proficient audience** familiar
+  with Jupyter, Kubernetes, and ML pipeline concepts.
+
+### Summary
+
+| Attribute             | Description                                        |
+|-----------------------|----------------------------------------------------|
+| **Formality**         | High — enterprise product documentation style      |
+| **Personality**       | Minimal — intentionally neutral                    |
+| **Audience**          | Intermediate-to-advanced (Jupyter, K8s, ML)        |
+| **Primary mode**      | Reference/procedural, not tutorial/narrative        |
+| **Brevity**           | Low — thorough, sometimes verbose explanations     |
+| **Consistency**       | High — follow the shared template across sections  |
+
 ## Testing Guidelines
 
 - All new features must include tests

--- a/docs/source/recipes/configure-airflow-as-a-runtime.md
+++ b/docs/source/recipes/configure-airflow-as-a-runtime.md
@@ -21,8 +21,6 @@ limitations under the License.
 
 Pipelines in Elyra can be run locally in JupyterLab, or remotely on Kubeflow Pipelines or Apache Airflow to take advantage of shared resources that speed up processing of compute intensive tasks.
 
-**Note: Support for Apache Airflow is experimental.**
-
 This document outlines how to set up a new Elyra-enabled Apache Airflow environment or add Elyra support to an existing deployment.
 Elyra 4 supports Apache Airflow 2.7.0+ and 3.x with automatic version detection and backward compatibility.
 Generic components DAG code generation support for Airflow 1.x is removed in Elyra 4.

--- a/docs/source/user_guide/best-practices-file-based-nodes.md
+++ b/docs/source/user_guide/best-practices-file-based-nodes.md
@@ -17,7 +17,7 @@ limitations under the License.
 -->
 ## Best practices for file-based pipeline nodes
 
-[Generic pipelines and typed pipelines](pipelines.md) support natively file-based nodes for  Jupyter notebooks, Python scripts, and R scripts. In order to support heterogeneous execution - that is making them runnable in any runtime environment (JupyterLab, Kubeflow Pipelines, and Apache Airflow) - follow the guidelines listed below.
+[Generic pipelines and runtime specific pipelines](pipelines.md) support natively file-based nodes for  Jupyter notebooks, Python scripts, and R scripts. In order to support heterogeneous execution - that is making them runnable in any runtime environment (JupyterLab, Kubeflow Pipelines, and Apache Airflow) - follow the guidelines listed below.
 
 ### Runtime image
 

--- a/docs/source/user_guide/env-variables-file-based-nodes.md
+++ b/docs/source/user_guide/env-variables-file-based-nodes.md
@@ -17,7 +17,7 @@ limitations under the License.
 -->
 ## System-level environment variables used in file-based pipeline nodes
 
-[Generic pipelines and typed pipelines](pipelines.md) support natively file-based nodes for  Jupyter notebooks, Python scripts, and R scripts. In order to support heterogeneous execution - that is making them runnable to your requiremenents in any runtime environment (JupyterLab, Kubeflow Pipelines, and Apache Airflow) - follow the documentation on environment variables listed below.
+[Generic pipelines and runtime specific pipelines](pipelines.md) support natively file-based nodes for  Jupyter notebooks, Python scripts, and R scripts. In order to support heterogeneous execution - that is making them runnable to your requirements in any runtime environment (JupyterLab, Kubeflow Pipelines, and Apache Airflow) - follow the documentation on environment variables listed below.
 
 There are system-level environment variables for two types of scopes:
 - Jupyterlab pipeline generation and validation (PipelineProcessor)
@@ -76,3 +76,105 @@ Background:
 In air-gapped environments (where internet access is restricted), Elyra cannot automatically download its dependencies. Additionally, in some cases, the required packages may already be installed on the system.
 
 If your environment already has Elyra’s dependencies available, you can set **`ELYRA_INSTALL_PACKAGES`** to **`false`** to avoid installing them again or to avoid having errors in air-gapped environments.
+
+### `ELYRA_WRITABLE_CONTAINER_DIR`
+
+Scope: Runtime image task (Airflow) or component (KFP) execution of file-based node Jupyter notebooks, Python scripts, and R scripts
+
+Impact: Specifies the writable directory inside the container where Elyra stores temporary files during pipeline execution.
+
+Default: `/tmp`
+
+Background:
+During generic node execution in Kubeflow Pipelines or Apache Airflow, the bootstrapper needs a writable directory to download dependencies, scripts, and notebook files. If the container’s default `/tmp` directory is not writable or has limited space, set this variable to an alternative path.
+
+If you want to change the writable container directory, you can set `ELYRA_WRITABLE_CONTAINER_DIR` in either
+- Pipeline Editor at Pipeline Properties - Generic Node Defaults - Environment Variables or at Node Properties - Additional Properties - Environment Variables
+- Statically baked into the runtime image container definition
+
+### `ELYRA_WRITABLE_CONTAINER_DIR` (JupyterLab scope)
+
+Scope: JupyterLab PipelineProcessor (used during pipeline generation for KFP and Airflow)
+
+Impact: The value is embedded in the generated pipeline code to configure the container working directory for each generic node.
+
+Default: `/tmp`
+
+### `CRIO_RUNTIME`
+
+Scope: JupyterLab PipelineProcessor (KFP pipeline generation only)
+
+Impact: Enables CRI-O container runtime-specific workarounds during KFP pipeline generation. When set to `True`, the generated pipeline code includes additional configuration for pip and writable volume mounts required by CRI-O environments.
+
+Default: `False`
+
+If you want to enable CRI-O-specific behavior, set `CRIO_RUNTIME` to `True` in the JupyterLab environment where pipelines are submitted.
+
+### `ELYRA_BOOTSTRAP_SCRIPT_URL`
+
+Scope: JupyterLab PipelineProcessor (KFP and Airflow pipeline generation)
+
+Impact: Overrides the URL for the bootstrap script that is downloaded and executed in the container during generic node execution. By default, the URL is constructed from the Elyra GitHub repository (`elyra-ai/elyra`, current release branch).
+
+Default: Constructed as `https://raw.githubusercontent.com/{org}/{repo}/{branch}/elyra/kfp/bootstrapper.py`, where `{org}`, `{repo}`, and `{branch}` default to `elyra-ai`, `elyra`, and the current release tag (or `main` for development builds).
+
+You can also override the individual URL components using:
+- `ELYRA_GITHUB_ORG` (default: `elyra-ai`)
+- `ELYRA_GITHUB_REPO` (default: `elyra`)
+- `ELYRA_GITHUB_BRANCH` (default: `main` for development builds, `v{version}` for releases)
+
+### `ELYRA_REQUIREMENTS_URL`
+
+Scope: JupyterLab PipelineProcessor (KFP and Airflow pipeline generation)
+
+Impact: Overrides the URL for the `requirements-elyra.txt` file that lists Elyra’s runtime dependencies. This file is downloaded during generic node bootstrap and used to install the required Python packages.
+
+Default: Constructed from the same GitHub repository URL components as `ELYRA_BOOTSTRAP_SCRIPT_URL`.
+
+### `ELYRA_PIP_CONFIG_URL`
+
+Scope: JupyterLab PipelineProcessor (KFP pipeline generation, CRI-O environments only)
+
+Impact: Overrides the URL for the `pip.conf` file used in CRI-O environments. This variable is only used when `CRIO_RUNTIME` is set to `True`.
+
+Default: Constructed from the same GitHub repository URL components as `ELYRA_BOOTSTRAP_SCRIPT_URL`.
+
+### `ELYRA_CATALOG_CONNECTOR_MAX_READERS`
+
+Scope: JupyterLab component catalog connector
+
+Impact: Controls the maximum number of reader threads used to read catalog entries in parallel. Increasing this value may speed up catalog loading for large catalogs but will consume more system resources.
+
+Default: `3`
+
+### `ELYRA_CATALOG_UPDATE_TIMEOUT`
+
+Scope: JupyterLab component catalog refresh
+
+Impact: Time in seconds before a warning is logged if a catalog update is still in progress. This does not cancel the update; it only generates a log warning.
+
+Default: `15`
+
+### `ELYRA_WORKER_THREAD_WARNING_THRESHOLD`
+
+Scope: JupyterLab component catalog refresh
+
+Impact: Threshold for outstanding worker thread count. When the number of active catalog refresh threads exceeds this value, a warning is logged.
+
+Default: `10`
+
+### `ELYRA_METADATA_PATH`
+
+Scope: JupyterLab metadata storage
+
+Impact: Overrides the default metadata storage search paths. When set, the specified directories take highest priority when Elyra resolves metadata instances (runtime configurations, runtime images, code snippets, component catalogs). Accepts an OS-specific path-separator-delimited list of directories (`:` on Linux/macOS, `;` on Windows).
+
+Default: Not set. Elyra uses the standard Jupyter data directories.
+
+### `TRUSTED_CA_BUNDLE_PATH`
+
+Scope: JupyterLab (catalog connectors, URL downloads)
+
+Impact: Path to a PEM file containing trusted CA certificates. In environments where SSL server authenticity can only be validated using private public key infrastructure (PKI) with non-publicly-trusted certificate authorities, set this variable to the path of a PEM file containing the required certificates. Elyra uses this bundle for SSL verification when downloading component catalog entries or other resources over HTTPS.
+
+Default: Not set. Standard system CA certificates are used.

--- a/docs/source/user_guide/pipeline-components.md
+++ b/docs/source/user_guide/pipeline-components.md
@@ -436,6 +436,8 @@ Examples (CLI):
 
 #### Apache Airflow package catalog
 
+> **Deprecated in Elyra 4.** This catalog connector requires Apache Airflow 1.x, which Elyra 4 no longer supports. The section is retained for users of earlier Elyra releases.
+
 The [Apache Airflow package catalog connector](https://github.com/elyra-ai/elyra/tree/main/elyra/pipeline/airflow/package_catalog_connector) provides access to operators that are stored in Apache Airflow [built distributions](https://packaging.python.org/en/latest/glossary/#term-built-distribution):
 - Only the [wheel distribution format](https://packaging.python.org/en/latest/glossary/#term-Wheel) is supported.
 - Only Airflow < 2 is supported. Use of that functionality is not working in Elyra >=4, which is no longer supporting Airflow 1.x.
@@ -453,6 +455,9 @@ Examples:
    ``` 
 
 #### Apache Airflow provider package catalog
+
+> **Deprecated in Elyra 4.** This catalog connector requires Apache Airflow 1.x, which Elyra 4 no longer supports. The section is retained for users of earlier Elyra releases.
+
 The [Apache Airflow provider package catalog connector](https://github.com/elyra-ai/elyra/tree/main/elyra/pipeline/airflow/provider_package_catalog_connector) provides access to operators that are stored in [Apache Airflow provider packages](https://airflow.apache.org/docs/apache-airflow-providers/):
 - Only the [wheel distribution format](https://packaging.python.org/en/latest/glossary/#term-Wheel) is supported.
 - Only Airflow < 2 and operators for Airflow < 2 are supported. Use of that functionality is not working in Elyra >=4, which is no longer supporting Airflow 1.x. 

--- a/docs/source/user_guide/runtime-conf.md
+++ b/docs/source/user_guide/runtime-conf.md
@@ -27,7 +27,7 @@ A runtime configuration requires connectivity details for
 * A Kubeflow Pipelines deployment or an Apache Airflow deployment
 * S3-based Object Storage (e.g. Minio or IBM Cloud Object Storage)
 
-Note: Elyra is only tested with Kubeflow v1.5.x (Kubeflow Pipelines v1) and Apache Airflow v1.10.x.
+Note: Elyra 4.x is tested with Kubeflow Pipelines v2 and Apache Airflow 2.7.0+ and 3.x. Airflow 1.x is no longer supported.
 
 ### Managing runtime configurations using the JupyterLab UI
 
@@ -385,7 +385,7 @@ Example: `minio`
 
 ##### Cloud Object Storage password (cos_password)
 
-Password for cos_username, if credentials are required for the selected authentication type.
+Password for cos_username, if credentials are required for the selected authentication type. The password must be at least 8 characters long.
 
 Example: `minio123`
 

--- a/docs/source/user_guide/runtime-image-conf.md
+++ b/docs/source/user_guide/runtime-image-conf.md
@@ -228,6 +228,7 @@ If `Image Name` references a container image in a secured registry (requiring cr
 
 Restrictions:
  - Only supported for generic components.
+ - The secret name must conform to Kubernetes naming conventions: lowercase alphanumeric characters, hyphens, or dots, starting and ending with an alphanumeric character. Maximum length is 253 characters.
 
 Example:
 


### PR DESCRIPTION
- Replace stale runtime version note (KFP v1.5.x, Airflow v1.10.x) with current Elyra 4 support (KFP v2, Airflow 2.7.0+/3.x)
- Remove outdated "experimental" label for Airflow support
- Add cos_password minimum length constraint from JSON schema
- Add pull_secret naming conventions from JSON schema
- Document 11 previously undocumented environment variables
- Add deprecation notices to Airflow 1.x catalog sections
- Fix typos and rename "typed pipelines" to "runtime specific pipelines" for consistency
- Add documentation tone and style guide to AGENT.md

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
