### PR TITLE
Fix #3357: Broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Elyra currently includes the following functionality:
 - [Visual Pipeline Editor](https://elyra.readthedocs.io/en/latest/getting_started/overview.html#ai-pipelines-visual-editor)
 - [Ability to run a notebook, Python or R script as a batch job](https://elyra.readthedocs.io/en/latest/getting_started/overview.html#ability-to-run-a-notebook-python-or-r-script-as-a-batch-job)
 - [Reusable Code Snippets](https://elyra.readthedocs.io/en/latest/getting_started/overview.html#reusable-code-snippets)
-- [AI Assistant integration](https://github.com/jupyterlab/magic-wand) for AI-powered code assistance in notebook cells. See the [AI Assistant setup guide](docs/source/user_guide/ai-assistant-setup.md) for configuration details.
+- [AI Assistant integration](https://github.com/jupyterlab/jupyter-ai) for AI-powered code assistance in notebook cells. See the [AI Assistant setup guide](docs/source/user_guide/ai-assistant-setup.md) for configuration details.
 - [Hybrid runtime support](https://elyra.readthedocs.io/en/latest/getting_started/overview.html#hybrid-runtime-support) based on [Jupyter Enterprise Gateway](https://github.com/jupyter/enterprise_gateway)
 - [Python and R script editors with local/remote execution capabilities](https://elyra.readthedocs.io/en/latest/getting_started/overview.html#python-and-r-scripts-execution-support)
 - [Python script navigation using auto-generated Table of Contents](https://elyra.readthedocs.io/en/latest/getting_started/overview.html##python-and-r-scripts-execution-support)


### PR DESCRIPTION
Closes #3357

Fixes a broken link in `README.md` (line 37) where the "AI Assistant integration" anchor pointed to `https://github.com/jupyterlab/magic-wand`, a non-existent repository, replacing it with the correct URL `https://github.com/jupyterlab/jupyter-ai`.

- `README.md`: Updated the `href` in the "AI Assistant integration" list item under the feature overview section.

Verified by confirming `https://github.com/jupyterlab/jupyter-ai` resolves to the active JupyterLab AI extension repository and that the surrounding links in the feature list remain intact.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*