### PR TITLE
Fix pipeline unsaved-changes state and Cypress CI on Lab 4.6.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,6 +220,9 @@ jobs:
       - name: Collect logs
         uses: actions/upload-artifact@v4
         if: failure()
+        # jupyter_builder writes extension build tracebacks to
+        # /tmp/jupyterlab-debug-*.log and only prints the path, so a failing
+        # `make build-ui-prod` is otherwise undiagnosable from the job log.
         with:
           name: elyra_test_artifacts-${{ matrix.name }}
           path: |
@@ -228,6 +231,7 @@ jobs:
             ${{ github.workspace }}/build/cypress/screenshots//**/*
             ${{ github.workspace }}/build/cypress/videos//**/*
             /home/runner/.npm/_logs/*.log
+            /tmp/jupyterlab-debug-*.log
 
   test-documentation-build:
     name: Test documentation build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,10 @@ jobs:
         run: |
           python3 ./.github/workflows/scripts/fetch_packages_metadata.py $days
       - name: Upload coverage reports to Codecov
-        if: ${{ matrix.python-version == env.PYTHON_VERSION }}
+        # always() so a failing test job still reports what it covered. Without
+        # it the upload is skipped, the flag's report goes missing, and Codecov
+        # reads that as a coverage drop on top of the test failure.
+        if: ${{ always() && matrix.python-version == env.PYTHON_VERSION }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -153,6 +156,7 @@ jobs:
       - name: Test
         run: make test-ui-unit
       - name: Upload coverage reports to Codecov
+        if: always()
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -212,6 +216,10 @@ jobs:
           CYPRESS_SPEC: ${{ matrix.spec }}
         run: make test-integration
       - name: Upload coverage reports to Codecov
+        # nyc writes the report even when the Cypress run fails, so upload it
+        # either way: a skipped upload drops this shard from the totals and
+        # shows up as a coverage regression rather than a test failure.
+        if: always()
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,65 @@
+# Codecov configuration for Elyra.
+#
+# Every value below is derived from what the repository already does or
+# already enforces, rather than introducing a new standard:
+#
+#   - the patch target matches the line/statement floor .nycrc already
+#     enforces for the UI packages (lines 70, statements 70)
+#   - the project threshold absorbs the rounding drift seen on real PRs
+#     (a three-line change moves the total by ~0.01%), which currently
+#     fails because an absent config means a 0% threshold
+#   - the flags match the three Cypress shards defined in build.yml
+#
+# Reference: https://docs.codecov.com/docs/codecovyml-reference
+
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  # Lower bound is the branch floor .nycrc enforces; upper bound is roughly
+  # where the project total sits today (~84%).
+  range: '50...85'
+
+  status:
+    project:
+      default:
+        # Compare against the base commit rather than a fixed number, so the
+        # bar tracks the project instead of needing to be edited.
+        target: auto
+        # Observed drift on small PRs is ~0.01-0.02%. This leaves room for
+        # that and for a shard reporting slightly differently, while still
+        # catching a real regression.
+        threshold: 0.5%
+        if_ci_failed: error
+    patch:
+      default:
+        # Codecov defaults this to `auto`, i.e. the project total (~84%),
+        # which is a stricter bar for new code than the project has ever
+        # enforced anywhere. 70% is the floor .nycrc already requires.
+        target: 70%
+        # New code that no test touches at all should still fail.
+        if_ci_failed: error
+
+# Cypress runs as three sharded jobs. When one shard fails to upload, its
+# share of the report goes missing and Codecov reads the gap as a coverage
+# drop -- the problem the `always()` conditions in build.yml work around.
+# Carrying the last known report forward for a missing flag addresses that
+# at the source.
+flag_management:
+  default_rules:
+    carryforward: true
+
+flags:
+  integration-pipeline:
+    carryforward: true
+  integration-editors:
+    carryforward: true
+  integration-misc:
+    carryforward: true
+
+comment:
+  layout: 'reach, diff, flags, files'
+  behavior: default
+  require_changes: false

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -255,7 +255,33 @@ Cypress.Commands.add('bootstrapFile', (name: string): void => {
   });
 });
 
+Cypress.Commands.add('shutdownAllKernels', (): void => {
+  // Deleting a session shuts down its kernel. The Jupyter API lives at the
+  // server root, while baseUrl points at /lab, so resolve against the origin.
+  const sessionsUrl = new URL(
+    '/api/sessions',
+    Cypress.config('baseUrl') ?? 'http://localhost:58888'
+  ).toString();
+
+  cy.request({ url: sessionsUrl, qs: { token: 'test' } }).then((response) => {
+    for (const session of response.body) {
+      cy.request({
+        method: 'DELETE',
+        url: `${sessionsUrl}/${session.id}`,
+        qs: { token: 'test' }
+      });
+    }
+  });
+});
+
 Cypress.Commands.add('resetJupyterLab', (): void => {
+  // `?reset` only resets the workspace layout: it closes tabs but leaves every
+  // kernel running, and the next page load reconnects to all of them. Left
+  // alone they accumulate across specs until a new notebook no longer reaches
+  // a live kernel. Shut them down before loading the page so the reconnects
+  // never happen.
+  cy.shutdownAllKernels();
+
   // open jupyterlab with a clean workspace
   cy.visit('?token=test&reset');
   cy.findByRole('tab', { name: /file browser/i, timeout: 25000 }).should(

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -221,24 +221,25 @@ Cypress.Commands.add('dragAndDropFileToPipeline', (name: string) => {
 });
 
 Cypress.Commands.add('savePipeline', (): void => {
-  cy.intercept('PUT', '**/api/contents/**').as('savePipelineFile');
+  // The Save Pipeline toolbar button is always enabled and calls
+  // DocumentContext.save(), which always writes to the contents API. So the
+  // save request can be waited on unconditionally, which is what keeps a
+  // following cy.readFile from racing the server-side write.
+  cy.intercept('PUT', /\/api\/contents\/.*\.pipeline/).as('savePipelineFile');
 
-  // Check if document has unsaved changes before clicking save
-  cy.document().then((doc) => {
-    const isDirty = doc.querySelector('.jp-Document.jp-mod-dirty') !== null;
+  cy.findByRole('button', { name: /save pipeline/i }).click();
 
-    cy.findByRole('button', { name: /save pipeline/i }).click();
+  // Wait for the server to finish writing the file
+  cy.wait('@savePipelineFile', { timeout: 20000 })
+    .its('response.statusCode')
+    .should('be.oneOf', [200, 201]);
 
-    if (isDirty) {
-      // Wait for the server to finish writing the file
-      cy.wait('@savePipelineFile');
-    }
-
-    // Confirm document is no longer dirty
-    cy.get('.jp-Document:not(.jp-mod-dirty)', { timeout: 10000 }).should(
-      'exist'
-    );
-  });
+  // Confirm the editor is no longer dirty. JupyterLab puts jp-mod-dirty on the
+  // widget's title, which renders on the tab -- never on the .jp-Document node.
+  cy.get('#jp-main-dock-panel .lm-TabBar-tab.lm-mod-current').should(
+    'not.have.class',
+    'jp-mod-dirty'
+  );
 });
 
 Cypress.Commands.add('openFile', (name: string): void => {

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -39,6 +39,7 @@ declare namespace Cypress {
     openFile(fileName: string): Chainable<void>;
     bootstrapFile(fileName: string): Chainable<void>;
     resetJupyterLab(): Chainable<void>;
+    shutdownAllKernels(): Chainable<void>;
     checkTabMenuOptions(fileType: string): Chainable<void>;
     closeTab(index: number): Chainable<void>;
     closeCurrentEditor(): Chainable<void>;

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -34,6 +34,7 @@ declare namespace Cypress {
     createPipeline(options?: {
       name?: string;
       type?: 'kfp' | 'airflow' | 'generic';
+      emptyPipeline?: string;
     }): Chainable<void>;
     savePipeline(): Chainable<void>;
     openFile(fileName: string): Chainable<void>;

--- a/cypress/tests/codesnippetfromselectedcells.cy.ts
+++ b/cypress/tests/codesnippetfromselectedcells.cy.ts
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+// The context menu item Elyra registers for `.jp-Cell`. It is registered with
+// isVisible: () => true, so once the extension has activated the item is
+// always in a cell's context menu -- only its enabled state varies.
+const SNIPPET_MENU_ITEM =
+  'li.lm-Menu-item[data-command="codesnippet:save-as-snippet"]';
+
 describe('Code snippet from cells tests', () => {
   beforeEach(() => {
     // Each test creates another notebook, which JupyterLab names
@@ -22,6 +28,13 @@ describe('Code snippet from cells tests', () => {
     cy.deleteFiles(['Untitled*.ipynb']);
 
     cy.resetJupyterLab();
+
+    // The code snippet extension registers its sidebar button and its cell
+    // context menu item in the same activate(), so waiting for the button is a
+    // precise signal that the menu item is registered too.
+    cy.get('.jp-SideBar [title*="Code Snippets"]', { timeout: 20000 }).should(
+      'exist'
+    );
 
     // Create new python notebook
     cy.get(
@@ -40,12 +53,9 @@ describe('Code snippet from cells tests', () => {
   it('test empty cell', () => {
     cy.get('.jp-Notebook').should('have.length', 1);
 
-    // Extension commands register asynchronously — use retry helper
-    openCellContextMenuWithSnippetItem();
+    openCellContextMenu();
 
-    cy.get(
-      'li.lm-Menu-item[data-command="codesnippet:save-as-snippet"]'
-    ).should('have.class', 'lm-mod-disabled');
+    cy.get(SNIPPET_MENU_ITEM).should('have.class', 'lm-mod-disabled');
   });
 
   it('test 1 cell', () => {
@@ -53,11 +63,11 @@ describe('Code snippet from cells tests', () => {
 
     cy.get('.jp-Notebook').should('have.length', 1);
 
-    openCellContextMenuWithSnippetItem();
+    openCellContextMenu();
 
-    cy.get(
-      'li.lm-Menu-item[data-command="codesnippet:save-as-snippet"]'
-    ).click();
+    cy.get(SNIPPET_MENU_ITEM)
+      .should('not.have.class', 'lm-mod-disabled')
+      .click();
 
     // Wait for snippet editor to open
     cy.get('.elyra-metadataEditor', { timeout: 10000 }).should('be.visible');
@@ -93,17 +103,13 @@ describe('Code snippet from cells tests', () => {
         shiftKey: true
       });
 
-    cy.get('div.lm-Widget.lm-Widget.jp-InputPrompt.jp-InputArea-prompt:visible')
-      .first()
-      .rightclick({
-        force: true
-      });
+    openCellContextMenu(
+      'div.lm-Widget.lm-Widget.jp-InputPrompt.jp-InputArea-prompt:visible'
+    );
 
-    openCellContextMenuWithSnippetItem();
-
-    cy.get(
-      'li.lm-Menu-item[data-command="codesnippet:save-as-snippet"]'
-    ).click();
+    cy.get(SNIPPET_MENU_ITEM)
+      .should('not.have.class', 'lm-mod-disabled')
+      .click();
 
     // Wait for snippet editor to open
     cy.get('.elyra-metadataEditor', { timeout: 10000 }).should('be.visible');
@@ -126,9 +132,14 @@ describe('Code snippet from cells tests', () => {
 // ----- Utility Functions
 // ------------------------------
 
-// Wait for kernel to reach idle status
+// Wait for the kernel of the notebook under test to reach idle status. Scoped
+// to the visible notebook panel: an unscoped [data-status="idle"] also matches
+// the status bar indicator and any other widget's, which reports idle while
+// this notebook is still connecting.
 const waitForKernelIdle = (): void => {
-  cy.get('[data-status="idle"]', { timeout: 30000 }).should('exist');
+  cy.get('.jp-NotebookPanel:visible [data-status="idle"]', {
+    timeout: 30000
+  }).should('exist');
 };
 
 // Populate cells by re-querying each by index to avoid stale DOM references
@@ -146,28 +157,16 @@ const populateCells = (): void => {
   });
 };
 
-// Retry opening context menu until the snippet command is registered.
-// Extension commands register asynchronously; the menu must be
-// re-opened to pick up newly available items.
-const openCellContextMenuWithSnippetItem = (maxRetries: number = 5): void => {
-  const attemptOpen = (remaining: number): void => {
-    cy.get('.jp-Cell').first().rightclick();
-    cy.get('ul.lm-Menu-content').should('exist');
-
-    cy.get('body').then(($body) => {
-      const hasItem =
-        $body.find(
-          'li.lm-Menu-item[data-command="codesnippet:save-as-snippet"]'
-        ).length > 0;
-
-      if (!hasItem && remaining > 0) {
-        // Dismiss menu and retry
-        cy.get('body').click(0, 0, { force: true });
-        cy.get('ul.lm-Menu-content').should('not.exist');
-        attemptOpen(remaining - 1);
-      }
-    });
-  };
-
-  attemptOpen(maxRetries);
+// Open a cell's context menu. Callers then assert on SNIPPET_MENU_ITEM, and
+// cy.get retries that query, which covers the extension registering its item
+// slightly after the page settles. force: true fires the event on the cell
+// itself, so the menu is always anchored on the .jp-Cell that Elyra's item is
+// registered against, whatever floats above it.
+//
+// Never dismiss a menu by clicking page coordinates: body (0, 0) lands on
+// JupyterLab's menu bar, and Lumino menu bars track the pointer once open, so
+// follow-up clicks walk into File > New > Notebook and Kernel > Interrupt.
+const openCellContextMenu = (target: string = '.jp-Cell'): void => {
+  cy.get(target).first().rightclick({ force: true });
+  cy.get('ul.lm-Menu-content').should('be.visible');
 };

--- a/cypress/tests/codesnippetfromselectedcells.cy.ts
+++ b/cypress/tests/codesnippetfromselectedcells.cy.ts
@@ -16,6 +16,11 @@
 
 describe('Code snippet from cells tests', () => {
   beforeEach(() => {
+    // Each test creates another notebook, which JupyterLab names
+    // Untitled.ipynb, Untitled1.ipynb, ... Clear them so they do not pile up
+    // across these tests or the other specs sharing this shard's workspace.
+    cy.deleteFiles(['Untitled*.ipynb']);
+
     cy.resetJupyterLab();
 
     // Create new python notebook
@@ -26,6 +31,10 @@ describe('Code snippet from cells tests', () => {
     // Wait for notebook and kernel to be ready
     cy.get('.jp-Notebook', { timeout: 10000 }).should('exist');
     waitForKernelIdle();
+  });
+
+  afterEach(() => {
+    cy.deleteFiles(['Untitled*.ipynb']);
   });
 
   it('test empty cell', () => {

--- a/cypress/tests/pipeline.cy.ts
+++ b/cypress/tests/pipeline.cy.ts
@@ -873,24 +873,42 @@ describe('Pipeline Editor tests', () => {
   it('exporting pipeline with unsaved changes should prompt to save', () => {
     cy.installRuntimeConfig({ type: 'kfp' });
 
-    cy.openFile('generic-test.pipeline');
-    cy.get('.common-canvas-drop-div').should('be.visible');
+    cy.createPipeline({ name: 'unsaved.pipeline', emptyPipeline });
 
-    // Adding a comment dirties the document without adding nodes, so the
-    // validation that runs ahead of the prompt still passes. Assert the dirty
-    // state so the prompt below has a precondition rather than a hope.
-    cy.findByRole('button', { name: /add comment/i }).click();
+    // Adding a node is a canvas edit, so it reaches onChange, which writes the
+    // new flow into the model and takes the document dirty. The empty pipeline
+    // snapshot test proves the round trip: it opens the same fixture, adds and
+    // deletes this notebook, and saves content the fixture does not carry.
+    cy.addFileToPipeline('helloworld.ipynb');
     cy.get(CURRENT_TAB_SELECTOR).should('have.class', 'jp-mod-dirty');
+
+    // Delete the node again. handleSubmission validates before it checks for
+    // unsaved changes, and a notebook node with no runtime image fails that
+    // validation, which would toast an error instead of prompting. An empty
+    // pipeline validates -- the invalid runtime config test above gets past
+    // this same check -- and the document stays dirty either way, because
+    // JupyterLab clears that flag on save, not on content matching disk.
+    cy.get('#jp-main-dock-panel').within(() => {
+      cy.findByText('helloworld.ipynb').rightclick();
+      cy.findByRole('menuitem', { name: /delete/i }).click();
+    });
+    cy.get(CURRENT_TAB_SELECTOR).should('have.class', 'jp-mod-dirty');
+
+    // Accepting the prompt saves, then carries on to the export dialog. Wait on
+    // the write rather than on the tab losing jp-mod-dirty: the save is the
+    // behaviour under test, and nothing else in this test writes a *.pipeline.
+    cy.intercept('PUT', /\/api\/contents\/.*\.pipeline/).as('savePipelineFile');
 
     cy.findByRole('button', { name: /export pipeline/i }).click();
 
     cy.contains('.jp-Dialog-buttonLabel', /Save and Submit/i).click();
 
-    // Accepting the prompt saves, then carries on to the export dialog
+    cy.wait('@savePipelineFile', { timeout: 20000 })
+      .its('response.statusCode')
+      .should('be.oneOf', [200, 201]);
+
     cy.get('.jp-Dialog-header').contains('Export pipeline');
     cy.findByRole('button', { name: /cancel/i }).click();
-
-    cy.get(CURRENT_TAB_SELECTOR).should('not.have.class', 'jp-mod-dirty');
   });
 
   it('generic pipeline toolbar should display expected runtime', () => {

--- a/cypress/tests/pipeline.cy.ts
+++ b/cypress/tests/pipeline.cy.ts
@@ -771,6 +771,10 @@ describe('Pipeline Editor tests', () => {
 
     cy.installRuntimeConfig({ type: 'kfp' });
 
+    // Save again so the export dialog opens directly, without the prompt to
+    // save that Elyra shows when the editor is dirty.
+    cy.savePipeline();
+
     // Validate all export options are available
     cy.findByRole('button', { name: /export pipeline/i }).click();
     cy.findByRole('option', { name: /yaml/i }).should('have.value', 'yaml');
@@ -785,6 +789,8 @@ describe('Pipeline Editor tests', () => {
     cy.savePipeline();
 
     cy.installRuntimeConfig({ type: 'airflow' });
+
+    cy.savePipeline();
 
     // Validate all export options are available
     cy.findByRole('button', { name: /export pipeline/i }).click();
@@ -827,6 +833,11 @@ describe('Pipeline Editor tests', () => {
     // Test Airflow export options
     cy.installRuntimeConfig({ type: 'airflow' });
 
+    // Elyra prompts to save before exporting whenever the editor is dirty.
+    // Installing a runtime configuration may or may not dirty the editor, so
+    // save first to make sure the export dialog opens directly.
+    cy.savePipeline();
+
     cy.findByRole('button', { name: /export pipeline/i }).click();
 
     // Validate all export options are available for airflow
@@ -840,9 +851,9 @@ describe('Pipeline Editor tests', () => {
     // Test KFP export options
     cy.installRuntimeConfig({ type: 'kfp' });
 
-    cy.findByRole('button', { name: /export pipeline/i }).click();
+    cy.savePipeline();
 
-    cy.contains('.jp-Dialog-buttonLabel', /Save and Submit/i).click();
+    cy.findByRole('button', { name: /export pipeline/i }).click();
 
     // Validate all export options are available for kfp
     cy.findByLabelText(/runtime platform/i).select('KUBEFLOW_PIPELINES');

--- a/cypress/tests/pipeline.cy.ts
+++ b/cypress/tests/pipeline.cy.ts
@@ -36,6 +36,12 @@ const emptyPipeline = `{
   "schemas": []
 }`;
 
+// The tab of the document under test. JupyterLab puts jp-mod-dirty on the
+// widget's title, which renders on the tab, so this is where unsaved state is
+// visible -- same element savePipeline checks.
+const CURRENT_TAB_SELECTOR =
+  '#jp-main-dock-panel .lm-TabBar-tab.lm-mod-current';
+
 describe('Pipeline Editor tests', () => {
   beforeEach(() => {
     cy.deleteFiles([
@@ -862,6 +868,29 @@ describe('Pipeline Editor tests', () => {
 
     // Dismiss dialog
     cy.findByRole('button', { name: /cancel/i }).click();
+  });
+
+  it('exporting pipeline with unsaved changes should prompt to save', () => {
+    cy.installRuntimeConfig({ type: 'kfp' });
+
+    cy.openFile('generic-test.pipeline');
+    cy.get('.common-canvas-drop-div').should('be.visible');
+
+    // Adding a comment dirties the document without adding nodes, so the
+    // validation that runs ahead of the prompt still passes. Assert the dirty
+    // state so the prompt below has a precondition rather than a hope.
+    cy.findByRole('button', { name: /add comment/i }).click();
+    cy.get(CURRENT_TAB_SELECTOR).should('have.class', 'jp-mod-dirty');
+
+    cy.findByRole('button', { name: /export pipeline/i }).click();
+
+    cy.contains('.jp-Dialog-buttonLabel', /Save and Submit/i).click();
+
+    // Accepting the prompt saves, then carries on to the export dialog
+    cy.get('.jp-Dialog-header').contains('Export pipeline');
+    cy.findByRole('button', { name: /cancel/i }).click();
+
+    cy.get(CURRENT_TAB_SELECTOR).should('not.have.class', 'jp-mod-dirty');
   });
 
   it('generic pipeline toolbar should display expected runtime', () => {

--- a/packages/pipeline-editor/src/PipelineEditorWidget.tsx
+++ b/packages/pipeline-editor/src/PipelineEditorWidget.tsx
@@ -174,6 +174,22 @@ const getDisplayName = (
   return schema?.title;
 };
 
+/**
+ * Mark a document as holding unsaved changes.
+ *
+ * JupyterLab 4.6 moved the dirty flag onto the shared model and stopped
+ * raising it when content changes, so a document that is not a text file or a
+ * notebook has to mark itself dirty after every write it makes to the model
+ * (jupyterlab/jupyterlab#18739). Without this the tab shows no unsaved-changes
+ * marker, closing the editor does not warn, and the prompt to save before
+ * running or exporting a pipeline never appears.
+ *
+ * @param context - Document context whose model was just written to.
+ */
+const markDirty = (context: DocumentRegistry.Context): void => {
+  context.model.dirty = true;
+};
+
 interface IPipelineEditorWidgetProps {
   context: DocumentRegistry.Context;
   browserFactory: IDefaultFileBrowser;
@@ -461,9 +477,15 @@ const PipelineWrapper: React.FC<
         {}
     );
     if (contextRef.current.isReady) {
-      contextRef.current.model.fromString(
-        JSON.stringify(pipelineJson, null, 2)
-      );
+      // The canvas reports a change whenever it settles, including when it
+      // settles on what the model already holds -- selecting a node is enough.
+      // Writing that back would take a just-saved document dirty again, so
+      // only write when the content actually differs.
+      const content = JSON.stringify(pipelineJson, null, 2);
+      if (contextRef.current.model.toString() !== content) {
+        contextRef.current.model.fromString(content);
+        markDirty(contextRef.current);
+      }
     }
   }, []);
 
@@ -516,6 +538,9 @@ const PipelineWrapper: React.FC<
               contextRef.current.model.fromString(
                 JSON.stringify(migratedPipeline, null, 2)
               );
+              // The dialog above tells the user the migration is not complete
+              // until the pipeline is saved, so it has to look unsaved.
+              markDirty(contextRef.current);
             } catch (migrationError) {
               if (migrationError instanceof ComponentNotFoundError) {
                 showDialog({
@@ -1044,6 +1069,7 @@ const PipelineWrapper: React.FC<
           }
         }
         contextRef.current.model.fromJSON(newPipeline);
+        markDirty(contextRef.current);
       }
     });
   }, []);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Three related changes, all falling out of the JupyterLab 4.6 upgrade.

**1. Restore the pipeline editor's unsaved-changes state (user-facing fix)**

JupyterLab 4.6 moved the document dirty flag onto the shared model and stopped
raising it on content change ([jupyterlab#18739][1], first released in 4.6.0).
Its release note calls this out as a backwards-incompatible change: extensions
implementing documents other than a text file or a notebook must now mark them
dirty themselves after each write.

The pipeline editor is such a document and never did, so on 4.6:

- a modified pipeline shows no unsaved-changes marker on its tab
- closing a modified pipeline does not warn
- `handleSubmission` never sees a dirty model, so the prompt to save before
  running or exporting stopped appearing altogether

The model content itself was still correct — `fromString` updates the source, so
a save writes the right file — only the flag was missing, which is why nothing
caught this until a test asserted the marker.

`PipelineEditorWidget` now marks the document dirty at each point it writes a
pipeline the user asked for: a canvas change, an accepted migration, and Clear.
The two remaining writes are deliberately left alone, as both seed a brand new
file and save it immediately, and a new pipeline should not open unsaved.

The canvas write is additionally guarded on the content having actually changed.
The canvas reports a change whenever it settles, selection included, and writing
identical content back would take a just-saved document dirty again.

**2. Stabilize the Cypress suite**

- `savePipeline` gated its wait for the contents `PUT` on `.jp-Document.jp-mod-dirty`,
  a selector that can never match — JupyterLab puts `jp-Document` on the widget
  node and `jp-mod-dirty` on the title, which renders on the tab. The command had
  no synchronization at all, letting `cy.readFile` race the server-side write.
  It now waits on the write unconditionally.
- The export-options tests expected the unsaved-changes dialog unconditionally,
  which only appears when the model is dirty. They now save first so the export
  dialog opens directly, and the save prompt gets its own dedicated test.
- Kernels are shut down between tests. `?reset` only resets workspace layout, so
  kernels accumulated across specs until a new notebook no longer reached a live one.
- Code snippet cell tests delete leftover notebooks, and the snippet context menu
  retry no longer drives the menu bar.
- Coverage uploads and JupyterLab build logs are collected even when tests fail.
  A skipped upload drops a shard from the totals and reads as a coverage
  regression rather than a test failure.

**3. Add `codecov.yml`**

The repository had no Codecov config, so both checks ran on defaults that fit
poorly: `project` defaults to a 0% threshold, making rounding drift a failure (a
three-line change moved the total by 0.01% and turned it red), and `patch`
defaults to the project total (~84%), holding every diff to a higher bar than the
project enforces anywhere else. Values are taken from what the repo already
declares — the patch target and range floor come from `.nycrc`, the flags from
the Cypress shard names in `build.yml`.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
