### PR TITLE
Serialize UI package builds to avoid yarn state race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,11 +149,16 @@ dev-dependencies:
 yarn-install:
 	yarn install
 
+# Each package's build shells out to `jupyter labextension build`, which runs
+# `jlpm` against the hoisted node_modules at the repo root. Concurrent builds
+# therefore race on node_modules/.yarn-state.yml and intermittently fail with
+# "ENOENT: no such file or directory, unlink '.../.yarn-state.yml'". Serialize
+# them, as test:unit already does in package.json.
 build-ui-prod: ## Build UI packages for production
-	lerna run build:prod --stream
+	lerna run build:prod --concurrency 1 --stream
 
 build-ui-dev: ## Build UI packages for development
-	lerna run build --stream
+	lerna run build --concurrency 1 --stream
 
 package-ui-prod: build-dependencies yarn-install lint-ui build-ui-prod ## Package UI for production
 


### PR DESCRIPTION
## What

Pass `--concurrency 1` to the `lerna run` invocations in `build-ui-prod` and
`build-ui-dev`.

## Why

Both targets ran lerna without a concurrency limit, so several workspace
packages built simultaneously. Each package build shells out to
`jupyter labextension build`, which runs `jlpm` against the **hoisted**
`node_modules` at the repository root — so every concurrent build mutates the
same `node_modules/.yarn-state.yml`.

When they overlap, one process removes the state file while another is still in
yarn's Link step, and that build dies:

```
@elyra/script-editor: YN0001: Error: ENOENT: no such file or directory,
  unlink '/home/runner/work/elyra/elyra/node_modules/.yarn-state.yml'
@elyra/script-editor: YN0000: Failed with errors in 2s 997ms
@elyra/script-editor: subprocess.CalledProcessError: Command '['jlpm']'
  returned non-zero exit status 1
```

The UI build then fails *before* Cypress starts. On CI this surfaces as a
`Run Integration Tests` failure with no test results and a misleading
`No coverage reports found` error, which makes it look like a test problem
rather than a build problem.

Observed on [PR #3397](https://github.com/elyra-ai/elyra/pull/3397)
([job](https://github.com/elyra-ai/elyra/actions/runs/31993693679/job/95281519939)),
where `@elyra/script-editor`, `@elyra/ui-components` and `@elyra/services` were
all in yarn's Link step within the same two seconds and script-editor lost the
race. Being a race, it is intermittent — the same job passed on other PRs from
the same base.

`package.json` already serializes the equivalent test target
(`"test:unit": "lerna run test --concurrency 1 --stream"`); the build targets
were simply never given the same treatment.

## Trade-off

Serializing costs some build wall-clock in exchange for a deterministic build.
The alternative — giving each package its own yarn state — runs against the
deliberately hoisted root `node_modules`, so serializing is the appropriate fix.

`watch --parallel` and `cy:instrument` are intentionally left parallel: the
former is a dev-loop task, and the latter only runs `nyc instrument` over each
package's own `src/`, touching no shared state.

## Testing

CI on this PR exercises `build-ui-prod` through the integration test jobs.
