### PR TITLE
Update runtime images and fix dependency conflicts

### DIFF
--- a/cypress/tests/pipeline.cy.ts
+++ b/cypress/tests/pipeline.cy.ts
@@ -909,11 +909,14 @@ const RUNTIME_IMAGE = 'continuumio/anaconda3:2024.02-1';
 
 // Wait for async-loaded select options before calling .select()
 const selectRuntimeImage = (): void => {
-  cy.get('select[id="root_component_parameters_runtime_image"]')
+  cy.get('select[id="root_component_parameters_runtime_image"]', {
+    timeout: 10000
+  })
     .find(`option[value="${RUNTIME_IMAGE}"]`)
     .should('exist');
   cy.get('select[id="root_component_parameters_runtime_image"]').select(
-    RUNTIME_IMAGE
+    RUNTIME_IMAGE,
+    { force: true }
   );
 };
 

--- a/etc/config/metadata/runtime-images/pandas.json
+++ b/etc/config/metadata/runtime-images/pandas.json
@@ -1,8 +1,8 @@
 {
-  "display_name": "Pandas 2.2.2",
+  "display_name": "Pandas 2.2.3",
   "metadata": {
-    "description": "Pandas 2.2.2",
-    "image_name": "amancevice/pandas:jupyter-2.2.2",
+    "description": "Pandas 2.2.3",
+    "image_name": "amancevice/pandas:jupyter-2.2.3",
     "tags": ["pandas"]
   },
   "schema_name": "runtime-image"

--- a/etc/config/metadata/runtime-images/pytorch-devel.json
+++ b/etc/config/metadata/runtime-images/pytorch-devel.json
@@ -1,8 +1,8 @@
 {
   "display_name": "PyTorch 2.5.1 (with GPU support)",
   "metadata": {
-    "description": "Pytorch 2.5.1 with CUDA 11.8 devel",
-    "image_name": "pytorch/pytorch:2.5.1-cuda11.8-cudnn9-devel",
+    "description": "Pytorch 2.5.1 with CUDA 12.1 devel",
+    "image_name": "pytorch/pytorch:2.5.1-cuda12.1-cudnn9-devel",
     "tags": ["gpu", "pytorch"]
   },
   "schema_name": "runtime-image"

--- a/etc/config/metadata/runtime-images/pytorch-runtime.json
+++ b/etc/config/metadata/runtime-images/pytorch-runtime.json
@@ -1,8 +1,8 @@
 {
   "display_name": "PyTorch 2.5.1 (with GPU support)",
   "metadata": {
-    "description": "Pytorch 2.5.1 with CUDA 11.8 runtime",
-    "image_name": "pytorch/pytorch:2.5.1-cuda11.8-cudnn9-runtime",
+    "description": "Pytorch 2.5.1 with CUDA 12.1 runtime",
+    "image_name": "pytorch/pytorch:2.5.1-cuda12.1-cudnn9-runtime",
     "tags": ["gpu", "pytorch"]
   },
   "schema_name": "runtime-image"

--- a/etc/config/metadata/runtime-images/r.json
+++ b/etc/config/metadata/runtime-images/r.json
@@ -1,8 +1,8 @@
 {
   "display_name": "R Script 4.3.1",
   "metadata": {
-    "description": "R Script 4.3.1 with Python 3.11.6",
-    "image_name": "jupyter/r-notebook:x86_64-python-3.11.6",
+    "description": "R Script 4.3.1 with Python 3.11",
+    "image_name": "quay.io/jupyter/r-notebook:python-3.11",
     "tags": ["R"]
   },
   "schema_name": "runtime-image"

--- a/etc/config/metadata/runtime-images/tensorflow_2x_gpu_py3.json
+++ b/etc/config/metadata/runtime-images/tensorflow_2x_gpu_py3.json
@@ -1,8 +1,8 @@
 {
-  "display_name": "Tensorflow 2.18.0 with GPU",
+  "display_name": "Tensorflow 2.19.0 with GPU",
   "metadata": {
-    "description": "TensorFlow 2.18.0 (with GPU and Python 3.11)",
-    "image_name": "tensorflow/tensorflow:2.18.0-gpu",
+    "description": "TensorFlow 2.19.0 (with GPU and Python 3.11)",
+    "image_name": "tensorflow/tensorflow:2.19.0-gpu",
     "tags": ["gpu", "tensorflow"]
   },
   "schema_name": "runtime-image"

--- a/etc/config/metadata/runtime-images/tensorflow_2x_py3.json
+++ b/etc/config/metadata/runtime-images/tensorflow_2x_py3.json
@@ -1,8 +1,8 @@
 {
-  "display_name": "Tensorflow 2.18.0",
+  "display_name": "Tensorflow 2.19.0",
   "metadata": {
-    "description": "TensorFlow 2.18.0 (with Python 3.11)",
-    "image_name": "tensorflow/tensorflow:2.18.0",
+    "description": "TensorFlow 2.19.0 (with Python 3.11)",
+    "image_name": "tensorflow/tensorflow:2.19.0",
     "tags": ["tensorflow"]
   },
   "schema_name": "runtime-image"


### PR DESCRIPTION
- Update Pandas runtime image to 2.2.3
- Update PyTorch runtime and devel images to 2.5.1 with CUDA 12.1
- Update TensorFlow runtime images to 2.19.0
- Update R runtime image to use quay.io registry and python-3.11 tag
- Maintain Python 3.11 consistency across updated images

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
