### PR TITLE
Prevent decimal input on Integer-type pipeline parameters

### DIFF
--- a/packages/pipeline-editor/src/ParameterInputForm.tsx
+++ b/packages/pipeline-editor/src/ParameterInputForm.tsx
@@ -54,13 +54,20 @@ export const ParameterInputForm: React.FC<IParameterProps> = ({
             ? true
             : undefined;
         let type = 'text';
+        let step: string | undefined = undefined;
         switch (param.default_value?.type) {
           case 'Bool':
             type = 'checkbox';
             break;
           case 'Float':
+            type = 'number';
+            break;
           case 'Integer':
             type = 'number';
+            // Restrict this field to whole numbers. `pattern` is not
+            // supported on type="number" inputs, so `step` is the
+            // correct way to prevent decimal input here.
+            step = '1';
             break;
         }
         if (type === 'checkbox') {
@@ -111,6 +118,7 @@ export const ParameterInputForm: React.FC<IParameterProps> = ({
               id={`${param.name}-paramInput`}
               name={`${param.name}-paramInput`}
               type={type}
+              step={step}
               placeholder={param.default_value?.value as string | undefined}
               data-form-required={required}
             />


### PR DESCRIPTION
### Summary

Fixes #3084. Both `Float` and `Integer` parameter types in the pipeline submission dialog (`ParameterInputForm.tsx`) render as a plain `type="number"` input with no attribute distinguishing them, so an `Integer`-typed parameter silently accepts decimal input (e.g. `3.5`) with no validation feedback.

### Fix

The originally-suggested approach (add a `pattern` attribute to block `.`) doesn't actually work here: per the HTML5 spec, `pattern` is ignored on `type="number"` inputs (it only applies to text-like input types). `step="1"` is the correct native constraint for restricting a number input to whole numbers - it disables decimal increments on the input's up/down controls and marks a non-integer value as invalid (`:invalid` / native validation message) on submit.

Added a `step` variable alongside the existing `type` variable, set to `'1'` only for the `Integer` case, and wired it into the `<input>` element.

### Testing

This component (`pipeline-editor`) doesn't have existing unit tests to extend - the package's coverage for this dialog is via Cypress end-to-end tests (`cypress/tests/`), and a full Cypress run wasn't something I could set up in my environment (no local yarn/monorepo bootstrap here). I did verify the change compiles as valid TypeScript/TSX (standalone `tsc` syntax/type check against the file, clean apart from the expected "can't resolve 'react'" error from not having the monorepo's `node_modules` installed) and reviewed the diff carefully - it's a minimal, mechanical change (8 lines). Happy to add Cypress coverage if a maintainer can point me to the right pattern, or if CI surfaces something I should fix.

### Checklist
- [x] My change follows the style guidelines of this project (eslint/prettier config)
- [x] I have signed off my commit (DCO)