### PR TITLE
Resolve urllib3 conflict and update to v2.6.3

### DIFF
--- a/elyra/tests/kfp/resources/test-requirements-elyra.txt
+++ b/elyra/tests/kfp/resources/test-requirements-elyra.txt
@@ -17,5 +17,5 @@ pyzmq==26.4.0
 requests==2.25.1
 tornado==6.1.0
 traitlets==4.3.3
-urllib3==1.26.5
+urllib3==2.6.3
 zebra===0.1.32

--- a/elyra/tests/kfp/test_bootstrapper.py
+++ b/elyra/tests/kfp/test_bootstrapper.py
@@ -26,9 +26,9 @@ import sys
 from tempfile import TemporaryFile
 import time
 from typing import Optional
+from unittest import mock
 
 import minio
-import mock
 import nbformat
 import papermill
 import pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,10 @@ dependencies = [
     "tornado>=6.1.0",
     "traitlets>=4.3.2",
     "typing-extensions>=3.10",
-    "urllib3>=1.26.5",
+    "urllib3>=2.5.0",
     "watchdog>=2.1.3",
     "websocket-client",
     "yaspin",
-    # see: https://stackoverflow.com/questions/76175487/sudden-importerror-cannot-import-name-appengine-from-requests-packages-urlli
-    "appengine-python-standard",
     "kfp>=2.0.0", # Cap kfp for protobuf compatibility
     "kfp-kubernetes>=1.0.0",
     "pygithub",


### PR DESCRIPTION
 - Remove appengine-python-standard which is no longer needed with
      modern dependencies and restricted urllib3 to <2.
 - Update urllib3 to >=2.5.0 in pyproject.toml to address CVEs.
 - Update urllib3 to 2.6.3 in test requirements.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
