### PR TITLE
Decouple code snippet cell tests from kernel status

### DIFF
--- a/cypress/tests/codesnippetfromselectedcells.cy.ts
+++ b/cypress/tests/codesnippetfromselectedcells.cy.ts
@@ -41,9 +41,17 @@ describe('Code snippet from cells tests', () => {
       '.jp-LauncherCard[data-category="Notebook"][title="Python 3 (ipykernel)"]'
     ).click();
 
-    // Wait for notebook and kernel to be ready
+    // Wait for the notebook's editor to be ready to accept input.
+    //
+    // Deliberately not a kernel-status wait: none of these tests execute a
+    // cell, so nothing they assert depends on a live kernel. Waiting on kernel
+    // status coupled them to kernel lifecycle, and they failed whenever the
+    // notebook's kernel disconnected -- the panel then reports "No Kernel"
+    // rather than any [data-status], so such a wait can only ever time out.
     cy.get('.jp-Notebook', { timeout: 10000 }).should('exist');
-    waitForKernelIdle();
+    cy.get('.jp-Notebook:visible .jp-Cell .jp-InputArea .cm-editor', {
+      timeout: 30000
+    }).should('exist');
   });
 
   afterEach(() => {
@@ -90,7 +98,9 @@ describe('Code snippet from cells tests', () => {
       '.jp-NotebookPanel-toolbar > div:nth-child(2) > jp-button:nth-child(1)'
     ).click();
 
-    waitForKernelIdle();
+    // Wait for the observable effect of that click -- the second cell -- rather
+    // than for kernel status, which inserting a cell does not change.
+    cy.get('.jp-Notebook:visible .jp-Cell').should('have.length', 2);
 
     populateCells();
 
@@ -131,16 +141,6 @@ describe('Code snippet from cells tests', () => {
 // ------------------------------
 // ----- Utility Functions
 // ------------------------------
-
-// Wait for the kernel of the notebook under test to reach idle status. Scoped
-// to the visible notebook panel: an unscoped [data-status="idle"] also matches
-// the status bar indicator and any other widget's, which reports idle while
-// this notebook is still connecting.
-const waitForKernelIdle = (): void => {
-  cy.get('.jp-NotebookPanel:visible [data-status="idle"]', {
-    timeout: 30000
-  }).should('exist');
-};
 
 // Populate cells by re-querying each by index to avoid stale DOM references
 const populateCells = (): void => {


### PR DESCRIPTION
## Problem

`codesnippetfromselectedcells.cy.ts` fails intermittently on CI with:

```
Code snippet from cells tests
  1) test 2 cells
     AssertionError: Timed out retrying after 30000ms:
     Expected to find element: `.jp-NotebookPanel:visible [data-status="idle"]`,
     but never found it.
```

Seen on #3404, #3399 and #3408, on branches already rebased onto current
`main`, so it is not stale-branch fallout.

## Cause

The failure screenshot from
[this run](https://github.com/elyra-ai/elyra/actions/runs/32097752241/job/95592284113)
shows the notebook with **both cells present** — so the insert-cell click
worked — and the kernel gone:

- notebook toolbar: **"No Kernel"**
- status bar: **`Python 3 (ipykernel) | Disconnected`**

Once the kernel disconnects the panel carries no `[data-status]` attribute at
all, so a wait for `[data-status="idle"]` cannot succeed. It burns its full 30s
timeout and fails. Waiting longer would never help.

The deeper issue is that the wait should not be there at all. **None of the
three tests in this spec execute a cell.** They type text via `populateCells()`
and assert on the contents of the snippet editor. Nothing they verify depends
on a live kernel, yet both `waitForKernelIdle()` calls hard-coupled them to
kernel lifecycle — turning any kernel disconnect into a test failure.

This also matches the observed pattern: `test 1 cell` has no kernel wait in its
body and passes reliably, while `test 2 cells` carries the extra wait and is the
case that keeps failing. In the same run above, `test empty cell` also failed
its first attempt and passed on retry, via the `beforeEach` wait.

## Change

Replace both kernel-status waits with waits on the direct observable effect of
the preceding action:

- in `beforeEach`, wait for the cell editor to be ready for input
- in `test 2 cells`, wait for the second cell to appear after the insert-cell
  button is clicked

Both are precise post-conditions of the step before them rather than proxies for
readiness. The now-unreferenced `waitForKernelIdle()` helper is removed.

## Scope

This does not change what any test asserts, and it does not touch
`shutdownAllKernels()` or the reset flow. Why the kernel disconnects mid-spec is
a separate question — this PR removes the tests' dependence on it, which is
correct regardless of that answer.

## Testing

CI runs this spec in `Run Integration Tests (editors)`. Note that a green run
alone cannot prove a flake is fixed, since the spec passed intermittently
before; the argument for this change is that the tests no longer depend on the
condition that was failing.
