### PR TITLE
Wait for kernel connection before running a script

### DIFF
--- a/packages/script-editor/src/ScriptRunner.ts
+++ b/packages/script-editor/src/ScriptRunner.ts
@@ -106,7 +106,22 @@ export class ScriptRunner {
       return;
     }
 
-    const future = this.sessionConnection.kernel.requestExecute({ code });
+    const kernel = this.sessionConnection.kernel;
+
+    // Wait for the kernel connection to be live before executing. startSession
+    // resolves while the connection is still 'connecting', and a requestExecute
+    // issued in that window is only queued client-side. If that queue is not
+    // flushed the execute reply never arrives, `future.done` stays pending
+    // forever, and the run button is never re-enabled. Awaiting `info` gates on
+    // the kernel_info reply, which arrives only once the connection is up.
+    try {
+      await kernel.info;
+    } catch (e) {
+      await this.errorDialog(SESSION_ERROR_MSG);
+      return;
+    }
+
+    const future = kernel.requestExecute({ code });
 
     future.onIOPub = (msg: IIOPubMessage): void => {
       const msgType = msg.header.msg_type;
@@ -144,9 +159,13 @@ export class ScriptRunner {
       // TO DO: Keep session open but shut down kernel
       // this.interruptKernel(); // debugger is not triggered after this
       // this.shutdownKernel(); // also shuts down session for some reason
-      this.disableButton(false);
     } catch (e) {
       console.log('Exception: done = ' + JSON.stringify(e));
+    } finally {
+      // Re-enable on every path. Previously this only ran when `future.done`
+      // resolved, so a failed execution left the run button disabled with no
+      // way to recover short of reopening the editor.
+      this.disableButton(false);
     }
   };
 


### PR DESCRIPTION
## Problem

`Test UI` intermittently fails with `@elyra/script-editor` hitting its 3 minute
jest timeout:

```
@elyra/script-editor › KernelManager › #startSession ›
  should receive error message when running a broken script
    thrown: "Exceeded timeout of 180000 ms for a test."
```

Seen on #3397 and #3408.

## Diagnosis

Server-side trace from the failing job on
[#3408](https://github.com/elyra-ai/elyra/actions/runs/32100443894/job/95599772120):

```
04:54:58.379  Kernel started:  06899269   (test 3 — executes fine, ~0.7s)
04:54:59.090  Kernel shutdown: 06899269
04:54:59.340  Kernel started:  eebc5054   (test 4 — starts fine)
04:54:59.830  Connecting to kernel eebc5054   ← websocket connects
        ...   180s with no execute reply ...
04:57:59.331  Kernel shutdown: eebc5054   ← only when jest gives up
```

Each test gets a distinct, freshly started kernel, and test 4's kernel was alive
and connected for the entire timeout. So this is not a stale session, not a
kernel that failed to start, and not a kernel that died: the execute reply
simply never arrived.

The cause is that `runScript` issues `requestExecute` without waiting for the
kernel connection to be usable. `startSession` returns while the connection is
still being established — the existing unit test asserts precisely this:

```ts
// packages/script-editor/src/test/script-editor.spec.ts
expect(runner.sessionConnection?.kernel?.connectionStatus).toEqual('connecting');
```

Messages sent in that window are queued client-side by
`@jupyterlab/services` and flushed once the connection is ready. When that flush
is missed, `future.done` never settles. `should run script` does the same thing
one test earlier and won the race; `should receive error message...` lost it.

## Not just a test problem

`runScript` calls `disableButton(true)` on entry, and `disableButton(false)` ran
only on the success path — the `catch` did not re-enable it. So a user who hits
Run before the kernel connection is up can lose the execution *and* be left with
a permanently disabled run button, recoverable only by reopening the editor.

## Change

- await the kernel's `info` promise before `requestExecute`. It settles on the
  `kernel_info` reply, which arrives only once the connection is live, so the
  execute request can no longer land in the queueing window. If the kernel never
  becomes usable, the session error dialog is shown, consistent with the other
  failure paths already in `runScript`.
- move `disableButton(false)` into a `finally` so it runs on every path.

`startSession`'s contract is deliberately unchanged, so the existing
`'connecting'` assertion still holds and no test needed adjusting.

## Testing

Covered by the existing `@elyra/script-editor` suite in `Test UI`, which
exercises `runScript` for both a valid and a broken script.

Note that a green run is not proof on its own — this failure is intermittent and
the suite passed on other PRs without the fix. The argument for the change is
the mechanism: the execute request can no longer be issued before the kernel
connection is live.
