### PR TITLE
Fix flaky pythoneditor Cypress race on launcher visibility

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -251,8 +251,10 @@ Cypress.Commands.add('resetJupyterLab', (): void => {
   cy.findByRole('tab', { name: /file browser/i, timeout: 25000 }).should(
     'exist'
   );
-  // Wait for the launcher to be fully rendered
-  cy.get('.jp-Launcher', { timeout: 10000 }).should('be.visible');
+  // Wait for the launcher to be the active main-area widget (not just present in DOM).
+  cy.get('.jp-MainAreaWidget.jp-Activity:not(.lm-mod-hidden) .jp-Launcher', {
+    timeout: 10000
+  }).should('be.visible');
 });
 
 Cypress.Commands.add('checkTabMenuOptions', (fileType: string): void => {
@@ -268,9 +270,30 @@ Cypress.Commands.add('closeTab', (index: number): void => {
   cy.get('.lm-TabBar-tabCloseIcon:visible').eq(index).click();
 });
 
+// Closes the active main-area document tab. Lumino disposes nested children
+// (e.g. the script editor's inner output dock), so this avoids the doubled-
+// closeTab race that occurs when an inner TabBar adds a second close icon.
+Cypress.Commands.add('closeCurrentEditor', (): void => {
+  cy.get(
+    '.lm-DockPanel-tabBar .lm-TabBar-tab[data-type="document-title"] .lm-TabBar-tabCloseIcon:visible'
+  )
+    .last()
+    .click();
+});
+
 Cypress.Commands.add('createNewScriptEditor', (language: string): void => {
-  // Ensure launcher is visible (may take a moment after closing a previous tab)
-  cy.get('.jp-Launcher', { timeout: 10000 }).should('be.visible');
+  // Match only a launcher whose parent main-area widget is currently active;
+  // a hidden launcher (lm-mod-hidden parent) would fail be.visible and flake.
+  const visibleLauncherSelector =
+    '.jp-MainAreaWidget.jp-Activity:not(.lm-mod-hidden) .jp-Launcher';
+  cy.get('body').then(($body) => {
+    if ($body.find(visibleLauncherSelector).length === 0) {
+      // Self-heal: no active launcher (e.g. another widget is the active tab).
+      cy.findByRole('menuitem', { name: /^file$/i }).click();
+      cy.findByText(/^new launcher$/i).click({ force: true });
+    }
+  });
+  cy.get(visibleLauncherSelector, { timeout: 10000 }).should('be.visible');
   cy.get(
     `.jp-LauncherCard[data-category="Elyra"][title="Create a new ${language} Editor"]:visible`
   ).click();

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -41,6 +41,7 @@ declare namespace Cypress {
     resetJupyterLab(): Chainable<void>;
     checkTabMenuOptions(fileType: string): Chainable<void>;
     closeTab(index: number): Chainable<void>;
+    closeCurrentEditor(): Chainable<void>;
     createNewScriptEditor(language: string): Chainable<void>;
     checkScriptEditorToolbarContent(): Chainable<void>;
     checkRightClickTabContent(fileType: string): Chainable<void>;

--- a/cypress/tests/pythoneditor.cy.ts
+++ b/cypress/tests/pythoneditor.cy.ts
@@ -137,11 +137,8 @@ describe('Python Editor tests', () => {
     cy.get('button[title="Top"]').should('be.visible');
     cy.get('button[title="Bottom"]').should('be.visible');
 
-    //close console tab
-    cy.closeTab(-1);
-
-    // Close editor tab
-    cy.closeTab(-1);
+    // Closing the editor disposes the inner output dock too.
+    cy.closeCurrentEditor();
   });
 
   it('open Python file with expected content', () => {
@@ -158,11 +155,7 @@ describe('Python Editor tests', () => {
       'Hello Elyra'
     );
 
-    //close console tab
-    cy.closeTab(-1);
-
-    // Close editor tab
-    cy.closeTab(-1);
+    cy.closeCurrentEditor();
   });
 
   // check for error message running an invalid code
@@ -184,11 +177,7 @@ describe('Python Editor tests', () => {
       'SyntaxError'
     );
 
-    //close console tab
-    cy.closeTab(-1);
-
-    // Close editor tab
-    cy.closeTab(-1);
+    cy.closeCurrentEditor();
 
     // Dismiss save your work dialog by discarding changes
     cy.get('button.jp-mod-warn').click();


### PR DESCRIPTION
The script editor renders its OutputArea inside its own internal dockPanel (ScriptEditor.tsx:306-340), so clicking Run adds a second visible .lm-TabBar-tabCloseIcon to the DOM. Tests then closed two tabs back-to-back via cy.closeTab(-1), opening a mid-tear-down window where the next test's cy.get('.jp-Launcher').should('be.visible') matched a launcher whose parent dock-panel widget still carried lm-mod-hidden, intermittently failing checks for Error message.

Add closeCurrentEditor that targets the main-area document tab once; Lumino disposes the nested output dock as a side effect, so the doubled close is no longer needed. Replace the three doubled cy.closeTab(-1) pairs in pythoneditor.cy.ts.

Tighten the launcher visibility selector in resetJupyterLab and createNewScriptEditor to require an active (non-hidden) parent widget, with a self-heal fallback that opens File > New Launcher if no active launcher is present. This is defense in depth for any future spec that re-introduces the inner-dock pattern.


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
