### PR TITLE
Cap ipykernel below 7.x in CI

### DIFF
--- a/.github/ci-constraints.txt
+++ b/.github/ci-constraints.txt
@@ -1,0 +1,20 @@
+# CI-only pip constraints. Deliberately not in pyproject.toml: this caps what
+# CI resolves without changing the published package metadata.
+#
+# ipykernel is not pinned by Elyra at all -- it arrives transitively via
+# jupyterlab~=4.4, whose constraint (ipykernel!=6.30.0,>=6.5.0) has no upper
+# bound. CI therefore floated to 7.x while development environments stayed on
+# 6.x, and kernel-dependent tests began failing intermittently.
+#
+# ipykernel 7's asyncio rewrite silently drops shell messages, so the kernel
+# accepts the connection, emits iopub_welcome, and then never replies to
+# kernel_info_request. Anything waiting for the kernel to become ready waits
+# forever. Observed in CI as the @elyra/script-editor jest suite hitting its
+# 180s timeout, and as Cypress timing out on [data-status="idle"] with the
+# notebook panel reporting "No Kernel" / "Disconnected".
+#
+# The same failure has been seen from Enterprise Gateway, there against
+# jupyter_client 6.1.12 signed sessions.
+#
+# Remove this cap once ipykernel 7.x handles the exchange correctly.
+ipykernel!=6.30.0,>=6.5.0,<7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,9 @@ env:
   NODE_VERSION: 22
   PYTHON_VERSION: 3.13
   NODE_OPTIONS: '--max_old_space_size=4096'
+  # Applies to every pip invocation in every job, including those reached
+  # indirectly through make. See .github/ci-constraints.txt for why.
+  PIP_CONSTRAINT: ${{ github.workspace }}/.github/ci-constraints.txt
 
 jobs:
   lint-server:
@@ -94,6 +97,7 @@ jobs:
             build_requirements.txt
             lint_requirements.txt
             test_requirements.txt
+            .github/ci-constraints.txt
       - name: Install
         # Note: Tests fail if we don't install `wheel` for some reason.
         run: |
@@ -137,6 +141,7 @@ jobs:
             build_requirements.txt
             lint_requirements.txt
             test_requirements.txt
+            .github/ci-constraints.txt
       - uses: actions/cache@v4
         with:
           path: |
@@ -192,6 +197,7 @@ jobs:
             build_requirements.txt
             lint_requirements.txt
             test_requirements.txt
+            .github/ci-constraints.txt
       - uses: actions/cache@v4
         with:
           path: |
@@ -296,6 +302,7 @@ jobs:
             build_requirements.txt
             lint_requirements.txt
             test_requirements.txt
+            .github/ci-constraints.txt
       - uses: actions/cache@v4
         with:
           path: |

--- a/elyra/tests/kfp/test_bootstrapper.py
+++ b/elyra/tests/kfp/test_bootstrapper.py
@@ -505,19 +505,19 @@ def test_fail_bad_notebook_main_method(monkeypatch, s3_setup, tmpdir):
 
 def test_package_installation(monkeypatch, virtualenv):
     elyra_packages = {
-        "ipykernel": "5.3.0",
+        "ipykernel": "6.31.0",
         "ansiwrap": "0.8.4",
-        "packaging": "20.0",
+        "packaging": "23.0",
     }
     current_packages = {
         "bleach": "3.1.5",
         "ansiwrap": "0.7.0",
-        "packaging": "20.4",
+        "packaging": "24.0",
     }
     expected_packages = {
-        "ipykernel": "5.3.0",
+        "ipykernel": "6.31.0",
         "ansiwrap": "0.8.4",
-        "packaging": "20.4",
+        "packaging": "24.0",
     }
 
     mocked_func = mock.Mock(side_effect=[elyra_packages, current_packages])
@@ -527,7 +527,7 @@ def test_package_installation(monkeypatch, virtualenv):
 
     virtualenv.run("python3 -m pip install bleach==3.1.5")
     virtualenv.run("python3 -m pip install ansiwrap==0.7.0")
-    virtualenv.run("python3 -m pip install packaging==20.4")
+    virtualenv.run("python3 -m pip install packaging==24.0")
 
     bootstrapper.OpUtil.package_install(user_volume_path=None)
     virtualenv_packages = {}
@@ -550,7 +550,7 @@ def test_package_installation(monkeypatch, virtualenv):
 def test_package_installation_with_target_path(monkeypatch, virtualenv, tmpdir):
     # TODO : Need to add test for direct-source e.g. ' @ '
     elyra_packages = {
-        "ipykernel": "5.3.0",
+        "ipykernel": "6.31.0",
         "ansiwrap": "0.8.4",
         "packaging": "22.0",
     }
@@ -560,7 +560,7 @@ def test_package_installation_with_target_path(monkeypatch, virtualenv, tmpdir):
         "packaging": "21.0",
     }
     expected_packages = {
-        "ipykernel": "5.3.0",
+        "ipykernel": "6.31.0",
         "ansiwrap": "0.8.4",
         "packaging": "22.0",
     }

--- a/etc/generic/requirements-elyra.txt
+++ b/etc/generic/requirements-elyra.txt
@@ -1,9 +1,9 @@
 # This is a comprehensive list of python dependencies that Elyra requires to execute Jupyter notebooks.
-ipykernel==6.25.2
+ipykernel==6.31.0
 ipython==8.12.3
 ipython-genutils==0.2.0
 jinja2==3.1.6
-jupyter-client==7.4.9
+jupyter-client==8.9.1
 jupyter-core==5.8.1
 MarkupSafe==2.1.1
 minio==7.1.15


### PR DESCRIPTION
CI resolved ipykernel **7.3.0** — nothing pins it, and `jupyterlab~=4.4` leaves
it unbounded. ipykernel 7 never answers `kernel_info_request`, so kernels
connect and then go silent: the jest `@elyra/script-editor` suite timed out at
180s ([run](https://github.com/elyra-ai/elyra/actions/runs/32165209741/job/95803090257)),
and Cypress timed out on `[data-status="idle"]` with the panel showing
"No Kernel".

- cap CI at `<7` via `.github/ci-constraints.txt` + `PIP_CONSTRAINT` in
  `build.yml`'s top-level `env:`, which every job inherits. `pyproject.toml`
  untouched, so published metadata is unchanged.
- `requirements-elyra.txt`: ipykernel 6.25.2 → 6.31.0, which *requires*
  jupyter-client 7.4.9 → 8.9.1 (6.30.0 raised its floor to `>=8.0.0`).
- bootstrapper tests: ipykernel 5.3.0 → 6.31.0, plus the `packaging` fixture,
  which 6.31.0's `packaging>=22` was silently upgrading.

**Risk:** `requirements-elyra.txt` ships in the runtime images, so
jupyter-client 7→8 affects notebook execution in containers. `Validate Image
Environment` and `Validate Images` cover it.

`test-server` runs `pip freeze` — check it shows 6.x, rather than trusting a
green run, since these failures were intermittent.
